### PR TITLE
:technologist: Add some Init Containers

### DIFF
--- a/helm/acapy-cloud.yaml.gotmpl
+++ b/helm/acapy-cloud.yaml.gotmpl
@@ -127,6 +127,7 @@ releases:
         podLabels:
           admission.datadoghq.com/enabled: "false"
           tags.datadoghq.com/env: {{ .Environment.Name }}
+          sidecar.istio.io/inject: "false"
       - nodeSelector: {{ toYaml .Values.nodeSelector | nindent 10 }}
         tolerations: {{ toYaml .Values.tolerations | nindent 10 }}
     set:

--- a/helm/acapy-cloud/conf/dev/governance-agent.yaml
+++ b/helm/acapy-cloud/conf/dev/governance-agent.yaml
@@ -137,6 +137,20 @@ initContainers:
         value: "{{ .Values.env.NATS_SERVER }}"
       - name: NATS_STREAM
         value: "{{ .Values.env.NATS_STREAM }}"
+  - name: nc-postgres
+    image: busybox
+    command: ['sh', '-c', 'until nc -z $(PG_HOST) $(PG_PORT); do echo waiting for postgres; sleep 2; done;']
+    env:
+      - name: PG_HOST
+        valueFrom:
+          secretKeyRef:
+            name: '{{ include "acapy-cloud.fullname" . }}-env'
+            key: WALLET_DB_HOST
+      - name: PG_PORT
+        valueFrom:
+          secretKeyRef:
+            name: '{{ include "acapy-cloud.fullname" . }}-env'
+            key: WALLET_DB_PORT
 
 persistence:
   enabled: false

--- a/helm/acapy-cloud/conf/dev/mediator.yaml
+++ b/helm/acapy-cloud/conf/dev/mediator.yaml
@@ -106,6 +106,20 @@ readinessProbe:
 #     memory: 384Mi
 
 initContainers:
+  - name: nc-postgres
+    image: busybox
+    command: ['sh', '-c', 'until nc -z $(PG_HOST) $(PG_PORT); do echo waiting for postgres; sleep 2; done;']
+    env:
+      - name: PG_HOST
+        valueFrom:
+          secretKeyRef:
+            name: '{{ include "acapy-cloud.fullname" . }}-env'
+            key: WALLET_DB_HOST
+      - name: PG_PORT
+        valueFrom:
+          secretKeyRef:
+            name: '{{ include "acapy-cloud.fullname" . }}-env'
+            key: WALLET_DB_PORT
   - name: wait-governance-agent
     image: curlimages/curl
     command:

--- a/helm/acapy-cloud/conf/dev/multitenant-agent.yaml
+++ b/helm/acapy-cloud/conf/dev/multitenant-agent.yaml
@@ -118,6 +118,20 @@ initContainers:
         value: "{{ .Values.env.NATS_SERVER }}"
       - name: NATS_STREAM
         value: "{{ .Values.env.NATS_STREAM }}"
+  - name: nc-postgres
+    image: busybox
+    command: ['sh', '-c', 'until nc -z $(PG_HOST) $(PG_PORT); do echo waiting for postgres; sleep 2; done;']
+    env:
+      - name: PG_HOST
+        valueFrom:
+          secretKeyRef:
+            name: '{{ include "acapy-cloud.fullname" . }}-env'
+            key: WALLET_DB_HOST
+      - name: PG_PORT
+        valueFrom:
+          secretKeyRef:
+            name: '{{ include "acapy-cloud.fullname" . }}-env'
+            key: WALLET_DB_PORT
 
 persistence:
   enabled: true

--- a/helm/acapy-cloud/conf/dev/trust-registry.yaml
+++ b/helm/acapy-cloud/conf/dev/trust-registry.yaml
@@ -70,8 +70,13 @@ readinessProbe:
 autoscaling:
   enabled: false
 
+initContainers:
+  - name: nc-postgres
+    image: busybox
+    command: ['sh', '-c', 'until nc -z cloudapi-pgpool 5432; do echo waiting for pgproxy; sleep 2; done;']
+
 secretData:
-  POSTGRES_DATABASE_URL: postgresql://trust-registry:trust-registry@cloudapi-postgresql:5432/trust-registry?sslmode=prefer
+  POSTGRES_DATABASE_URL: postgresql://trust-registry:trust-registry@cloudapi-pgpool:5432/trust-registry?sslmode=prefer
 
 env:
   LOG_LEVEL: warning

--- a/helm/acapy-cloud/conf/local/governance-agent.yaml
+++ b/helm/acapy-cloud/conf/local/governance-agent.yaml
@@ -137,6 +137,20 @@ initContainers:
         value: "{{ .Values.env.NATS_SERVER }}"
       - name: NATS_STREAM
         value: "{{ .Values.env.NATS_STREAM }}"
