### PR TITLE
:arrow_up: Upgrade acapy image to 1.2.1

### DIFF
--- a/app/poetry.lock
+++ b/app/poetry.lock
@@ -198,14 +198,14 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "aries-cloudcontroller"
-version = "1.2.0.post20241205"
+version = "1.2.1.post20250213"
 description = "A simple python client for controlling an ACA-Py agent"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "aries_cloudcontroller-1.2.0.post20241205-py3-none-any.whl", hash = "sha256:981adef02b774481ce7a79d2eb69db6f0d7a240cf917d23c956386ad3613bc66"},
-    {file = "aries_cloudcontroller-1.2.0.post20241205.tar.gz", hash = "sha256:b3c31e13bad3f8e48e392dfa6163a2d22cd5db7fe9fa4e194f8cf09a4d84df35"},
+    {file = "aries_cloudcontroller-1.2.1.post20250213-py3-none-any.whl", hash = "sha256:ab3e73efdf5f5b746d893812095b449119f1d7bda2774e92f6876f0b5caa6ee4"},
+    {file = "aries_cloudcontroller-1.2.1.post20250213.tar.gz", hash = "sha256:0674b017d5fd73a264e894a4e6f5e0f663029cdd02cc67fa524e8f812b387cab"},
 ]
 
 [package.dependencies]
@@ -216,6 +216,11 @@ pydantic = ">=2.6,<3.0"
 python-dateutil = ">=2"
 typing-extensions = ">=4,<5.0"
 urllib3 = ">=2.1,<3"
+
+[package.source]
+type = "legacy"
+url = "https://test.pypi.org/simple"
+reference = "testpypi"
 
 [[package]]
 name = "assertpy"
@@ -1848,4 +1853,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.1"
 python-versions = "~3.12.8"
-content-hash = "033f4d21b60a84dc0a83696502772549bd9ed554fcd7dfe231b4d2ea3382354c"
+content-hash = "2ed41b23434e8670bb2b4cbe1aa42e76675a7269517e246a2f8a5121bc0ce633"

--- a/app/poetry.lock
+++ b/app/poetry.lock
@@ -204,8 +204,8 @@ optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "aries_cloudcontroller-1.2.1.post20250213-py3-none-any.whl", hash = "sha256:ab3e73efdf5f5b746d893812095b449119f1d7bda2774e92f6876f0b5caa6ee4"},
-    {file = "aries_cloudcontroller-1.2.1.post20250213.tar.gz", hash = "sha256:0674b017d5fd73a264e894a4e6f5e0f663029cdd02cc67fa524e8f812b387cab"},
+    {file = "aries_cloudcontroller-1.2.1.post20250213-py3-none-any.whl", hash = "sha256:07e4c30c82c87de983c3aa50fbd30aea6f9c62dfdd99a35644b41c037b3c80a6"},
+    {file = "aries_cloudcontroller-1.2.1.post20250213.tar.gz", hash = "sha256:a1f929d7155800ff9bf5cc0584355742a99fe00b356d1e3b839c368a30eb42f2"},
 ]
 
 [package.dependencies]
@@ -216,11 +216,6 @@ pydantic = ">=2.6,<3.0"
 python-dateutil = ">=2"
 typing-extensions = ">=4,<5.0"
 urllib3 = ">=2.1,<3"
-
-[package.source]
-type = "legacy"
-url = "https://test.pypi.org/simple"
-reference = "testpypi"
 
 [[package]]
 name = "assertpy"
@@ -1853,4 +1848,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.1"
 python-versions = "~3.12.8"
-content-hash = "2ed41b23434e8670bb2b4cbe1aa42e76675a7269517e246a2f8a5121bc0ce633"
+content-hash = "6ee15cc82196a2d8e02ae20675d2dc433aef56583a9d90361ad7050ece7e2ae3"

--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -13,7 +13,7 @@ python = "~3.12.8"
 
 aiohttp = "~3.11.7"
 aiocache = "~0.12.0"
-aries-cloudcontroller = "==1.2.0.post20241205"
+aries-cloudcontroller = { version = "==1.2.1.post20250213", source = "testpypi" }
 base58 = "~2.1.1"
 fastapi = "~0.115.0"
 httpx = "~0.28.0"
