### PR TITLE
:test_tube: Configure xdist group for session fixtures

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -113,6 +113,7 @@
     "pyproject",
     "pypy",
     "pytest",
+    "pytestmark",
     "PYTHONPATH",
     "pyyaml",
     "redoc",

--- a/app/services/onboarding/issuer.py
+++ b/app/services/onboarding/issuer.py
@@ -32,7 +32,9 @@ async def onboard_issuer(
         endorser_controller (AcaPyClient): authenticated ACA-Py client for endorser
         issuer_label (str): alias for the issuer
     """
-    bound_logger = logger.bind(body={"issuer_wallet_id": issuer_wallet_id})
+    bound_logger = logger.bind(
+        body={"issuer_wallet_id": issuer_wallet_id, "issuer_label": issuer_label}
+    )
     bound_logger.debug("Onboarding issuer")
 
     try:
@@ -92,7 +94,9 @@ async def onboard_issuer_no_public_did(
     Returns:
         issuer_did (DID): The issuer's DID after completing the onboarding process
     """
-    bound_logger = logger.bind(body={"issuer_wallet_id": issuer_wallet_id})
+    bound_logger = logger.bind(
+        body={"issuer_wallet_id": issuer_wallet_id, "issuer_label": issuer_label}
+    )
     bound_logger.debug("Onboarding issuer that has no public DID")
 
     try:

--- a/app/services/onboarding/issuer.py
+++ b/app/services/onboarding/issuer.py
@@ -33,7 +33,7 @@ async def onboard_issuer(
         issuer_label (str): alias for the issuer
     """
     bound_logger = logger.bind(
-        body={"issuer_wallet_id": issuer_wallet_id, "issuer_label": issuer_label}
+        body={"issuer_label": issuer_label, "issuer_wallet_id": issuer_wallet_id}
     )
     bound_logger.debug("Onboarding issuer")
 
@@ -95,7 +95,7 @@ async def onboard_issuer_no_public_did(
         issuer_did (DID): The issuer's DID after completing the onboarding process
     """
     bound_logger = logger.bind(
-        body={"issuer_wallet_id": issuer_wallet_id, "issuer_label": issuer_label}
+        body={"issuer_label": issuer_label, "issuer_wallet_id": issuer_wallet_id}
     )
     bound_logger.debug("Onboarding issuer that has no public DID")
 

--- a/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_bbs.py
+++ b/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_bbs.py
@@ -20,7 +20,7 @@ from app.tests.util.webhooks import assert_both_webhooks_received, check_webhook
 from shared import RichAsyncClient
 
 # Apply the marker to all tests in this module
-pytestmark = pytest.mark.xdist_group(name="issuer_test_group_2")
+pytestmark = pytest.mark.xdist_group(name="issuer_test_group_3")
 
 CREDENTIALS_BASE_PATH = issuer_router.prefix
 OOB_BASE_PATH = oob_router.prefix

--- a/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_bbs.py
+++ b/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_bbs.py
@@ -75,6 +75,7 @@ credential_ = SendCredential(
 
 
 @pytest.mark.anyio
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_send_jsonld_key_bbs(
     faber_client: RichAsyncClient,
     faber_and_alice_connection: FaberAliceConnect,
@@ -136,6 +137,7 @@ async def test_send_jsonld_key_bbs(
 
 
 @pytest.mark.anyio
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_send_jsonld_bbs_oob(
     faber_client: RichAsyncClient,
     alice_member_client: RichAsyncClient,
@@ -215,6 +217,7 @@ async def test_send_jsonld_bbs_oob(
 
 
 @pytest.mark.anyio
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_send_jsonld_request(
     alice_member_client: RichAsyncClient,
     faber_client: RichAsyncClient,
@@ -291,6 +294,7 @@ async def test_send_jsonld_request(
 
 
 @pytest.mark.anyio
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_issue_jsonld_bbs(
     alice_member_client: RichAsyncClient,
     faber_client: RichAsyncClient,
@@ -359,6 +363,7 @@ async def test_issue_jsonld_bbs(
 
 
 @pytest.mark.anyio
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_send_jsonld_mismatch_sov_bbs(
     faber_client: RichAsyncClient,
     faber_acapy_client: AcaPyClient,
@@ -385,6 +390,7 @@ async def test_send_jsonld_mismatch_sov_bbs(
 
 
 @pytest.mark.anyio
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_send_jsonld_mismatch_bbs_ed(
     faber_client: RichAsyncClient,
     faber_and_alice_connection: FaberAliceConnect,

--- a/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_bbs.py
+++ b/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_bbs.py
@@ -2,22 +2,18 @@ import asyncio
 from copy import deepcopy
 
 import pytest
-from aries_cloudcontroller import (
-    AcaPyClient,
-    Credential,
-    LDProofVCDetail,
-    LDProofVCOptions,
-)
+from aries_cloudcontroller import AcaPyClient
 from assertpy import assert_that
 from fastapi import HTTPException
 
-from app.models.issuer import SendCredential
 from app.routes.connections import router as conn_router
 from app.routes.issuer import router as issuer_router
 from app.routes.oob import router as oob_router
 from app.tests.util.connections import FaberAliceConnect
 from app.tests.util.webhooks import assert_both_webhooks_received, check_webhook_state
 from shared import RichAsyncClient
+
+from .util import create_credential
 
 # Apply the marker to all tests in this module
 pytestmark = pytest.mark.xdist_group(name="issuer_test_group_3")
@@ -26,55 +22,7 @@ CREDENTIALS_BASE_PATH = issuer_router.prefix
 OOB_BASE_PATH = oob_router.prefix
 CONNECTIONS_BASE_PATH = conn_router.prefix
 
-
-credential_ = SendCredential(
-    type="ld_proof",
-    connection_id="",
-    ld_credential_detail=LDProofVCDetail(
-        credential=Credential(
-            context=[
-                "https://www.w3.org/2018/credentials/v1",
-                "https://www.w3.org/2018/credentials/examples/v1",
-            ],
-            type=["VerifiableCredential", "UniversityDegreeCredential"],
-            credentialSubject={
-                "degree": {
-                    "type": "BachelorDegree",
-                    "name": "Bachelor of Science and Arts",
-                },
-                "college": "Faber College",
-            },
-            issuanceDate="2021-04-12",
-            issuer="",
-        ),
-        options=LDProofVCOptions(proofType="BbsBlsSignature2020"),
-    ),
-).model_dump(by_alias=True, exclude_unset=True)
-
-# This is the json of the below credential
-# {
-#     "type": "ld_proof",
-#     "connection_id": "",
-#     "ld_credential_detail": {
-#         "credential": {
-#             "@context": [
-#                 "https://www.w3.org/2018/credentials/v1",
-#                 "https://www.w3.org/2018/credentials/examples/v1",
-#             ],
-#             "type": ["VerifiableCredential", "UniversityDegreeCredential"],
-#             "credentialSubject": {
-#                 "degree": {
-#                     "type": "BachelorDegree",
-#                     "name": "Bachelor of Science and Arts",
-#                 },
-#                 "college": "Faber College",
-#             },
-#             "issuanceDate": "2021-04-12",
-#             "issuer": "",
-#         },
-#         "options": "",
-#     },
-# }
+credential_ = create_credential("BbsBlsSignature2020")
 
 
 @pytest.mark.anyio

--- a/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_bbs.py
+++ b/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_bbs.py
@@ -19,6 +19,9 @@ from app.tests.util.connections import FaberAliceConnect
 from app.tests.util.webhooks import assert_both_webhooks_received, check_webhook_state
 from shared import RichAsyncClient
 
+# Apply the marker to all tests in this module
+pytestmark = pytest.mark.xdist_group(name="issuer_test_group")
+
 CREDENTIALS_BASE_PATH = issuer_router.prefix
 OOB_BASE_PATH = oob_router.prefix
 CONNECTIONS_BASE_PATH = conn_router.prefix
@@ -75,7 +78,6 @@ credential_ = SendCredential(
 
 
 @pytest.mark.anyio
-@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_send_jsonld_key_bbs(
     faber_client: RichAsyncClient,
     faber_and_alice_connection: FaberAliceConnect,
@@ -136,7 +138,6 @@ async def test_send_jsonld_key_bbs(
 
 
 @pytest.mark.anyio
-@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_send_jsonld_bbs_oob(
     faber_client: RichAsyncClient,
     alice_member_client: RichAsyncClient,
@@ -215,7 +216,6 @@ async def test_send_jsonld_bbs_oob(
 
 
 @pytest.mark.anyio
-@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_send_jsonld_request(
     alice_member_client: RichAsyncClient,
     faber_client: RichAsyncClient,
@@ -292,7 +292,6 @@ async def test_send_jsonld_request(
 
 
 @pytest.mark.anyio
-@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_issue_jsonld_bbs(
     alice_member_client: RichAsyncClient,
     faber_client: RichAsyncClient,
@@ -361,7 +360,6 @@ async def test_issue_jsonld_bbs(
 
 
 @pytest.mark.anyio
-@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_send_jsonld_mismatch_sov_bbs(
     faber_client: RichAsyncClient,
     faber_acapy_client: AcaPyClient,
@@ -388,7 +386,6 @@ async def test_send_jsonld_mismatch_sov_bbs(
 
 
 @pytest.mark.anyio
-@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_send_jsonld_mismatch_bbs_ed(
     faber_client: RichAsyncClient,
     faber_and_alice_connection: FaberAliceConnect,

--- a/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_bbs.py
+++ b/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_bbs.py
@@ -97,13 +97,12 @@ async def test_send_jsonld_key_bbs(
     )
 
     data = response.json()
+    assert_that(data).contains("credential_exchange_id")
+    assert_that(data).has_state("offer-sent")
     cred_ex_id = data["credential_exchange_id"]
 
     try:
         thread_id = data["thread_id"]
-        assert_that(data).contains("credential_exchange_id")
-        assert_that(data).has_state("offer-sent")
-
         assert await check_webhook_state(
             client=alice_member_client,
             topic="credentials",
@@ -196,12 +195,11 @@ async def test_send_jsonld_bbs_oob(
     )
 
     data = response.json()
+    assert_that(data).contains("credential_exchange_id")
+    assert_that(data).has_state("offer-sent")
     cred_ex_id = data["credential_exchange_id"]
 
     try:
-        assert_that(data).contains("credential_exchange_id")
-        assert_that(data).has_state("offer-sent")
-
         assert await check_webhook_state(
             client=alice_member_client,
             topic="credentials",

--- a/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_bbs.py
+++ b/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_bbs.py
@@ -20,7 +20,7 @@ from app.tests.util.webhooks import assert_both_webhooks_received, check_webhook
 from shared import RichAsyncClient
 
 # Apply the marker to all tests in this module
-pytestmark = pytest.mark.xdist_group(name="issuer_test_group")
+pytestmark = pytest.mark.xdist_group(name="issuer_test_group_2")
 
 CREDENTIALS_BASE_PATH = issuer_router.prefix
 OOB_BASE_PATH = oob_router.prefix

--- a/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_ed25519.py
+++ b/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_ed25519.py
@@ -2,17 +2,17 @@ import asyncio
 from copy import deepcopy
 
 import pytest
-from aries_cloudcontroller import Credential, LDProofVCDetail, LDProofVCOptions
 from assertpy import assert_that
 from fastapi import HTTPException
 
-from app.models.issuer import SendCredential
 from app.routes.connections import router as conn_router
 from app.routes.issuer import router as issuer_router
 from app.routes.oob import router as oob_router
 from app.tests.util.connections import FaberAliceConnect
 from app.tests.util.webhooks import assert_both_webhooks_received, check_webhook_state
 from shared import RichAsyncClient
+
+from .util import create_credential
 
 # Apply the marker to all tests in this module
 pytestmark = pytest.mark.xdist_group(name="issuer_test_group_4")
@@ -21,54 +21,7 @@ CREDENTIALS_BASE_PATH = issuer_router.prefix
 OOB_BASE_PATH = oob_router.prefix
 CONNECTIONS_BASE_PATH = conn_router.prefix
 
-credential_ = SendCredential(
-    type="ld_proof",
-    connection_id="",
-    ld_credential_detail=LDProofVCDetail(
-        credential=Credential(
-            context=[
-                "https://www.w3.org/2018/credentials/v1",
-                "https://www.w3.org/2018/credentials/examples/v1",
-            ],
-            type=["VerifiableCredential", "UniversityDegreeCredential"],
-            credentialSubject={
-                "degree": {
-                    "type": "BachelorDegree",
-                    "name": "Bachelor of Science and Arts",
-                },
-                "college": "Faber College",
-            },
-            issuanceDate="2021-04-12",
-            issuer="",
-        ),
-        options=LDProofVCOptions(proofType="Ed25519Signature2018"),
-    ),
-).model_dump(by_alias=True, exclude_unset=True)
-
-# This is the json of the above credential
-# {
-#     "type": "ld_proof",
-#     "connection_id": "",
-#     "ld_credential_detail": {
-#         "credential": {
-#             "@context": [
-#                 "https://www.w3.org/2018/credentials/v1",
-#                 "https://www.w3.org/2018/credentials/examples/v1",
-#             ],
-#             "type": ["VerifiableCredential", "UniversityDegreeCredential"],
-#             "credentialSubject": {
-#                 "degree": {
-#                     "type": "BachelorDegree",
-#                     "name": "Bachelor of Science and Arts",
-#                 },
-#                 "college": "Faber College",
-#             },
-#             "issuanceDate": "2021-04-12",
-#             "issuer": "",
-#         },
-#         "options": "",
-#     },
-# }
+credential_ = create_credential("Ed25519Signature2018")
 
 
 @pytest.mark.anyio

--- a/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_ed25519.py
+++ b/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_ed25519.py
@@ -69,6 +69,7 @@ credential_ = SendCredential(
 
 
 @pytest.mark.anyio
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_send_jsonld_key_ed25519(
     faber_client: RichAsyncClient,
     faber_and_alice_connection: FaberAliceConnect,
@@ -132,6 +133,7 @@ async def test_send_jsonld_key_ed25519(
 
 
 @pytest.mark.anyio
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_send_jsonld_oob(
     faber_client: RichAsyncClient,
     alice_member_client: RichAsyncClient,
@@ -213,6 +215,7 @@ async def test_send_jsonld_oob(
 
 
 @pytest.mark.anyio
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_send_jsonld_request(
     alice_member_client: RichAsyncClient,
     faber_client: RichAsyncClient,
@@ -281,6 +284,7 @@ async def test_send_jsonld_request(
 
 
 @pytest.mark.anyio
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_issue_jsonld_ed(
     alice_member_client: RichAsyncClient,
     faber_client: RichAsyncClient,
@@ -352,6 +356,7 @@ async def test_issue_jsonld_ed(
 
 
 @pytest.mark.anyio
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_send_jsonld_mismatch_ed_bbs(
     faber_client: RichAsyncClient,
     faber_and_alice_connection: FaberAliceConnect,

--- a/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_ed25519.py
+++ b/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_ed25519.py
@@ -15,7 +15,7 @@ from app.tests.util.webhooks import assert_both_webhooks_received, check_webhook
 from shared import RichAsyncClient
 
 # Apply the marker to all tests in this module
-pytestmark = pytest.mark.xdist_group(name="issuer_test_group_2")
+pytestmark = pytest.mark.xdist_group(name="issuer_test_group_4")
 
 CREDENTIALS_BASE_PATH = issuer_router.prefix
 OOB_BASE_PATH = oob_router.prefix

--- a/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_ed25519.py
+++ b/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_ed25519.py
@@ -15,7 +15,7 @@ from app.tests.util.webhooks import assert_both_webhooks_received, check_webhook
 from shared import RichAsyncClient
 
 # Apply the marker to all tests in this module
-pytestmark = pytest.mark.xdist_group(name="issuer_test_group")
+pytestmark = pytest.mark.xdist_group(name="issuer_test_group_2")
 
 CREDENTIALS_BASE_PATH = issuer_router.prefix
 OOB_BASE_PATH = oob_router.prefix

--- a/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_ed25519.py
+++ b/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_ed25519.py
@@ -14,6 +14,9 @@ from app.tests.util.connections import FaberAliceConnect
 from app.tests.util.webhooks import assert_both_webhooks_received, check_webhook_state
 from shared import RichAsyncClient
 
+# Apply the marker to all tests in this module
+pytestmark = pytest.mark.xdist_group(name="issuer_test_group")
+
 CREDENTIALS_BASE_PATH = issuer_router.prefix
 OOB_BASE_PATH = oob_router.prefix
 CONNECTIONS_BASE_PATH = conn_router.prefix
@@ -69,7 +72,6 @@ credential_ = SendCredential(
 
 
 @pytest.mark.anyio
-@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_send_jsonld_key_ed25519(
     faber_client: RichAsyncClient,
     faber_and_alice_connection: FaberAliceConnect,
@@ -93,7 +95,6 @@ async def test_send_jsonld_key_ed25519(
     )
 
     data = response.json()
-    assert_that(data).contains("credential_exchange_id")
     assert_that(data).has_state("offer-sent")
     cred_ex_id = data["credential_exchange_id"]
 
@@ -132,7 +133,6 @@ async def test_send_jsonld_key_ed25519(
 
 
 @pytest.mark.anyio
-@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_send_jsonld_oob(
     faber_client: RichAsyncClient,
     alice_member_client: RichAsyncClient,
@@ -213,7 +213,6 @@ async def test_send_jsonld_oob(
 
 
 @pytest.mark.anyio
-@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_send_jsonld_request(
     alice_member_client: RichAsyncClient,
     faber_client: RichAsyncClient,
@@ -282,7 +281,6 @@ async def test_send_jsonld_request(
 
 
 @pytest.mark.anyio
-@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_issue_jsonld_ed(
     alice_member_client: RichAsyncClient,
     faber_client: RichAsyncClient,
@@ -354,7 +352,6 @@ async def test_issue_jsonld_ed(
 
 
 @pytest.mark.anyio
-@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_send_jsonld_mismatch_ed_bbs(
     faber_client: RichAsyncClient,
     faber_and_alice_connection: FaberAliceConnect,

--- a/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_ed25519.py
+++ b/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_ed25519.py
@@ -93,13 +93,12 @@ async def test_send_jsonld_key_ed25519(
     )
 
     data = response.json()
+    assert_that(data).contains("credential_exchange_id")
+    assert_that(data).has_state("offer-sent")
     cred_ex_id = data["credential_exchange_id"]
 
     try:
         thread_id = data["thread_id"]
-        assert_that(data).contains("credential_exchange_id")
-        assert_that(data).has_state("offer-sent")
-
         assert await check_webhook_state(
             client=alice_member_client,
             topic="credentials",
@@ -194,12 +193,11 @@ async def test_send_jsonld_oob(
     )
 
     data = response.json()
+    assert_that(data).contains("credential_exchange_id")
+    assert_that(data).has_state("offer-sent")
     cred_ex_id = data["credential_exchange_id"]
 
     try:
-        assert_that(data).contains("credential_exchange_id")
-        assert_that(data).has_state("offer-sent")
-
         assert await check_webhook_state(
             client=alice_member_client,
             topic="credentials",

--- a/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_sov.py
+++ b/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_sov.py
@@ -2,21 +2,17 @@ import asyncio
 from copy import deepcopy
 
 import pytest
-from aries_cloudcontroller import (
-    AcaPyClient,
-    Credential,
-    LDProofVCDetail,
-    LDProofVCOptions,
-)
+from aries_cloudcontroller import AcaPyClient
 from assertpy import assert_that
 
-from app.models.issuer import SendCredential
 from app.routes.issuer import router as issuer_router
 from app.routes.oob import router as oob_router
 from app.routes.wallet.dids import router as wallet_router
 from app.tests.util.connections import FaberAliceConnect
 from app.tests.util.webhooks import assert_both_webhooks_received, check_webhook_state
 from shared import RichAsyncClient
+
+from .util import create_credential
 
 # Apply the marker to all tests in this module
 pytestmark = pytest.mark.xdist_group(name="issuer_test_group_3")
@@ -25,54 +21,7 @@ CREDENTIALS_BASE_PATH = issuer_router.prefix
 OOB_BASE_PATH = oob_router.prefix
 WALLET = wallet_router.prefix
 
-credential_ = SendCredential(
-    type="ld_proof",
-    connection_id="",
-    ld_credential_detail=LDProofVCDetail(
-        credential=Credential(
-            context=[
-                "https://www.w3.org/2018/credentials/v1",
-                "https://www.w3.org/2018/credentials/examples/v1",
-            ],
-            type=["VerifiableCredential", "UniversityDegreeCredential"],
-            credentialSubject={
-                "degree": {
-                    "type": "BachelorDegree",
-                    "name": "Bachelor of Science and Arts",
-                },
-                "college": "Faber College",
-            },
-            issuanceDate="2021-04-12",
-            issuer="",
-        ),
-        options=LDProofVCOptions(proofType="Ed25519Signature2018"),
-    ),
-).model_dump(by_alias=True, exclude_unset=True)
-
-# This is the json of the above credential
-# {
-#     "type": "ld_proof",
-#     "connection_id": "",
-#     "ld_credential_detail": {
-#         "credential": {
-#             "@context": [
-#                 "https://www.w3.org/2018/credentials/v1",
-#                 "https://www.w3.org/2018/credentials/examples/v1",
-#             ],
-#             "type": ["VerifiableCredential", "UniversityDegreeCredential"],
-#             "credentialSubject": {
-#                 "degree": {
-#                     "type": "BachelorDegree",
-#                     "name": "Bachelor of Science and Arts",
-#                 },
-#                 "college": "Faber College",
-#             },
-#             "issuanceDate": "2021-04-12",
-#             "issuer": "",
-#         },
-#         "options": "",
-#     },
-# }
+credential_ = create_credential("Ed25519Signature2018")
 
 
 @pytest.mark.anyio

--- a/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_sov.py
+++ b/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_sov.py
@@ -19,7 +19,7 @@ from app.tests.util.webhooks import assert_both_webhooks_received, check_webhook
 from shared import RichAsyncClient
 
 # Apply the marker to all tests in this module
-pytestmark = pytest.mark.xdist_group(name="issuer_test_group")
+pytestmark = pytest.mark.xdist_group(name="issuer_test_group_2")
 
 CREDENTIALS_BASE_PATH = issuer_router.prefix
 OOB_BASE_PATH = oob_router.prefix

--- a/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_sov.py
+++ b/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_sov.py
@@ -18,6 +18,9 @@ from app.tests.util.connections import FaberAliceConnect
 from app.tests.util.webhooks import assert_both_webhooks_received, check_webhook_state
 from shared import RichAsyncClient
 
+# Apply the marker to all tests in this module
+pytestmark = pytest.mark.xdist_group(name="issuer_test_group")
+
 CREDENTIALS_BASE_PATH = issuer_router.prefix
 OOB_BASE_PATH = oob_router.prefix
 WALLET = wallet_router.prefix
@@ -73,7 +76,6 @@ credential_ = SendCredential(
 
 
 @pytest.mark.anyio
-@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_send_jsonld_credential_sov(
     faber_client: RichAsyncClient,
     faber_acapy_client: AcaPyClient,
@@ -138,7 +140,6 @@ async def test_send_jsonld_credential_sov(
 
 
 @pytest.mark.anyio
-@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_send_jsonld_oob_sov(
     faber_client: RichAsyncClient,
     faber_acapy_client: AcaPyClient,
@@ -208,7 +209,6 @@ async def test_send_jsonld_oob_sov(
 
 
 @pytest.mark.anyio
-@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_send_jsonld_request_sov(
     alice_member_client: RichAsyncClient,
     faber_client: RichAsyncClient,
@@ -286,7 +286,6 @@ async def test_send_jsonld_request_sov(
 
 
 @pytest.mark.anyio
-@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_issue_jsonld_sov(
     alice_member_client: RichAsyncClient,
     faber_client: RichAsyncClient,

--- a/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_sov.py
+++ b/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_sov.py
@@ -73,6 +73,7 @@ credential_ = SendCredential(
 
 
 @pytest.mark.anyio
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_send_jsonld_credential_sov(
     faber_client: RichAsyncClient,
     faber_acapy_client: AcaPyClient,
@@ -138,6 +139,7 @@ async def test_send_jsonld_credential_sov(
 
 
 @pytest.mark.anyio
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_send_jsonld_oob_sov(
     faber_client: RichAsyncClient,
     faber_acapy_client: AcaPyClient,
@@ -208,6 +210,7 @@ async def test_send_jsonld_oob_sov(
 
 
 @pytest.mark.anyio
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_send_jsonld_request_sov(
     alice_member_client: RichAsyncClient,
     faber_client: RichAsyncClient,
@@ -285,6 +288,7 @@ async def test_send_jsonld_request_sov(
 
 
 @pytest.mark.anyio
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_issue_jsonld_sov(
     alice_member_client: RichAsyncClient,
     faber_client: RichAsyncClient,

--- a/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_sov.py
+++ b/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_sov.py
@@ -99,13 +99,12 @@ async def test_send_jsonld_credential_sov(
     )
 
     data = response.json()
+    assert_that(data).contains("credential_exchange_id")
+    assert_that(data).has_state("offer-sent")
     cred_ex_id = data["credential_exchange_id"]
 
     try:
         thread_id = data["thread_id"]
-        assert_that(data).contains("credential_exchange_id")
-        assert_that(data).has_state("offer-sent")
-
         assert await check_webhook_state(
             client=alice_member_client,
             topic="credentials",
@@ -164,13 +163,12 @@ async def test_send_jsonld_oob_sov(
     )
 
     data = response.json()
+    assert_that(data).contains("credential_exchange_id")
+    assert_that(data).has_state("offer-sent")
     cred_ex_id = data["credential_exchange_id"]
-    thread_id = data["thread_id"]
 
     try:
-        assert_that(data).contains("credential_exchange_id")
-        assert_that(data).has_state("offer-sent")
-
+        thread_id = data["thread_id"]
         invitation_response = await faber_client.post(
             OOB_BASE_PATH + "/create-invitation",
             json={

--- a/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_sov.py
+++ b/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_sov.py
@@ -19,7 +19,7 @@ from app.tests.util.webhooks import assert_both_webhooks_received, check_webhook
 from shared import RichAsyncClient
 
 # Apply the marker to all tests in this module
-pytestmark = pytest.mark.xdist_group(name="issuer_test_group_2")
+pytestmark = pytest.mark.xdist_group(name="issuer_test_group_3")
 
 CREDENTIALS_BASE_PATH = issuer_router.prefix
 OOB_BASE_PATH = oob_router.prefix

--- a/app/tests/e2e/issuer/ld_proof/util.py
+++ b/app/tests/e2e/issuer/ld_proof/util.py
@@ -1,0 +1,29 @@
+from aries_cloudcontroller import Credential, LDProofVCDetail, LDProofVCOptions
+
+from app.models.issuer import SendCredential
+
+
+def create_credential(proof_type: str) -> dict:
+    return SendCredential(
+        type="ld_proof",
+        connection_id="",
+        ld_credential_detail=LDProofVCDetail(
+            credential=Credential(
+                context=[
+                    "https://www.w3.org/2018/credentials/v1",
+                    "https://www.w3.org/2018/credentials/examples/v1",
+                ],
+                type=["VerifiableCredential", "UniversityDegreeCredential"],
+                credentialSubject={
+                    "degree": {
+                        "type": "BachelorDegree",
+                        "name": "Bachelor of Science and Arts",
+                    },
+                    "college": "Faber College",
+                },
+                issuanceDate="2021-04-12",
+                issuer="",
+            ),
+            options=LDProofVCOptions(proofType=proof_type),
+        ),
+    ).model_dump(by_alias=True, exclude_unset=True)

--- a/app/tests/e2e/issuer/test_connections_use_public_did.py
+++ b/app/tests/e2e/issuer/test_connections_use_public_did.py
@@ -6,11 +6,14 @@ from app.routes.connections import router
 from app.tests.util.webhooks import check_webhook_state
 from shared import RichAsyncClient
 
+
+# Apply the marker to all tests in this module
+pytestmark = pytest.mark.xdist_group(name="issuer_test_group")
+
 CONNECTIONS_BASE_PATH = router.prefix
 
 
 @pytest.mark.anyio
-@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_accept_use_public_did(
     faber_client: RichAsyncClient,  # issuer has public did
     meld_co_client: RichAsyncClient,  # also has public did
@@ -55,7 +58,6 @@ async def test_accept_use_public_did(
 
 
 @pytest.mark.anyio
-@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_accept_use_public_did_between_issuer_and_holder(
     faber_client: RichAsyncClient,  # issuer has public did
     alice_member_client: RichAsyncClient,  # no public did

--- a/app/tests/e2e/issuer/test_connections_use_public_did.py
+++ b/app/tests/e2e/issuer/test_connections_use_public_did.py
@@ -10,6 +10,7 @@ CONNECTIONS_BASE_PATH = router.prefix
 
 
 @pytest.mark.anyio
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_accept_use_public_did(
     faber_client: RichAsyncClient,  # issuer has public did
     meld_co_client: RichAsyncClient,  # also has public did
@@ -54,6 +55,7 @@ async def test_accept_use_public_did(
 
 
 @pytest.mark.anyio
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_accept_use_public_did_between_issuer_and_holder(
     faber_client: RichAsyncClient,  # issuer has public did
     alice_member_client: RichAsyncClient,  # no public did

--- a/app/tests/e2e/issuer/test_connections_use_public_did.py
+++ b/app/tests/e2e/issuer/test_connections_use_public_did.py
@@ -6,7 +6,6 @@ from app.routes.connections import router
 from app.tests.util.webhooks import check_webhook_state
 from shared import RichAsyncClient
 
-
 # Apply the marker to all tests in this module
 pytestmark = pytest.mark.xdist_group(name="issuer_test_group")
 

--- a/app/tests/e2e/issuer/test_connections_use_public_did.py
+++ b/app/tests/e2e/issuer/test_connections_use_public_did.py
@@ -7,7 +7,7 @@ from app.tests.util.webhooks import check_webhook_state
 from shared import RichAsyncClient
 
 # Apply the marker to all tests in this module
-pytestmark = pytest.mark.xdist_group(name="issuer_test_group")
+pytestmark = pytest.mark.xdist_group(name="issuer_test_group_4")
 
 CONNECTIONS_BASE_PATH = router.prefix
 

--- a/app/tests/e2e/issuer/test_connections_use_public_did.py
+++ b/app/tests/e2e/issuer/test_connections_use_public_did.py
@@ -6,13 +6,11 @@ from app.routes.connections import router
 from app.tests.util.webhooks import check_webhook_state
 from shared import RichAsyncClient
 
-# Apply the marker to all tests in this module
-pytestmark = pytest.mark.xdist_group(name="issuer_test_group_4")
-
 CONNECTIONS_BASE_PATH = router.prefix
 
 
 @pytest.mark.anyio
+@pytest.mark.xdist_group(name="issuer_test_group_3")
 async def test_accept_use_public_did(
     faber_client: RichAsyncClient,  # issuer has public did
     meld_co_client: RichAsyncClient,  # also has public did
@@ -57,6 +55,7 @@ async def test_accept_use_public_did(
 
 
 @pytest.mark.anyio
+@pytest.mark.xdist_group(name="issuer_test_group_4")
 async def test_accept_use_public_did_between_issuer_and_holder(
     faber_client: RichAsyncClient,  # issuer has public did
     alice_member_client: RichAsyncClient,  # no public did

--- a/app/tests/e2e/issuer/test_get_records_paginated.py
+++ b/app/tests/e2e/issuer/test_get_records_paginated.py
@@ -16,6 +16,7 @@ CREDENTIALS_BASE_PATH = router.prefix
     TestMode.regression_run in TestMode.fixture_params,
     reason="Temporarily skip; existing tests on dev don't clean up old records yet",
 )
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_get_credential_exchange_records_paginated(
     faber_client: RichAsyncClient,
     alice_member_client: RichAsyncClient,

--- a/app/tests/e2e/issuer/test_get_records_paginated.py
+++ b/app/tests/e2e/issuer/test_get_records_paginated.py
@@ -16,7 +16,7 @@ CREDENTIALS_BASE_PATH = router.prefix
     TestMode.regression_run in TestMode.fixture_params,
     reason="Temporarily skip; existing tests on dev don't clean up old records yet",
 )
-@pytest.mark.xdist_group(name="issuer_test_group")
+@pytest.mark.xdist_group(name="issuer_test_group_4")
 async def test_get_credential_exchange_records_paginated(
     faber_client: RichAsyncClient,
     alice_member_client: RichAsyncClient,

--- a/app/tests/e2e/issuer/test_indy_credentials.py
+++ b/app/tests/e2e/issuer/test_indy_credentials.py
@@ -11,12 +11,14 @@ from app.tests.util.connections import FaberAliceConnect
 from app.tests.util.webhooks import check_webhook_state
 from shared import RichAsyncClient
 
+# Apply the marker to all tests in this module
+pytestmark = pytest.mark.xdist_group(name="issuer_test_group")
+
 CREDENTIALS_BASE_PATH = issuer_router.prefix
 OOB_BASE_PATH = oob_router.prefix
 
 
 @pytest.mark.anyio
-@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_send_credential_oob(
     faber_client: RichAsyncClient,
     schema_definition: CredentialSchema,
@@ -82,7 +84,6 @@ async def test_send_credential_oob(
 
 
 @pytest.mark.anyio
-@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_send_credential(
     faber_client: RichAsyncClient,
     schema_definition: CredentialSchema,
@@ -125,7 +126,6 @@ async def test_send_credential(
 
 
 @pytest.mark.anyio
-@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_create_offer(
     faber_client: RichAsyncClient,
     schema_definition: CredentialSchema,
@@ -166,7 +166,6 @@ async def test_create_offer(
 
 
 @pytest.mark.anyio
-@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_send_credential_request(
     alice_member_client: RichAsyncClient,
     faber_client: RichAsyncClient,
@@ -242,7 +241,6 @@ async def test_send_credential_request(
 
 
 @pytest.mark.anyio
-@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_revoke_credential(
     faber_client: RichAsyncClient,
     alice_member_client: RichAsyncClient,

--- a/app/tests/e2e/issuer/test_indy_credentials.py
+++ b/app/tests/e2e/issuer/test_indy_credentials.py
@@ -16,6 +16,7 @@ OOB_BASE_PATH = oob_router.prefix
 
 
 @pytest.mark.anyio
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_send_credential_oob(
     faber_client: RichAsyncClient,
     schema_definition: CredentialSchema,
@@ -81,6 +82,7 @@ async def test_send_credential_oob(
 
 
 @pytest.mark.anyio
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_send_credential(
     faber_client: RichAsyncClient,
     schema_definition: CredentialSchema,
@@ -123,6 +125,7 @@ async def test_send_credential(
 
 
 @pytest.mark.anyio
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_create_offer(
     faber_client: RichAsyncClient,
     schema_definition: CredentialSchema,
@@ -163,6 +166,7 @@ async def test_create_offer(
 
 
 @pytest.mark.anyio
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_send_credential_request(
     alice_member_client: RichAsyncClient,
     faber_client: RichAsyncClient,
@@ -238,6 +242,7 @@ async def test_send_credential_request(
 
 
 @pytest.mark.anyio
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_revoke_credential(
     faber_client: RichAsyncClient,
     alice_member_client: RichAsyncClient,

--- a/app/tests/e2e/issuer/test_indy_credentials.py
+++ b/app/tests/e2e/issuer/test_indy_credentials.py
@@ -12,7 +12,7 @@ from app.tests.util.webhooks import check_webhook_state
 from shared import RichAsyncClient
 
 # Apply the marker to all tests in this module
-pytestmark = pytest.mark.xdist_group(name="issuer_test_group")
+pytestmark = pytest.mark.xdist_group(name="issuer_test_group_2")
 
 CREDENTIALS_BASE_PATH = issuer_router.prefix
 OOB_BASE_PATH = oob_router.prefix

--- a/app/tests/e2e/issuer/test_save_exchange_record.py
+++ b/app/tests/e2e/issuer/test_save_exchange_record.py
@@ -12,7 +12,6 @@ from app.tests.util.webhooks import check_webhook_state
 from shared import RichAsyncClient
 from shared.models.credential_exchange import CredentialExchange
 
-
 # Apply the marker to all tests in this module
 pytestmark = pytest.mark.xdist_group(name="issuer_test_group")
 

--- a/app/tests/e2e/issuer/test_save_exchange_record.py
+++ b/app/tests/e2e/issuer/test_save_exchange_record.py
@@ -12,14 +12,12 @@ from app.tests.util.webhooks import check_webhook_state
 from shared import RichAsyncClient
 from shared.models.credential_exchange import CredentialExchange
 
-# Apply the marker to all tests in this module
-pytestmark = pytest.mark.xdist_group(name="issuer_test_group_4")
-
 CREDENTIALS_BASE_PATH = router.prefix
 
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("save_exchange_record", [None, False, True])
+@pytest.mark.xdist_group(name="issuer_test_group_3")
 async def test_issue_credential_with_save_exchange_record(
     faber_client: RichAsyncClient,
     credential_definition_id: str,
@@ -114,6 +112,7 @@ async def test_issue_credential_with_save_exchange_record(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("save_exchange_record", [None, False, True])
+@pytest.mark.xdist_group(name="issuer_test_group_4")
 async def test_request_credential_with_save_exchange_record(
     faber_client: RichAsyncClient,
     credential_definition_id: str,
@@ -208,6 +207,7 @@ async def test_request_credential_with_save_exchange_record(
 
 
 @pytest.mark.anyio
+@pytest.mark.xdist_group(name="issuer_test_group_3")
 async def test_get_cred_exchange_records(
     faber_client: RichAsyncClient,
     credential_definition_id: str,

--- a/app/tests/e2e/issuer/test_save_exchange_record.py
+++ b/app/tests/e2e/issuer/test_save_exchange_record.py
@@ -17,6 +17,7 @@ CREDENTIALS_BASE_PATH = router.prefix
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("save_exchange_record", [None, False, True])
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_issue_credential_with_save_exchange_record(
     faber_client: RichAsyncClient,
     credential_definition_id: str,
@@ -111,6 +112,7 @@ async def test_issue_credential_with_save_exchange_record(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("save_exchange_record", [None, False, True])
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_request_credential_with_save_exchange_record(
     faber_client: RichAsyncClient,
     credential_definition_id: str,
@@ -205,6 +207,7 @@ async def test_request_credential_with_save_exchange_record(
 
 
 @pytest.mark.anyio
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_get_cred_exchange_records(
     faber_client: RichAsyncClient,
     credential_definition_id: str,

--- a/app/tests/e2e/issuer/test_save_exchange_record.py
+++ b/app/tests/e2e/issuer/test_save_exchange_record.py
@@ -12,12 +12,15 @@ from app.tests.util.webhooks import check_webhook_state
 from shared import RichAsyncClient
 from shared.models.credential_exchange import CredentialExchange
 
+
+# Apply the marker to all tests in this module
+pytestmark = pytest.mark.xdist_group(name="issuer_test_group")
+
 CREDENTIALS_BASE_PATH = router.prefix
 
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("save_exchange_record", [None, False, True])
-@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_issue_credential_with_save_exchange_record(
     faber_client: RichAsyncClient,
     credential_definition_id: str,
@@ -112,7 +115,6 @@ async def test_issue_credential_with_save_exchange_record(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("save_exchange_record", [None, False, True])
-@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_request_credential_with_save_exchange_record(
     faber_client: RichAsyncClient,
     credential_definition_id: str,
@@ -207,7 +209,6 @@ async def test_request_credential_with_save_exchange_record(
 
 
 @pytest.mark.anyio
-@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_get_cred_exchange_records(
     faber_client: RichAsyncClient,
     credential_definition_id: str,

--- a/app/tests/e2e/issuer/test_save_exchange_record.py
+++ b/app/tests/e2e/issuer/test_save_exchange_record.py
@@ -13,7 +13,7 @@ from shared import RichAsyncClient
 from shared.models.credential_exchange import CredentialExchange
 
 # Apply the marker to all tests in this module
-pytestmark = pytest.mark.xdist_group(name="issuer_test_group")
+pytestmark = pytest.mark.xdist_group(name="issuer_test_group_4")
 
 CREDENTIALS_BASE_PATH = router.prefix
 

--- a/app/tests/e2e/test_definitions.py
+++ b/app/tests/e2e/test_definitions.py
@@ -155,6 +155,7 @@ async def test_get_credential_definition(
         "but it fails when run a 2nd time in regression mode"
     ),
 )
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_create_credential_definition_issuer_tenant(
     schema_definition: CredentialSchema,
     faber_acapy_client: AcaPyClient,

--- a/app/tests/e2e/test_did_exchange.py
+++ b/app/tests/e2e/test_did_exchange.py
@@ -29,6 +29,7 @@ TENANTS_BASE_PATH = tenants_router.prefix
         (None, None, True),
     ],
 )
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_create_did_exchange_request(
     alice_member_client: RichAsyncClient,
     faber_client: RichAsyncClient,
@@ -113,6 +114,7 @@ async def test_create_did_exchange_request(
     "This test works in isolation. Should be refactored to run in parallel."
 )
 @pytest.mark.parametrize("use_public_did", [False])
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_accept_did_exchange_invitation(
     alice_member_client: RichAsyncClient,
     faber_client: RichAsyncClient,

--- a/app/tests/e2e/test_did_rotate.py
+++ b/app/tests/e2e/test_did_rotate.py
@@ -55,6 +55,7 @@ async def test_rotate_did(
 
 
 @pytest.mark.anyio
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_hangup_did_rotation(
     alice_member_client: RichAsyncClient,
     faber_client: RichAsyncClient,

--- a/app/tests/e2e/test_did_rotate.py
+++ b/app/tests/e2e/test_did_rotate.py
@@ -15,6 +15,7 @@ CONNECTIONS_BASE_PATH = connections_router.prefix
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("did_method", ["did:peer:2", "did:peer:4"])
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_rotate_did(
     alice_member_client: RichAsyncClient,
     alice_acapy_client: AcaPyClient,

--- a/app/tests/e2e/test_jsonld.py
+++ b/app/tests/e2e/test_jsonld.py
@@ -53,6 +53,7 @@ signed_doc = {
 
 
 @pytest.mark.anyio
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_sign_jsonld(
     faber_acapy_client: AcaPyClient,
     faber_client: RichAsyncClient,
@@ -126,6 +127,7 @@ async def test_sign_jsonld(
 
 @pytest.mark.skip("Model validation is overly strict again. To be reviewed")
 @pytest.mark.anyio
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_verify_jsonld(
     alice_member_client: RichAsyncClient,
     faber_acapy_client: AcaPyClient,

--- a/app/tests/e2e/test_oob.py
+++ b/app/tests/e2e/test_oob.py
@@ -68,6 +68,7 @@ async def test_accept_invitation_oob(
 
 
 @pytest.mark.anyio
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_oob_connect_via_public_did(
     bob_member_client: RichAsyncClient,
     faber_acapy_client: AcaPyClient,

--- a/app/tests/e2e/test_proof_request_models.py
+++ b/app/tests/e2e/test_proof_request_models.py
@@ -24,6 +24,7 @@ VERIFIER_BASE_PATH = verifier_router.prefix
         (None, None),
     ],
 )
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_proof_model_failures(
     issue_credential_to_alice: CredentialExchange,  # pylint: disable=unused-argument
     acme_acapy_client: AcaPyClient,

--- a/app/tests/e2e/test_proof_request_models.py
+++ b/app/tests/e2e/test_proof_request_models.py
@@ -24,7 +24,7 @@ VERIFIER_BASE_PATH = verifier_router.prefix
         (None, None),
     ],
 )
-@pytest.mark.xdist_group(name="issuer_test_group_4")
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_proof_model_failures(
     issue_credential_to_alice: CredentialExchange,  # pylint: disable=unused-argument
     acme_acapy_client: AcaPyClient,

--- a/app/tests/e2e/test_proof_request_models.py
+++ b/app/tests/e2e/test_proof_request_models.py
@@ -24,7 +24,7 @@ VERIFIER_BASE_PATH = verifier_router.prefix
         (None, None),
     ],
 )
-@pytest.mark.xdist_group(name="issuer_test_group")
+@pytest.mark.xdist_group(name="issuer_test_group_4")
 async def test_proof_model_failures(
     issue_credential_to_alice: CredentialExchange,  # pylint: disable=unused-argument
     acme_acapy_client: AcaPyClient,

--- a/app/tests/e2e/test_revocation.py
+++ b/app/tests/e2e/test_revocation.py
@@ -20,6 +20,7 @@ skip_regression_test_reason = "Skip publish-revocations in regression mode"
     TestMode.regression_run in TestMode.fixture_params,
     reason=skip_regression_test_reason,
 )
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_clear_pending_revokes(
     faber_client: RichAsyncClient,
     revoke_alice_creds: List[CredentialExchange],
@@ -81,6 +82,7 @@ async def test_clear_pending_revokes(
     TestMode.regression_run in TestMode.fixture_params,
     reason=skip_regression_test_reason,
 )
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_clear_pending_revokes_no_map(
     faber_client: RichAsyncClient,
     revoke_alice_creds: List[CredentialExchange],
@@ -111,6 +113,7 @@ async def test_clear_pending_revokes_no_map(
     TestMode.regression_run in TestMode.fixture_params,
     reason=skip_regression_test_reason,
 )
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_clear_pending_revokes_bad_payload(
     faber_client: RichAsyncClient,
 ):
@@ -148,6 +151,7 @@ async def test_clear_pending_revokes_bad_payload(
     TestMode.regression_run in TestMode.fixture_params,
     reason=skip_regression_test_reason,
 )
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_publish_all_revocations_for_rev_reg_id(
     faber_client: RichAsyncClient,
     revoke_alice_creds: List[CredentialExchange],
@@ -185,6 +189,7 @@ async def test_publish_all_revocations_for_rev_reg_id(
     TestMode.regression_run in TestMode.fixture_params,
     reason=skip_regression_test_reason,
 )
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_publish_all_revocations_no_payload(
     faber_client: RichAsyncClient,
     revoke_alice_creds: List[CredentialExchange],
@@ -211,6 +216,7 @@ async def test_publish_all_revocations_no_payload(
     TestMode.regression_run in TestMode.fixture_params,
     reason=skip_regression_test_reason,
 )
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_publish_one_revocation(
     faber_client: RichAsyncClient,
     revoke_alice_creds: List[CredentialExchange],
@@ -260,6 +266,7 @@ async def test_publish_one_revocation(
     TestMode.regression_run in TestMode.fixture_params,
     reason=skip_regression_test_reason,
 )
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_publish_revocations_bad_payload(
     faber_client: RichAsyncClient,
 ):
@@ -297,6 +304,7 @@ async def test_publish_revocations_bad_payload(
     TestMode.regression_run in TestMode.fixture_params,
     reason=skip_regression_test_reason,
 )
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_get_pending_revocations(
     faber_client: RichAsyncClient,
     revoke_alice_creds: List[CredentialExchange],
@@ -339,6 +347,7 @@ async def test_get_pending_revocations(
     TestMode.regression_run in TestMode.fixture_params,
     reason=skip_regression_test_reason,
 )
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_get_pending_revocations_bad_payload(
     faber_client: RichAsyncClient,
 ):
@@ -363,6 +372,7 @@ async def test_get_pending_revocations_bad_payload(
         ("bad_format", 422),
     ],
 )
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_fix_rev_reg_bad_id(
     faber_client: RichAsyncClient, rev_reg_id: str, status_code: int
 ):

--- a/app/tests/e2e/test_revocation.py
+++ b/app/tests/e2e/test_revocation.py
@@ -10,7 +10,7 @@ from shared import RichAsyncClient
 from shared.models.credential_exchange import CredentialExchange
 
 # Apply the marker to all tests in this module
-pytestmark = pytest.mark.xdist_group(name="issuer_test_group_3")
+pytestmark = pytest.mark.xdist_group(name="issuer_test_group_2")
 
 REVOCATION_BASE_PATH = router.prefix
 VERIFIER_BASE_PATH = verifier_router.prefix

--- a/app/tests/e2e/test_revocation.py
+++ b/app/tests/e2e/test_revocation.py
@@ -10,7 +10,7 @@ from shared import RichAsyncClient
 from shared.models.credential_exchange import CredentialExchange
 
 # Apply the marker to all tests in this module
-pytestmark = pytest.mark.xdist_group(name="issuer_test_group")
+pytestmark = pytest.mark.xdist_group(name="issuer_test_group_3")
 
 REVOCATION_BASE_PATH = router.prefix
 VERIFIER_BASE_PATH = verifier_router.prefix

--- a/app/tests/e2e/test_revocation.py
+++ b/app/tests/e2e/test_revocation.py
@@ -9,7 +9,6 @@ from app.tests.util.regression_testing import TestMode
 from shared import RichAsyncClient
 from shared.models.credential_exchange import CredentialExchange
 
-
 # Apply the marker to all tests in this module
 pytestmark = pytest.mark.xdist_group(name="issuer_test_group")
 

--- a/app/tests/e2e/test_revocation.py
+++ b/app/tests/e2e/test_revocation.py
@@ -9,6 +9,10 @@ from app.tests.util.regression_testing import TestMode
 from shared import RichAsyncClient
 from shared.models.credential_exchange import CredentialExchange
 
+
+# Apply the marker to all tests in this module
+pytestmark = pytest.mark.xdist_group(name="issuer_test_group")
+
 REVOCATION_BASE_PATH = router.prefix
 VERIFIER_BASE_PATH = verifier_router.prefix
 
@@ -20,7 +24,6 @@ skip_regression_test_reason = "Skip publish-revocations in regression mode"
     TestMode.regression_run in TestMode.fixture_params,
     reason=skip_regression_test_reason,
 )
-@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_clear_pending_revokes(
     faber_client: RichAsyncClient,
     revoke_alice_creds: List[CredentialExchange],
@@ -82,7 +85,6 @@ async def test_clear_pending_revokes(
     TestMode.regression_run in TestMode.fixture_params,
     reason=skip_regression_test_reason,
 )
-@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_clear_pending_revokes_no_map(
     faber_client: RichAsyncClient,
     revoke_alice_creds: List[CredentialExchange],
@@ -113,7 +115,6 @@ async def test_clear_pending_revokes_no_map(
     TestMode.regression_run in TestMode.fixture_params,
     reason=skip_regression_test_reason,
 )
-@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_clear_pending_revokes_bad_payload(
     faber_client: RichAsyncClient,
 ):
@@ -151,7 +152,6 @@ async def test_clear_pending_revokes_bad_payload(
     TestMode.regression_run in TestMode.fixture_params,
     reason=skip_regression_test_reason,
 )
-@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_publish_all_revocations_for_rev_reg_id(
     faber_client: RichAsyncClient,
     revoke_alice_creds: List[CredentialExchange],
@@ -180,7 +180,6 @@ async def test_publish_all_revocations_for_rev_reg_id(
     TestMode.regression_run in TestMode.fixture_params,
     reason=skip_regression_test_reason,
 )
-@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_publish_all_revocations_no_payload(
     faber_client: RichAsyncClient,
     revoke_alice_creds: List[CredentialExchange],
@@ -215,7 +214,6 @@ async def check_revocation_status(
     TestMode.regression_run in TestMode.fixture_params,
     reason=skip_regression_test_reason,
 )
-@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_publish_one_revocation(
     faber_client: RichAsyncClient,
     revoke_alice_creds: List[CredentialExchange],
@@ -265,7 +263,6 @@ async def test_publish_one_revocation(
     TestMode.regression_run in TestMode.fixture_params,
     reason=skip_regression_test_reason,
 )
-@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_publish_revocations_bad_payload(
     faber_client: RichAsyncClient,
 ):
@@ -303,7 +300,6 @@ async def test_publish_revocations_bad_payload(
     TestMode.regression_run in TestMode.fixture_params,
     reason=skip_regression_test_reason,
 )
-@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_get_pending_revocations(
     faber_client: RichAsyncClient,
     revoke_alice_creds: List[CredentialExchange],
@@ -346,7 +342,6 @@ async def test_get_pending_revocations(
     TestMode.regression_run in TestMode.fixture_params,
     reason=skip_regression_test_reason,
 )
-@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_get_pending_revocations_bad_payload(
     faber_client: RichAsyncClient,
 ):
@@ -371,7 +366,6 @@ async def test_get_pending_revocations_bad_payload(
         ("bad_format", 422),
     ],
 )
-@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_fix_rev_reg_bad_id(
     faber_client: RichAsyncClient, rev_reg_id: str, status_code: int
 ):

--- a/app/tests/e2e/test_revocation.py
+++ b/app/tests/e2e/test_revocation.py
@@ -172,16 +172,7 @@ async def test_publish_all_revocations_for_rev_reg_id(
         json={"revocation_registry_credential_map": {rev_reg_id: []}},
     )
 
-    for cred in revoke_alice_creds:
-        rev_record = (
-            await faber_client.get(
-                f"{REVOCATION_BASE_PATH}/revocation/record"
-                + "?credential_exchange_id="
-                + cred.credential_exchange_id
-            )
-        ).json()
-
-        assert rev_record["state"] == "revoked"
+    await check_revocation_status(faber_client, revoke_alice_creds, "revoked")
 
 
 @pytest.mark.anyio
@@ -199,16 +190,24 @@ async def test_publish_all_revocations_no_payload(
         json={"revocation_registry_credential_map": {}},
     )
 
-    for cred in revoke_alice_creds:
+    await check_revocation_status(faber_client, revoke_alice_creds, "revoked")
+
+
+async def check_revocation_status(
+    client: RichAsyncClient,
+    credentials: List[CredentialExchange],
+    expected_state: str,
+):
+    for cred in credentials:
         rev_record = (
-            await faber_client.get(
+            await client.get(
                 f"{REVOCATION_BASE_PATH}/revocation/record"
                 + "?credential_exchange_id="
                 + cred.credential_exchange_id
             )
         ).json()
 
-        assert rev_record["state"] == "revoked"
+        assert rev_record["state"] == expected_state
 
 
 @pytest.mark.anyio

--- a/app/tests/e2e/test_tenants.py
+++ b/app/tests/e2e/test_tenants.py
@@ -176,6 +176,7 @@ async def test_create_tenant_member_w_wallet_name(
     TestMode.regression_run in TestMode.fixture_params,
     reason=skip_regression_test_reason,
 )
+@pytest.mark.xdist_group(name="issuer_test_group_5")
 async def test_create_tenant_issuer(
     tenant_admin_client: RichAsyncClient,
     tenant_admin_acapy_client: AcaPyClient,
@@ -320,6 +321,7 @@ async def test_create_tenant_verifier(
     TestMode.regression_run in TestMode.fixture_params,
     reason=skip_regression_test_reason,
 )
+@pytest.mark.xdist_group(name="issuer_test_group_5")
 async def test_update_tenant_verifier_to_issuer(
     tenant_admin_client: RichAsyncClient,
     tenant_admin_acapy_client: AcaPyClient,

--- a/app/tests/e2e/test_trust_registry.py
+++ b/app/tests/e2e/test_trust_registry.py
@@ -12,6 +12,7 @@ CLOUDAPI_TRUST_REGISTRY_PATH = router.prefix
 
 
 @pytest.mark.anyio
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_get_schemas(
     schema_definition: CredentialSchema,  # pylint: disable=unused-argument
     schema_definition_alt: CredentialSchema,  # pylint: disable=unused-argument
@@ -27,6 +28,7 @@ async def test_get_schemas(
 
 
 @pytest.mark.anyio
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_get_schema_by_id(
     schema_definition: CredentialSchema, trust_registry_client: RichAsyncClient
 ):
@@ -47,6 +49,7 @@ async def test_get_schema_by_id(
 
 
 @pytest.mark.anyio
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_get_actors(
     faber_issuer: CreateTenantResponse,
     faber_acapy_client: AcaPyClient,
@@ -118,6 +121,7 @@ async def test_get_actors_x(trust_registry_client: RichAsyncClient):
 
 
 @pytest.mark.anyio
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_get_issuers(
     faber_issuer: CreateTenantResponse,  # pylint: disable=unused-argument
     trust_registry_client: RichAsyncClient,

--- a/app/tests/e2e/test_wallet_credentials.py
+++ b/app/tests/e2e/test_wallet_credentials.py
@@ -71,6 +71,7 @@ async def test_get_and_delete_credential_record(
 @pytest.mark.parametrize(
     "issue_alice_many_creds", [3], indirect=True
 )  # issue alice 3 creds
+@pytest.mark.xdist_group(name="issuer_test_group_4")
 async def test_get_credential_record_with_limit(
     alice_member_client: RichAsyncClient,
     issue_alice_many_creds: List[CredentialExchange],  # pylint: disable=unused-argument

--- a/app/tests/e2e/test_wallet_credentials.py
+++ b/app/tests/e2e/test_wallet_credentials.py
@@ -23,6 +23,7 @@ async def test_get_credentials(alice_member_client: RichAsyncClient):
     TestMode.regression_run in TestMode.fixture_params,
     reason="Don't delete credentials in regression run",
 )
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_get_and_delete_credential_record(
     alice_member_client: RichAsyncClient,
     issue_credential_to_alice: CredentialExchange,  # pylint: disable=unused-argument

--- a/app/tests/e2e/test_wallet_credentials.py
+++ b/app/tests/e2e/test_wallet_credentials.py
@@ -23,7 +23,7 @@ async def test_get_credentials(alice_member_client: RichAsyncClient):
     TestMode.regression_run in TestMode.fixture_params,
     reason="Don't delete credentials in regression run",
 )
-@pytest.mark.xdist_group(name="issuer_test_group")
+@pytest.mark.xdist_group(name="issuer_test_group_4")
 async def test_get_and_delete_credential_record(
     alice_member_client: RichAsyncClient,
     issue_credential_to_alice: CredentialExchange,  # pylint: disable=unused-argument

--- a/app/tests/e2e/verifier/test_get_credentials_by_proof_id.py
+++ b/app/tests/e2e/verifier/test_get_credentials_by_proof_id.py
@@ -18,7 +18,7 @@ VERIFIER_BASE_PATH = router.prefix
     TestMode.regression_run in TestMode.fixture_params,
     reason="Temporarily skip; existing tests on dev don't clean up old records yet",
 )
-@pytest.mark.xdist_group(name="issuer_test_group_4")
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_limit_and_offset(
     issue_alice_creds: List[CredentialExchange],  # pylint: disable=unused-argument
     acme_and_alice_connection: AcmeAliceConnect,

--- a/app/tests/e2e/verifier/test_get_credentials_by_proof_id.py
+++ b/app/tests/e2e/verifier/test_get_credentials_by_proof_id.py
@@ -18,6 +18,7 @@ VERIFIER_BASE_PATH = router.prefix
     TestMode.regression_run in TestMode.fixture_params,
     reason="Temporarily skip; existing tests on dev don't clean up old records yet",
 )
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_limit_and_offset(
     issue_alice_creds: List[CredentialExchange],  # pylint: disable=unused-argument
     acme_and_alice_connection: AcmeAliceConnect,

--- a/app/tests/e2e/verifier/test_get_credentials_by_proof_id.py
+++ b/app/tests/e2e/verifier/test_get_credentials_by_proof_id.py
@@ -18,7 +18,7 @@ VERIFIER_BASE_PATH = router.prefix
     TestMode.regression_run in TestMode.fixture_params,
     reason="Temporarily skip; existing tests on dev don't clean up old records yet",
 )
-@pytest.mark.xdist_group(name="issuer_test_group")
+@pytest.mark.xdist_group(name="issuer_test_group_4")
 async def test_limit_and_offset(
     issue_alice_creds: List[CredentialExchange],  # pylint: disable=unused-argument
     acme_and_alice_connection: AcmeAliceConnect,

--- a/app/tests/e2e/verifier/test_get_records_paginated.py
+++ b/app/tests/e2e/verifier/test_get_records_paginated.py
@@ -18,6 +18,7 @@ VERIFIER_BASE_PATH = router.prefix
     TestMode.regression_run in TestMode.fixture_params,
     reason="Temporarily skip; existing tests on dev don't clean up old records yet",
 )
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_get_presentation_exchange_records_paginated(
     acme_client: RichAsyncClient,
     alice_member_client: RichAsyncClient,

--- a/app/tests/e2e/verifier/test_get_records_paginated.py
+++ b/app/tests/e2e/verifier/test_get_records_paginated.py
@@ -18,7 +18,7 @@ VERIFIER_BASE_PATH = router.prefix
     TestMode.regression_run in TestMode.fixture_params,
     reason="Temporarily skip; existing tests on dev don't clean up old records yet",
 )
-@pytest.mark.xdist_group(name="issuer_test_group_4")
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_get_presentation_exchange_records_paginated(
     acme_client: RichAsyncClient,
     alice_member_client: RichAsyncClient,

--- a/app/tests/e2e/verifier/test_get_records_paginated.py
+++ b/app/tests/e2e/verifier/test_get_records_paginated.py
@@ -18,7 +18,7 @@ VERIFIER_BASE_PATH = router.prefix
     TestMode.regression_run in TestMode.fixture_params,
     reason="Temporarily skip; existing tests on dev don't clean up old records yet",
 )
-@pytest.mark.xdist_group(name="issuer_test_group")
+@pytest.mark.xdist_group(name="issuer_test_group_4")
 async def test_get_presentation_exchange_records_paginated(
     acme_client: RichAsyncClient,
     alice_member_client: RichAsyncClient,

--- a/app/tests/e2e/verifier/test_many_revocations.py
+++ b/app/tests/e2e/verifier/test_many_revocations.py
@@ -12,10 +12,6 @@ from app.tests.util.webhooks import assert_both_webhooks_received, check_webhook
 from shared import RichAsyncClient
 from shared.models.credential_exchange import CredentialExchange
 
-
-# Apply the marker to all tests in this module
-pytestmark = pytest.mark.xdist_group(name="issuer_test_group")
-
 CREDENTIALS_BASE_PATH = issuer_router.prefix
 VERIFIER_BASE_PATH = verifier_router.prefix
 
@@ -23,6 +19,7 @@ VERIFIER_BASE_PATH = verifier_router.prefix
 @pytest.mark.anyio
 @pytest.mark.skip("This test exists for local testing")
 @pytest.mark.parametrize("revoke_many", ["auto_publish_true"], indirect=True)
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_revoke_many_credentials(
     revoke_many: List[  # pylint: disable=unused-argument, redefined-outer-name
         CredentialExchange

--- a/app/tests/e2e/verifier/test_many_revocations.py
+++ b/app/tests/e2e/verifier/test_many_revocations.py
@@ -19,7 +19,7 @@ VERIFIER_BASE_PATH = verifier_router.prefix
 @pytest.mark.anyio
 @pytest.mark.skip("This test exists for local testing")
 @pytest.mark.parametrize("revoke_many", ["auto_publish_true"], indirect=True)
-@pytest.mark.xdist_group(name="issuer_test_group_3")
+@pytest.mark.xdist_group(name="issuer_test_group_2")
 async def test_revoke_many_credentials(
     revoke_many: List[  # pylint: disable=unused-argument, redefined-outer-name
         CredentialExchange

--- a/app/tests/e2e/verifier/test_many_revocations.py
+++ b/app/tests/e2e/verifier/test_many_revocations.py
@@ -19,6 +19,7 @@ VERIFIER_BASE_PATH = verifier_router.prefix
 @pytest.mark.anyio
 @pytest.mark.skip("This test exists for local testing")
 @pytest.mark.parametrize("revoke_many", ["auto_publish_true"], indirect=True)
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_revoke_many_credentials(
     revoke_many: List[  # pylint: disable=unused-argument, redefined-outer-name
         CredentialExchange
@@ -108,6 +109,7 @@ async def test_revoke_many_credentials(
 
 
 @pytest.fixture(scope="function")
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def revoke_many(
     request,
     faber_client: RichAsyncClient,
@@ -131,6 +133,7 @@ async def revoke_many(
 
 
 @pytest.fixture(scope="function")
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def issue_many_creds(
     faber_client: RichAsyncClient,
     alice_member_client: RichAsyncClient,

--- a/app/tests/e2e/verifier/test_many_revocations.py
+++ b/app/tests/e2e/verifier/test_many_revocations.py
@@ -19,7 +19,7 @@ VERIFIER_BASE_PATH = verifier_router.prefix
 @pytest.mark.anyio
 @pytest.mark.skip("This test exists for local testing")
 @pytest.mark.parametrize("revoke_many", ["auto_publish_true"], indirect=True)
-@pytest.mark.xdist_group(name="issuer_test_group")
+@pytest.mark.xdist_group(name="issuer_test_group_3")
 async def test_revoke_many_credentials(
     revoke_many: List[  # pylint: disable=unused-argument, redefined-outer-name
         CredentialExchange

--- a/app/tests/e2e/verifier/test_many_revocations.py
+++ b/app/tests/e2e/verifier/test_many_revocations.py
@@ -12,6 +12,10 @@ from app.tests.util.webhooks import assert_both_webhooks_received, check_webhook
 from shared import RichAsyncClient
 from shared.models.credential_exchange import CredentialExchange
 
+
+# Apply the marker to all tests in this module
+pytestmark = pytest.mark.xdist_group(name="issuer_test_group")
+
 CREDENTIALS_BASE_PATH = issuer_router.prefix
 VERIFIER_BASE_PATH = verifier_router.prefix
 
@@ -19,7 +23,6 @@ VERIFIER_BASE_PATH = verifier_router.prefix
 @pytest.mark.anyio
 @pytest.mark.skip("This test exists for local testing")
 @pytest.mark.parametrize("revoke_many", ["auto_publish_true"], indirect=True)
-@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_revoke_many_credentials(
     revoke_many: List[  # pylint: disable=unused-argument, redefined-outer-name
         CredentialExchange
@@ -109,7 +112,6 @@ async def test_revoke_many_credentials(
 
 
 @pytest.fixture(scope="function")
-@pytest.mark.xdist_group(name="issuer_test_group")
 async def revoke_many(
     request,
     faber_client: RichAsyncClient,
@@ -133,7 +135,6 @@ async def revoke_many(
 
 
 @pytest.fixture(scope="function")
-@pytest.mark.xdist_group(name="issuer_test_group")
 async def issue_many_creds(
     faber_client: RichAsyncClient,
     alice_member_client: RichAsyncClient,

--- a/app/tests/e2e/verifier/test_predicate_proofs.py
+++ b/app/tests/e2e/verifier/test_predicate_proofs.py
@@ -15,7 +15,7 @@ VERIFIER_BASE_PATH = router.prefix
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("predicate", ["<", ">", "<=", ">="])
-@pytest.mark.xdist_group(name="issuer_test_group")
+@pytest.mark.xdist_group(name="issuer_test_group_3")
 async def test_predicate_proofs(
     acme_client: RichAsyncClient,
     acme_and_alice_connection: AcmeAliceConnect,

--- a/app/tests/e2e/verifier/test_predicate_proofs.py
+++ b/app/tests/e2e/verifier/test_predicate_proofs.py
@@ -15,6 +15,7 @@ VERIFIER_BASE_PATH = router.prefix
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("predicate", ["<", ">", "<=", ">="])
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_predicate_proofs(
     acme_client: RichAsyncClient,
     acme_and_alice_connection: AcmeAliceConnect,

--- a/app/tests/e2e/verifier/test_proof_revoked_credential.py
+++ b/app/tests/e2e/verifier/test_proof_revoked_credential.py
@@ -14,6 +14,10 @@ from app.tests.util.webhooks import assert_both_webhooks_received, check_webhook
 from shared import RichAsyncClient
 from shared.models.credential_exchange import CredentialExchange
 
+
+# Apply the marker to all tests in this module
+pytestmark = pytest.mark.xdist_group(name="issuer_test_group")
+
 CREDENTIALS_BASE_PATH = issuer_router.prefix
 VERIFIER_BASE_PATH = verifier_router.prefix
 
@@ -26,7 +30,6 @@ VERIFIER_BASE_PATH = verifier_router.prefix
     TestMode.regression_run in TestMode.fixture_params,
     reason="Proving revoked credentials is currently non-deterministic",
 )
-@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_proof_revoked_credential(
     revoke_alice_creds_and_publish: List[  # pylint: disable=unused-argument
         CredentialExchange
@@ -120,7 +123,6 @@ async def test_proof_revoked_credential(
     TestMode.clean_run in TestMode.fixture_params,
     reason="Run only in regression mode",
 )
-@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_regression_proof_revoked_credential(
     get_or_issue_regression_cred_revoked: ReferentCredDef,
     acme_client: RichAsyncClient,

--- a/app/tests/e2e/verifier/test_proof_revoked_credential.py
+++ b/app/tests/e2e/verifier/test_proof_revoked_credential.py
@@ -14,7 +14,6 @@ from app.tests.util.webhooks import assert_both_webhooks_received, check_webhook
 from shared import RichAsyncClient
 from shared.models.credential_exchange import CredentialExchange
 
-
 # Apply the marker to all tests in this module
 pytestmark = pytest.mark.xdist_group(name="issuer_test_group")
 

--- a/app/tests/e2e/verifier/test_proof_revoked_credential.py
+++ b/app/tests/e2e/verifier/test_proof_revoked_credential.py
@@ -26,6 +26,7 @@ VERIFIER_BASE_PATH = verifier_router.prefix
     TestMode.regression_run in TestMode.fixture_params,
     reason="Proving revoked credentials is currently non-deterministic",
 )
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_proof_revoked_credential(
     revoke_alice_creds_and_publish: List[  # pylint: disable=unused-argument
         CredentialExchange
@@ -119,6 +120,7 @@ async def test_proof_revoked_credential(
     TestMode.clean_run in TestMode.fixture_params,
     reason="Run only in regression mode",
 )
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_regression_proof_revoked_credential(
     get_or_issue_regression_cred_revoked: ReferentCredDef,
     acme_client: RichAsyncClient,

--- a/app/tests/e2e/verifier/test_proof_revoked_credential.py
+++ b/app/tests/e2e/verifier/test_proof_revoked_credential.py
@@ -15,7 +15,7 @@ from shared import RichAsyncClient
 from shared.models.credential_exchange import CredentialExchange
 
 # Apply the marker to all tests in this module
-pytestmark = pytest.mark.xdist_group(name="issuer_test_group_3")
+pytestmark = pytest.mark.xdist_group(name="issuer_test_group_4")
 
 CREDENTIALS_BASE_PATH = issuer_router.prefix
 VERIFIER_BASE_PATH = verifier_router.prefix

--- a/app/tests/e2e/verifier/test_proof_revoked_credential.py
+++ b/app/tests/e2e/verifier/test_proof_revoked_credential.py
@@ -15,7 +15,7 @@ from shared import RichAsyncClient
 from shared.models.credential_exchange import CredentialExchange
 
 # Apply the marker to all tests in this module
-pytestmark = pytest.mark.xdist_group(name="issuer_test_group")
+pytestmark = pytest.mark.xdist_group(name="issuer_test_group_3")
 
 CREDENTIALS_BASE_PATH = issuer_router.prefix
 VERIFIER_BASE_PATH = verifier_router.prefix

--- a/app/tests/e2e/verifier/test_proof_revoked_credential.py
+++ b/app/tests/e2e/verifier/test_proof_revoked_credential.py
@@ -14,9 +14,6 @@ from app.tests.util.webhooks import assert_both_webhooks_received, check_webhook
 from shared import RichAsyncClient
 from shared.models.credential_exchange import CredentialExchange
 
-# Apply the marker to all tests in this module
-pytestmark = pytest.mark.xdist_group(name="issuer_test_group_4")
-
 CREDENTIALS_BASE_PATH = issuer_router.prefix
 VERIFIER_BASE_PATH = verifier_router.prefix
 
@@ -29,6 +26,7 @@ VERIFIER_BASE_PATH = verifier_router.prefix
     TestMode.regression_run in TestMode.fixture_params,
     reason="Proving revoked credentials is currently non-deterministic",
 )
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_proof_revoked_credential(
     revoke_alice_creds_and_publish: List[  # pylint: disable=unused-argument
         CredentialExchange
@@ -122,6 +120,7 @@ async def test_proof_revoked_credential(
     TestMode.clean_run in TestMode.fixture_params,
     reason="Run only in regression mode",
 )
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_regression_proof_revoked_credential(
     get_or_issue_regression_cred_revoked: ReferentCredDef,
     acme_client: RichAsyncClient,

--- a/app/tests/e2e/verifier/test_self_attested.py
+++ b/app/tests/e2e/verifier/test_self_attested.py
@@ -13,7 +13,7 @@ VERIFIER_BASE_PATH = router.prefix
 
 
 @pytest.mark.anyio
-@pytest.mark.xdist_group(name="issuer_test_group")
+@pytest.mark.xdist_group(name="issuer_test_group_3")
 async def test_self_attested_attributes(
     acme_client: RichAsyncClient,
     acme_and_alice_connection: AcmeAliceConnect,

--- a/app/tests/e2e/verifier/test_self_attested.py
+++ b/app/tests/e2e/verifier/test_self_attested.py
@@ -13,6 +13,7 @@ VERIFIER_BASE_PATH = router.prefix
 
 
 @pytest.mark.anyio
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_self_attested_attributes(
     acme_client: RichAsyncClient,
     acme_and_alice_connection: AcmeAliceConnect,

--- a/app/tests/e2e/verifier/test_self_attested.py
+++ b/app/tests/e2e/verifier/test_self_attested.py
@@ -13,7 +13,7 @@ VERIFIER_BASE_PATH = router.prefix
 
 
 @pytest.mark.anyio
-@pytest.mark.xdist_group(name="issuer_test_group_3")
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_self_attested_attributes(
     acme_client: RichAsyncClient,
     acme_and_alice_connection: AcmeAliceConnect,

--- a/app/tests/e2e/verifier/test_verifier.py
+++ b/app/tests/e2e/verifier/test_verifier.py
@@ -226,7 +226,7 @@ async def test_reject_proof_request(
 
 
 @pytest.mark.anyio
-@pytest.mark.xdist_group(name="issuer_test_group_3")
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_get_proof_and_get_proofs(
     acme_and_alice_connection: AcmeAliceConnect,
     issue_credential_to_alice: CredentialExchange,  # pylint: disable=unused-argument
@@ -468,7 +468,7 @@ async def test_get_credentials_for_request(
 @pytest.mark.parametrize(
     "meld_co_and_alice_connection", ["trust_registry", "default"], indirect=True
 )
-@pytest.mark.xdist_group(name="issuer_test_group_4")
+@pytest.mark.xdist_group(name="issuer_test_group_3")
 async def test_accept_proof_request_verifier_has_issuer_role(
     meld_co_issue_credential_to_alice: CredentialExchange,  # pylint: disable=unused-argument
     meld_co_credential_definition_id: str,
@@ -543,7 +543,7 @@ async def test_accept_proof_request_verifier_has_issuer_role(
 @pytest.mark.anyio
 @pytest.mark.parametrize("acme_save_exchange_record", [None, False, True])
 @pytest.mark.parametrize("alice_save_exchange_record", [None, False, True])
-@pytest.mark.xdist_group(name="issuer_test_group_3")
+@pytest.mark.xdist_group(name="issuer_test_group_4")
 async def test_saving_of_presentation_exchange_records(
     issue_credential_to_alice: CredentialExchange,  # pylint: disable=unused-argument
     credential_definition_id: str,

--- a/app/tests/e2e/verifier/test_verifier.py
+++ b/app/tests/e2e/verifier/test_verifier.py
@@ -68,6 +68,7 @@ async def test_send_proof_request(
 
 
 @pytest.mark.anyio
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_accept_proof_request(
     issue_credential_to_alice: CredentialExchange,  # pylint: disable=unused-argument
     alice_member_client: RichAsyncClient,
@@ -225,6 +226,7 @@ async def test_reject_proof_request(
 
 
 @pytest.mark.anyio
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_get_proof_and_get_proofs(
     acme_and_alice_connection: AcmeAliceConnect,
     issue_credential_to_alice: CredentialExchange,  # pylint: disable=unused-argument
@@ -409,6 +411,7 @@ async def test_delete_proof(
 
 
 @pytest.mark.anyio
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_get_credentials_for_request(
     issue_credential_to_alice: CredentialExchange,  # pylint: disable=unused-argument
     acme_and_alice_connection: AcmeAliceConnect,
@@ -465,6 +468,7 @@ async def test_get_credentials_for_request(
 @pytest.mark.parametrize(
     "meld_co_and_alice_connection", ["trust_registry", "default"], indirect=True
 )
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_accept_proof_request_verifier_has_issuer_role(
     meld_co_issue_credential_to_alice: CredentialExchange,  # pylint: disable=unused-argument
     meld_co_credential_definition_id: str,
@@ -539,6 +543,7 @@ async def test_accept_proof_request_verifier_has_issuer_role(
 @pytest.mark.anyio
 @pytest.mark.parametrize("acme_save_exchange_record", [None, False, True])
 @pytest.mark.parametrize("alice_save_exchange_record", [None, False, True])
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_saving_of_presentation_exchange_records(
     issue_credential_to_alice: CredentialExchange,  # pylint: disable=unused-argument
     credential_definition_id: str,
@@ -645,6 +650,7 @@ async def test_saving_of_presentation_exchange_records(
     TestMode.clean_run in TestMode.fixture_params,
     reason="Run only in regression mode",
 )
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_regression_proof_valid_credential(
     get_or_issue_regression_cred_valid: ReferentCredDef,
     acme_client: RichAsyncClient,

--- a/app/tests/e2e/verifier/test_verifier.py
+++ b/app/tests/e2e/verifier/test_verifier.py
@@ -468,7 +468,7 @@ async def test_get_credentials_for_request(
 @pytest.mark.parametrize(
     "meld_co_and_alice_connection", ["trust_registry", "default"], indirect=True
 )
-@pytest.mark.xdist_group(name="issuer_test_group_3")
+@pytest.mark.xdist_group(name="issuer_test_group_4")
 async def test_accept_proof_request_verifier_has_issuer_role(
     meld_co_issue_credential_to_alice: CredentialExchange,  # pylint: disable=unused-argument
     meld_co_credential_definition_id: str,

--- a/app/tests/e2e/verifier/test_verifier.py
+++ b/app/tests/e2e/verifier/test_verifier.py
@@ -68,7 +68,7 @@ async def test_send_proof_request(
 
 
 @pytest.mark.anyio
-@pytest.mark.xdist_group(name="issuer_test_group")
+@pytest.mark.xdist_group(name="issuer_test_group_3")
 async def test_accept_proof_request(
     issue_credential_to_alice: CredentialExchange,  # pylint: disable=unused-argument
     alice_member_client: RichAsyncClient,
@@ -226,7 +226,7 @@ async def test_reject_proof_request(
 
 
 @pytest.mark.anyio
-@pytest.mark.xdist_group(name="issuer_test_group")
+@pytest.mark.xdist_group(name="issuer_test_group_3")
 async def test_get_proof_and_get_proofs(
     acme_and_alice_connection: AcmeAliceConnect,
     issue_credential_to_alice: CredentialExchange,  # pylint: disable=unused-argument
@@ -411,7 +411,7 @@ async def test_delete_proof(
 
 
 @pytest.mark.anyio
-@pytest.mark.xdist_group(name="issuer_test_group")
+@pytest.mark.xdist_group(name="issuer_test_group_3")
 async def test_get_credentials_for_request(
     issue_credential_to_alice: CredentialExchange,  # pylint: disable=unused-argument
     acme_and_alice_connection: AcmeAliceConnect,
@@ -468,7 +468,7 @@ async def test_get_credentials_for_request(
 @pytest.mark.parametrize(
     "meld_co_and_alice_connection", ["trust_registry", "default"], indirect=True
 )
-@pytest.mark.xdist_group(name="issuer_test_group")
+@pytest.mark.xdist_group(name="issuer_test_group_3")
 async def test_accept_proof_request_verifier_has_issuer_role(
     meld_co_issue_credential_to_alice: CredentialExchange,  # pylint: disable=unused-argument
     meld_co_credential_definition_id: str,
@@ -543,7 +543,7 @@ async def test_accept_proof_request_verifier_has_issuer_role(
 @pytest.mark.anyio
 @pytest.mark.parametrize("acme_save_exchange_record", [None, False, True])
 @pytest.mark.parametrize("alice_save_exchange_record", [None, False, True])
-@pytest.mark.xdist_group(name="issuer_test_group")
+@pytest.mark.xdist_group(name="issuer_test_group_3")
 async def test_saving_of_presentation_exchange_records(
     issue_credential_to_alice: CredentialExchange,  # pylint: disable=unused-argument
     credential_definition_id: str,
@@ -650,7 +650,7 @@ async def test_saving_of_presentation_exchange_records(
     TestMode.clean_run in TestMode.fixture_params,
     reason="Run only in regression mode",
 )
-@pytest.mark.xdist_group(name="issuer_test_group")
+@pytest.mark.xdist_group(name="issuer_test_group_3")
 async def test_regression_proof_valid_credential(
     get_or_issue_regression_cred_valid: ReferentCredDef,
     acme_client: RichAsyncClient,

--- a/app/tests/e2e/verifier/test_verifier_oob.py
+++ b/app/tests/e2e/verifier/test_verifier_oob.py
@@ -25,6 +25,7 @@ CONNECTIONS_BASE_PATH = connections_router.prefix
 
 
 @pytest.mark.anyio
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_accept_proof_request_oob(
     issue_credential_to_alice: CredentialExchange,  # pylint: disable=unused-argument
     alice_member_client: RichAsyncClient,
@@ -123,6 +124,7 @@ async def test_accept_proof_request_oob(
     TestMode.regression_run in TestMode.fixture_params,
     reason="Verifier trust registry OOB connection already tested in test_verifier",
 )
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_accept_proof_request_verifier_oob_connection(
     credential_definition_id: str,
     issue_credential_to_alice: CredentialExchange,  # pylint: disable=unused-argument

--- a/app/tests/e2e/verifier/test_verifier_oob.py
+++ b/app/tests/e2e/verifier/test_verifier_oob.py
@@ -19,13 +19,16 @@ from app.util.string import base64_to_json
 from shared import RichAsyncClient
 from shared.models.credential_exchange import CredentialExchange
 
+
+# Apply the marker to all tests in this module
+pytestmark = pytest.mark.xdist_group(name="issuer_test_group")
+
 OOB_BASE_PATH = oob_router.prefix
 VERIFIER_BASE_PATH = verifier_router.prefix
 CONNECTIONS_BASE_PATH = connections_router.prefix
 
 
 @pytest.mark.anyio
-@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_accept_proof_request_oob(
     issue_credential_to_alice: CredentialExchange,  # pylint: disable=unused-argument
     alice_member_client: RichAsyncClient,
@@ -124,7 +127,6 @@ async def test_accept_proof_request_oob(
     TestMode.regression_run in TestMode.fixture_params,
     reason="Verifier trust registry OOB connection already tested in test_verifier",
 )
-@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_accept_proof_request_verifier_oob_connection(
     credential_definition_id: str,
     issue_credential_to_alice: CredentialExchange,  # pylint: disable=unused-argument

--- a/app/tests/e2e/verifier/test_verifier_oob.py
+++ b/app/tests/e2e/verifier/test_verifier_oob.py
@@ -20,7 +20,7 @@ from shared import RichAsyncClient
 from shared.models.credential_exchange import CredentialExchange
 
 # Apply the marker to all tests in this module
-pytestmark = pytest.mark.xdist_group(name="issuer_test_group")
+pytestmark = pytest.mark.xdist_group(name="issuer_test_group_3")
 
 OOB_BASE_PATH = oob_router.prefix
 VERIFIER_BASE_PATH = verifier_router.prefix

--- a/app/tests/e2e/verifier/test_verifier_oob.py
+++ b/app/tests/e2e/verifier/test_verifier_oob.py
@@ -19,7 +19,6 @@ from app.util.string import base64_to_json
 from shared import RichAsyncClient
 from shared.models.credential_exchange import CredentialExchange
 
-
 # Apply the marker to all tests in this module
 pytestmark = pytest.mark.xdist_group(name="issuer_test_group")
 

--- a/trustregistry/tests/e2e/test_actor.py
+++ b/trustregistry/tests/e2e/test_actor.py
@@ -145,22 +145,23 @@ async def test_get_actor():
 
 @pytest.mark.anyio
 async def test_update_actor():
+    test_actor = generate_actor()
     async with RichAsyncClient(raise_status_error=False) as client:
         response = await client.put(
-            f"{TRUST_REGISTRY_URL}/registry/actors/{actor_id}",
-            json=new_actor,
+            f"{TRUST_REGISTRY_URL}/registry/actors/{test_actor['id']}",
+            json=test_actor,
         )
         assert response.status_code == 200
-        assert response.json() == new_actor
+        assert response.json() == test_actor
 
         new_actors_response = await client.get(f"{TRUST_REGISTRY_URL}/registry/actors")
         assert new_actors_response.status_code == 200
         new_actors_list = new_actors_response.json()
-        assert new_actor in new_actors_list
+        assert test_actor in new_actors_list
 
         response = await client.put(
             f"{TRUST_REGISTRY_URL}/registry/actors/bad",
-            json=new_actor,
+            json=test_actor,
         )
         assert response.status_code == 400
 

--- a/trustregistry/tests/e2e/test_actor.py
+++ b/trustregistry/tests/e2e/test_actor.py
@@ -6,6 +6,9 @@ from app.util.string import random_string
 from shared import TRUST_REGISTRY_URL
 from shared.util.rich_async_client import RichAsyncClient
 
+# Apply the marker to all tests in this module. Tests must run sequentially in same xdist group.
+pytestmark = pytest.mark.xdist_group(name="trust_registry_test_group")
+
 new_actor = {
     "id": "darth-vader",
     "name": "Darth Vader",
@@ -145,23 +148,22 @@ async def test_get_actor():
 
 @pytest.mark.anyio
 async def test_update_actor():
-    test_actor = generate_actor()
     async with RichAsyncClient(raise_status_error=False) as client:
         response = await client.put(
-            f"{TRUST_REGISTRY_URL}/registry/actors/{test_actor['id']}",
-            json=test_actor,
+            f"{TRUST_REGISTRY_URL}/registry/actors/{actor_id}",
+            json=new_actor,
         )
         assert response.status_code == 200
-        assert response.json() == test_actor
+        assert response.json() == new_actor
 
         new_actors_response = await client.get(f"{TRUST_REGISTRY_URL}/registry/actors")
         assert new_actors_response.status_code == 200
         new_actors_list = new_actors_response.json()
-        assert test_actor in new_actors_list
+        assert new_actor in new_actors_list
 
         response = await client.put(
             f"{TRUST_REGISTRY_URL}/registry/actors/bad",
-            json=test_actor,
+            json=new_actor,
         )
         assert response.status_code == 400
 

--- a/trustregistry/tests/e2e/test_schema.py
+++ b/trustregistry/tests/e2e/test_schema.py
@@ -4,8 +4,8 @@ from shared import TRUST_REGISTRY_URL
 from shared.util.rich_async_client import RichAsyncClient
 from trustregistry.registry.registry_schemas import SchemaID, _get_schema_attrs
 
-# Apply the marker to all tests in this module
-pytestmark = pytest.mark.xdist_group(name="schema_test_group")
+# Apply the marker to all tests in this module. Tests must run sequentially in same xdist group.
+pytestmark = pytest.mark.xdist_group(name="trust_registry_test_group")
 
 schema_id = "string:2:string:string"
 updated_schema_id = "string_updated:2:string_updated:string_updated"

--- a/trustregistry/tests/e2e/test_schema.py
+++ b/trustregistry/tests/e2e/test_schema.py
@@ -4,6 +4,9 @@ from shared import TRUST_REGISTRY_URL
 from shared.util.rich_async_client import RichAsyncClient
 from trustregistry.registry.registry_schemas import SchemaID, _get_schema_attrs
 
+# Apply the marker to all tests in this module
+pytestmark = pytest.mark.xdist_group(name="schema_test_group")
+
 schema_id = "string:2:string:string"
 updated_schema_id = "string_updated:2:string_updated:string_updated"
 


### PR DESCRIPTION
We currently run with `--dist loadfile`, which groups tests by file / module. This means "session" scoped fixtures become module-scoped, which we don't want. Therefore, switch to `--dist loadgroup` (in charts repo) and configure same group for session fixtures

See: https://pytest-xdist.readthedocs.io/en/stable/distribution.html

___
Edit: damn, marks applied to fixtures have no effect. So each test using faber / other session scoped fixtures needs to be marked individually ...

:zap: Looked at test durations to spread tests out across xdist group in a logical way to shorten test runs with fewer xdist workers
(the grouping might seem a bit random, but it was based somewhat on pytest --durations result)

:art: Includes some deduplication, which codacy reported after some files were edited

:loud_sound: Include issuer wallet label in log contexts