+  - name: nc-postgres
+    image: busybox
+    command: ['sh', '-c', 'until nc -z $(PG_HOST) $(PG_PORT); do echo waiting for postgres; sleep 2; done;']
+    env:
+      - name: PG_HOST
+        valueFrom:
+          secretKeyRef:
+            name: '{{ include "acapy-cloud.fullname" . }}-env'
+            key: WALLET_DB_HOST
+      - name: PG_PORT
+        valueFrom:
+          secretKeyRef:
+            name: '{{ include "acapy-cloud.fullname" . }}-env'
+            key: WALLET_DB_PORT
 
 persistence:
   enabled: false

--- a/helm/acapy-cloud/conf/local/mediator.yaml
+++ b/helm/acapy-cloud/conf/local/mediator.yaml
@@ -106,6 +106,20 @@ readinessProbe:
 #     memory: 384Mi
 
 initContainers:
+  - name: nc-postgres
+    image: busybox
+    command: ['sh', '-c', 'until nc -z $(PG_HOST) $(PG_PORT); do echo waiting for postgres; sleep 2; done;']
+    env:
+      - name: PG_HOST
+        valueFrom:
+          secretKeyRef:
+            name: '{{ include "acapy-cloud.fullname" . }}-env'
+            key: WALLET_DB_HOST
+      - name: PG_PORT
+        valueFrom:
+          secretKeyRef:
+            name: '{{ include "acapy-cloud.fullname" . }}-env'
+            key: WALLET_DB_PORT
   - name: wait-governance-agent
     image: curlimages/curl
     command:

--- a/helm/acapy-cloud/conf/local/multitenant-agent.yaml
+++ b/helm/acapy-cloud/conf/local/multitenant-agent.yaml
@@ -119,6 +119,20 @@ initContainers:
         value: "{{ .Values.env.NATS_SERVER }}"
       - name: NATS_STREAM
         value: "{{ .Values.env.NATS_STREAM }}"
+  - name: nc-postgres
+    image: busybox
+    command: ['sh', '-c', 'until nc -z $(PG_HOST) $(PG_PORT); do echo waiting for postgres; sleep 2; done;']
+    env:
+      - name: PG_HOST
+        valueFrom:
+          secretKeyRef:
+            name: '{{ include "acapy-cloud.fullname" . }}-env'
+            key: WALLET_DB_HOST
+      - name: PG_PORT
+        valueFrom:
+          secretKeyRef:
+            name: '{{ include "acapy-cloud.fullname" . }}-env'
+            key: WALLET_DB_PORT
 
 persistence:
   enabled: true

--- a/helm/acapy-cloud/conf/local/trust-registry.yaml
+++ b/helm/acapy-cloud/conf/local/trust-registry.yaml
@@ -70,8 +70,13 @@ readinessProbe:
 autoscaling:
   enabled: false
 
+initContainers:
+  - name: nc-postgres
+    image: busybox
+    command: ['sh', '-c', 'until nc -z cloudapi-pgpool 5432; do echo waiting for pgproxy; sleep 2; done;']
+
 secretData:
-  POSTGRES_DATABASE_URL: postgresql://trust-registry:trust-registry@cloudapi-postgresql:5432/trust-registry?sslmode=prefer
+  POSTGRES_DATABASE_URL: postgresql://trust-registry:trust-registry@cloudapi-pgpool:5432/trust-registry?sslmode=prefer
 
 env:
   LOG_LEVEL: warning

--- a/helm/acapy-cloud/values.yaml
+++ b/helm/acapy-cloud/values.yaml
@@ -62,7 +62,7 @@ podLabels:
   admission.datadoghq.com/enabled: "false" # disabled by default (for now)
 podAnnotations:
   # gcr.io/datadoghq/dd-lib-python-init
-  admission.datadoghq.com/python-lib.version: v2.20.0
+  admission.datadoghq.com/python-lib.version: v2.20.1
   ad.datadoghq.com/istio-proxy.logs: '[{ "source": "envoy", "service": "{{ include "acapy-cloud.fullname" . }}" }]'
   ad.datadoghq.com/istio-init.logs: '[{ "source": "envoy", "service": "{{ include "acapy-cloud.fullname" . }}" }]'
 

--- a/tilt/acapy-cloud/Tiltfile
+++ b/tilt/acapy-cloud/Tiltfile
@@ -125,7 +125,6 @@ def setup_nats(namespace):
         resource_deps=[
             "cloudapi-ns",
             "build-nats",
-            "istio",
         ],
         port_forwards=[
             port_forward(8222, name="monitoring"),


### PR DESCRIPTION
* Add some Init Containers to make sure Postgres is up
  * Governance/Multitenant Agent
  * Mediator
  * Trust Registry
  * Reduces pod restarts due to PG not being up
* Trust Registry doesn't have the Askar bug when using PGPool
  * That bug where if the DB doesn't exist it can't connect to a connection pooler
    * https://github.com/openwallet-foundation/askar/issues/299
  * Trust Registry doesn't create it's own DB, so it can always use PGPool
* NATS does not depend on Istio
  * Could _very slightly_ speed up local startup