@@ -54,3 +54,8 @@ profile = "black"
 [tool.pytest.ini_options]
 addopts = "--junitxml=junit.xml -p no:cacheprovider --cov-report=xml --cov-report=term"
 junit_family = "xunit2"
+
+[[tool.poetry.source]]
+name = "testpypi"
+url = "https://test.pypi.org/simple/"
+priority = "supplemental"

--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -13,7 +13,7 @@ python = "~3.12.8"
 
 aiohttp = "~3.11.7"
 aiocache = "~0.12.0"
-aries-cloudcontroller = { version = "==1.2.1.post20250213", source = "testpypi" }
+aries-cloudcontroller = "==1.2.1.post20250213"
 base58 = "~2.1.1"
 fastapi = "~0.115.0"
 httpx = "~0.28.0"
@@ -54,8 +54,3 @@ profile = "black"
 [tool.pytest.ini_options]
 addopts = "--junitxml=junit.xml -p no:cacheprovider --cov-report=xml --cov-report=term"
 junit_family = "xunit2"
-
-[[tool.poetry.source]]
-name = "testpypi"
-url = "https://test.pypi.org/simple/"
-priority = "supplemental"

--- a/dockerfiles/agents/Dockerfile
+++ b/dockerfiles/agents/Dockerfile
@@ -3,11 +3,11 @@ FROM ghcr.io/didx-xyz/acapy-agent${BBS_SUFFIX}:py3.12-1.2.1-20250213
 
 USER root
 
-# Install Google Protobuf and Python packages
+# Install Google Protobuf and Plugins
 ARG PROTOBUF_VERSION=5.29.3
 RUN pip install --no-cache-dir protobuf==${PROTOBUF_VERSION} \
-  git+https://github.com/didx-xyz/acapy-wallet-groups-plugin@fb0ed39 \
-  git+https://github.com/didx-xyz/acapy-plugins@16062c227#subdirectory=nats_events
+  acapy-wallet-groups-plugin==1.2.1.post20250213 \
+  git+https://github.com/didx-xyz/aries-acapy-plugins@1.2.1-20250213#subdirectory=nats_events
 
 COPY scripts/startup.sh startup.sh
 RUN chmod +x ./startup.sh
@@ -15,10 +15,10 @@ RUN chmod +x ./startup.sh
 USER aries
 
 ENTRYPOINT [ "./startup.sh" ]
-## Governance Agent
 CMD [ "--wallet-type", "askar", \
+  ## Setting for Governance Agent and Multitenant Agent
   "--plugin", "nats_events.v1_0.nats_queue.events", \
-  ## Multitenant Agent
+  ## Additional settings for Multitenant Agent only
   #   "--auto-promote-author-did", \
   #   "--plugin", "acapy_wallet_groups_plugin", \
   "--plugin-config-value", "nats_queue.connection.connection_url=\"nats://nats-1:4222\""]

--- a/dockerfiles/agents/Dockerfile
+++ b/dockerfiles/agents/Dockerfile
@@ -1,13 +1,13 @@
 ARG BBS_SUFFIX="-bbs"
-FROM ghcr.io/didx-xyz/acapy-agent${BBS_SUFFIX}:py3.12-release-1.2.1-20250130
+FROM ghcr.io/didx-xyz/acapy-agent${BBS_SUFFIX}:py3.12-1.2.1-20250213
 
 USER root
 
 # Install Google Protobuf
 ARG PROTOBUF_VERSION=5.29.3
 RUN pip install --no-cache-dir protobuf==${PROTOBUF_VERSION} \
-  git+https://github.com/didx-xyz/acapy-wallet-groups-plugin@396eeb4290 \
-  git+https://github.com/didx-xyz/acapy-plugins@b3c593f103aa#subdirectory=nats_events
+  git+https://github.com/didx-xyz/acapy-wallet-groups-plugin@fb0ed39 \
+  git+https://github.com/didx-xyz/acapy-plugins@16062c227#subdirectory=nats_events
 
 COPY scripts/startup.sh startup.sh
 RUN chmod +x ./startup.sh

--- a/dockerfiles/agents/Dockerfile
+++ b/dockerfiles/agents/Dockerfile
@@ -1,13 +1,13 @@
 ARG BBS_SUFFIX="-bbs"
-FROM ghcr.io/didx-xyz/acapy-agent${BBS_SUFFIX}:py3.12-1.2.1-20250130
+FROM ghcr.io/didx-xyz/acapy-agent${BBS_SUFFIX}:py3.12-release-1.2.1-20250130
 
 USER root
 
 # Install Google Protobuf
 ARG PROTOBUF_VERSION=5.29.3
 RUN pip install --no-cache-dir protobuf==${PROTOBUF_VERSION} \
-  git+https://github.com/didx-xyz/acapy-wallet-groups-plugin@3fd7d79db \
-  git+https://github.com/didx-xyz/acapy-plugins@5b137142d70#subdirectory=nats_events
+  git+https://github.com/didx-xyz/acapy-wallet-groups-plugin@396eeb4290 \
+  git+https://github.com/didx-xyz/acapy-plugins@b3c593f103aa#subdirectory=nats_events
 
 COPY scripts/startup.sh startup.sh
 RUN chmod +x ./startup.sh

--- a/dockerfiles/agents/Dockerfile
+++ b/dockerfiles/agents/Dockerfile
@@ -1,13 +1,13 @@
 ARG BBS_SUFFIX="-bbs"
-FROM ghcr.io/didx-xyz/acapy-agent${BBS_SUFFIX}:py3.12-1.2.0-20250127
+FROM ghcr.io/didx-xyz/acapy-agent${BBS_SUFFIX}:py3.12-1.2.1-20250130
 
 USER root
 
 # Install Google Protobuf
 ARG PROTOBUF_VERSION=5.29.3
 RUN pip install --no-cache-dir protobuf==${PROTOBUF_VERSION} \
-  acapy-wallet-groups-plugin==1.2.0.post20250127 \
-  git+https://github.com/didx-xyz/acapy-plugins@1.2.0-20250127#subdirectory=nats_events
+  git+https://github.com/didx-xyz/acapy-wallet-groups-plugin@release-1.2.1-20250130 \
+  git+https://github.com/didx-xyz/acapy-plugins@release-1.2.1-20250130#subdirectory=nats_events
 
 COPY scripts/startup.sh startup.sh
 RUN chmod +x ./startup.sh

--- a/dockerfiles/agents/Dockerfile
+++ b/dockerfiles/agents/Dockerfile
@@ -7,7 +7,7 @@ USER root
 ARG PROTOBUF_VERSION=5.29.3
 RUN pip install --no-cache-dir protobuf==${PROTOBUF_VERSION} \
   acapy-wallet-groups-plugin==1.2.0.post20250127 \
-  git+https://github.com/didx-xyz/aries-acapy-plugins@1.2.0-20250127#subdirectory=nats_events
+  git+https://github.com/didx-xyz/acapy-plugins@1.2.0-20250127#subdirectory=nats_events
 
 COPY scripts/startup.sh startup.sh
 RUN chmod +x ./startup.sh

--- a/dockerfiles/agents/Dockerfile
+++ b/dockerfiles/agents/Dockerfile
@@ -3,16 +3,11 @@ FROM ghcr.io/didx-xyz/acapy-agent${BBS_SUFFIX}:py3.12-1.2.1-20250213
 
 USER root
 
-# Install git for testing (acapy agent no longer includes git)
-RUN apt-get update && \
-    apt-get install -y git && \
-    rm -rf /var/lib/apt/lists/*
-
 # Install Google Protobuf and Python packages
 ARG PROTOBUF_VERSION=5.29.3
 RUN pip install --no-cache-dir protobuf==${PROTOBUF_VERSION} \
-    git+https://github.com/didx-xyz/acapy-wallet-groups-plugin@fb0ed39 \
-    git+https://github.com/didx-xyz/acapy-plugins@16062c227#subdirectory=nats_events
+  git+https://github.com/didx-xyz/acapy-wallet-groups-plugin@fb0ed39 \
+  git+https://github.com/didx-xyz/acapy-plugins@16062c227#subdirectory=nats_events
 
 COPY scripts/startup.sh startup.sh
 RUN chmod +x ./startup.sh

--- a/dockerfiles/agents/Dockerfile
+++ b/dockerfiles/agents/Dockerfile
@@ -6,8 +6,8 @@ USER root
 # Install Google Protobuf
 ARG PROTOBUF_VERSION=5.29.3
 RUN pip install --no-cache-dir protobuf==${PROTOBUF_VERSION} \
-  git+https://github.com/didx-xyz/acapy-wallet-groups-plugin@release-1.2.1-20250130 \
-  git+https://github.com/didx-xyz/acapy-plugins@release-1.2.1-20250130#subdirectory=nats_events
+  git+https://github.com/didx-xyz/acapy-wallet-groups-plugin@3fd7d79db \
+  git+https://github.com/didx-xyz/acapy-plugins@5b137142d70#subdirectory=nats_events
 
 COPY scripts/startup.sh startup.sh
 RUN chmod +x ./startup.sh

--- a/dockerfiles/agents/Dockerfile
+++ b/dockerfiles/agents/Dockerfile
@@ -3,11 +3,16 @@ FROM ghcr.io/didx-xyz/acapy-agent${BBS_SUFFIX}:py3.12-1.2.1-20250213
 
 USER root
 
-# Install Google Protobuf
+# Install git for testing (acapy agent no longer includes git)
+RUN apt-get update && \
+    apt-get install -y git && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Google Protobuf and Python packages
 ARG PROTOBUF_VERSION=5.29.3
 RUN pip install --no-cache-dir protobuf==${PROTOBUF_VERSION} \
-  git+https://github.com/didx-xyz/acapy-wallet-groups-plugin@fb0ed39 \
-  git+https://github.com/didx-xyz/acapy-plugins@16062c227#subdirectory=nats_events
+    git+https://github.com/didx-xyz/acapy-wallet-groups-plugin@fb0ed39 \
+    git+https://github.com/didx-xyz/acapy-plugins@16062c227#subdirectory=nats_events
 
 COPY scripts/startup.sh startup.sh
 RUN chmod +x ./startup.sh

--- a/docs/openapi/tenant-admin-openapi.json
+++ b/docs/openapi/tenant-admin-openapi.json
@@ -5,11 +5,6 @@
     "description": "\nWelcome to CloudAPI Multitenant Admin!\n\nFor detailed guidance on using the API, please visit our official documentation:\nhttps://www.didx.co.za/acapy-cloud/index.html\n",
     "version": "4.2.0"
   },
-  "servers": [
-    {
-      "url": "/tenant-admin"
-    }
-  ],
   "paths": {
     "/v1/tenants": {
       "post": {

--- a/docs/openapi/tenant-admin-openapi.yaml
+++ b/docs/openapi/tenant-admin-openapi.yaml
@@ -12,8 +12,6 @@ info:
 
     '
   version: 4.2.0
-servers:
-- url: /tenant-admin
 paths:
   /v1/tenants:
     post:

--- a/endorser/poetry.lock
+++ b/endorser/poetry.lock
@@ -187,8 +187,8 @@ optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "aries_cloudcontroller-1.2.1.post20250213-py3-none-any.whl", hash = "sha256:ab3e73efdf5f5b746d893812095b449119f1d7bda2774e92f6876f0b5caa6ee4"},
-    {file = "aries_cloudcontroller-1.2.1.post20250213.tar.gz", hash = "sha256:0674b017d5fd73a264e894a4e6f5e0f663029cdd02cc67fa524e8f812b387cab"},
+    {file = "aries_cloudcontroller-1.2.1.post20250213-py3-none-any.whl", hash = "sha256:07e4c30c82c87de983c3aa50fbd30aea6f9c62dfdd99a35644b41c037b3c80a6"},
+    {file = "aries_cloudcontroller-1.2.1.post20250213.tar.gz", hash = "sha256:a1f929d7155800ff9bf5cc0584355742a99fe00b356d1e3b839c368a30eb42f2"},
 ]
 
 [package.dependencies]
@@ -199,11 +199,6 @@ pydantic = ">=2.6,<3.0"
 python-dateutil = ">=2"
 typing-extensions = ">=4,<5.0"
 urllib3 = ">=2.1,<3"
-
-[package.source]
-type = "legacy"
-url = "https://test.pypi.org/simple"
-reference = "testpypi"
 
 [[package]]
 name = "astroid"
@@ -1974,4 +1969,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.1"
 python-versions = "~3.12.8"
-content-hash = "cca1e40a4890ddc60653905b7f0e5e066fcee1c8988436c21117a47dd103249b"
+content-hash = "fab4c242a75526f59068c872cfcf15745031318dcae03df7223bfb7edb1d8104"

--- a/endorser/poetry.lock
+++ b/endorser/poetry.lock
@@ -181,14 +181,14 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "aries-cloudcontroller"
-version = "1.2.0.post20241205"
+version = "1.2.1.post20250213"
 description = "A simple python client for controlling an ACA-Py agent"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "aries_cloudcontroller-1.2.0.post20241205-py3-none-any.whl", hash = "sha256:981adef02b774481ce7a79d2eb69db6f0d7a240cf917d23c956386ad3613bc66"},
-    {file = "aries_cloudcontroller-1.2.0.post20241205.tar.gz", hash = "sha256:b3c31e13bad3f8e48e392dfa6163a2d22cd5db7fe9fa4e194f8cf09a4d84df35"},
+    {file = "aries_cloudcontroller-1.2.1.post20250213-py3-none-any.whl", hash = "sha256:ab3e73efdf5f5b746d893812095b449119f1d7bda2774e92f6876f0b5caa6ee4"},
+    {file = "aries_cloudcontroller-1.2.1.post20250213.tar.gz", hash = "sha256:0674b017d5fd73a264e894a4e6f5e0f663029cdd02cc67fa524e8f812b387cab"},
 ]
 
 [package.dependencies]
@@ -199,6 +199,11 @@ pydantic = ">=2.6,<3.0"
 python-dateutil = ">=2"
 typing-extensions = ">=4,<5.0"
 urllib3 = ">=2.1,<3"
+
+[package.source]
+type = "legacy"
+url = "https://test.pypi.org/simple"
+reference = "testpypi"
 
 [[package]]
 name = "astroid"
@@ -1969,4 +1974,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.1"
 python-versions = "~3.12.8"
-content-hash = "cdc46aa2bb10c3cec34fcc66e20be8c7a24ec69173aaf977f723d609a137314a"
+content-hash = "cca1e40a4890ddc60653905b7f0e5e066fcee1c8988436c21117a47dd103249b"

--- a/endorser/pyproject.toml
+++ b/endorser/pyproject.toml
@@ -11,7 +11,7 @@ package-mode = false
 [tool.poetry.dependencies]
 python = "~3.12.8"
 
-aries-cloudcontroller = "==1.2.0.post20241205"
+aries-cloudcontroller = { version = "==1.2.1.post20250213", source = "testpypi" }
 dependency-injector = "~=4.45.0"
 fastapi = "~0.115.0"
 httpx = "~0.28.0"
@@ -48,3 +48,8 @@ profile = "black"
 [tool.pytest.ini_options]
 addopts = "--junitxml=junit.xml -p no:cacheprovider --cov-report=xml --cov-report=term"
 junit_family = "xunit2"
+
+[[tool.poetry.source]]
+name = "testpypi"
+url = "https://test.pypi.org/simple/"
+priority = "supplemental"

--- a/endorser/pyproject.toml
+++ b/endorser/pyproject.toml
@@ -11,7 +11,7 @@ package-mode = false
 [tool.poetry.dependencies]
 python = "~3.12.8"
 
-aries-cloudcontroller = { version = "==1.2.1.post20250213", source = "testpypi" }
+aries-cloudcontroller = "==1.2.1.post20250213"
 dependency-injector = "~=4.45.0"
 fastapi = "~0.115.0"
 httpx = "~0.28.0"
@@ -48,8 +48,3 @@ profile = "black"
 [tool.pytest.ini_options]
 addopts = "--junitxml=junit.xml -p no:cacheprovider --cov-report=xml --cov-report=term"
 junit_family = "xunit2"
-
-[[tool.poetry.source]]
-name = "testpypi"
-url = "https://test.pypi.org/simple/"
-priority = "supplemental"


### PR DESCRIPTION
Upgrades to latest didx-acapy release: 
https://github.com/didx-xyz/acapy/releases/tag/1.2.1-20250213

plugins:
https://github.com/didx-xyz/acapy-wallet-groups-plugin/releases/tag/1.2.1-20250213
https://github.com/didx-xyz/acapy-plugins/releases/tag/1.2.1-20250213

cloudcontroller:
https://github.com/didx-xyz/aries-cloudcontroller-python/pull/238