### PR TITLE
:technologist: Expand Tilt ignore patterns

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,10 +6,9 @@
 !app/
 !shared/
 !endorser/
+!scripts/
 !trustregistry/
 !waypoint/
-!scripts/
-!configuration/
 !LICENSE
 
 **/__pycache__/

--- a/helm/acapy-cloud/conf/dev/endorser.yaml
+++ b/helm/acapy-cloud/conf/dev/endorser.yaml
@@ -39,7 +39,8 @@ command:
   - uvicorn
   - endorser.main:app
   - --log-config=/tmp/log_conf.yaml
-  - --reload
+  - --workers
+  - 1
   - --host
   - 0.0.0.0
   - --port

--- a/helm/acapy-cloud/conf/dev/governance-web.yaml
+++ b/helm/acapy-cloud/conf/dev/governance-web.yaml
@@ -17,7 +17,8 @@ command:
   - uvicorn
   - app.main:app
   - --log-config=/tmp/log_conf.yaml
-  - --reload
+  - --workers
+  - 1
   - --host
   - 0.0.0.0
   - --port

--- a/helm/acapy-cloud/conf/dev/multitenant-web.yaml
+++ b/helm/acapy-cloud/conf/dev/multitenant-web.yaml
@@ -17,7 +17,8 @@ command:
   - uvicorn
   - app.main:app
   - --log-config=/tmp/log_conf.yaml
-  - --reload
+  - --workers
+  - 1
   - --host
   - 0.0.0.0
   - --port

--- a/helm/acapy-cloud/conf/dev/public-web.yaml
+++ b/helm/acapy-cloud/conf/dev/public-web.yaml
@@ -17,7 +17,8 @@ command:
   - uvicorn
   - app.main:app
   - --log-config=/tmp/log_conf.yaml
-  - --reload
+  - --workers
+  - 1
   - --host
   - 0.0.0.0
   - --port

--- a/helm/acapy-cloud/conf/dev/tenant-web.yaml
+++ b/helm/acapy-cloud/conf/dev/tenant-web.yaml
@@ -17,7 +17,8 @@ command:
   - uvicorn
   - app.main:app
   - --log-config=/tmp/log_conf.yaml
-  - --reload
+  - --workers
+  - 1
   - --host
   - 0.0.0.0
   - --port

--- a/helm/acapy-cloud/conf/dev/trust-registry.yaml
+++ b/helm/acapy-cloud/conf/dev/trust-registry.yaml
@@ -19,7 +19,8 @@ command:
   - uvicorn
   - trustregistry.main:app
   - --log-config=/tmp/log_conf.yaml
-  - --reload
+  - --workers
+  - 1
   - --host
   - 0.0.0.0
   - --port

--- a/helm/acapy-cloud/conf/dev/waypoint.yaml
+++ b/helm/acapy-cloud/conf/dev/waypoint.yaml
@@ -22,7 +22,8 @@ command:
   - uvicorn
   - waypoint.main:app
   - --log-config=/tmp/log_conf.yaml
-  - --reload
+  - --workers
+  - 1
   - --host
   - 0.0.0.0
   - --port

--- a/tilt/acapy-cloud/Tiltfile
+++ b/tilt/acapy-cloud/Tiltfile
@@ -240,7 +240,7 @@ def build_cloudapi_service(service, image={}):
         deps=["./"],
         live_update=image.get("live_update", []),
         skips_local_docker=True,
-        ignore=["**/__pycache__/**", "**/tests/**"],
+        ignore=["**/tests/**"] + image.get("ignore", []),
     )
     return [registry + "/" + service]
 
@@ -422,6 +422,12 @@ def setup_cloudapi(build_enabled, expose):
                     ],
                     enabled=build_enabled,
                 ),
+                "ignore": [
+                    "app/**",
+                    "scripts/**",
+                    "trustregistry/**",
+                    "waypoint/**",
+                ],
             },
         },
         "governance-agent": {
@@ -434,6 +440,13 @@ def setup_cloudapi(build_enabled, expose):
             ],
             "image": {
                 "dockerfile": "./dockerfiles/agents/Dockerfile.agent",
+                "ignore": [
+                    "app/**",
+                    "endorser/**",
+                    "shared/**",
+                    "trustregistry/**",
+                    "waypoint/**",
+                ],
             },
         },
         "governance-web": {
@@ -457,6 +470,12 @@ def setup_cloudapi(build_enabled, expose):
                     ],
                     enabled=build_enabled,
                 ),
+                "ignore": [
+                    "endorser/**",
+                    "scripts/**",
+                    "trustregistry/**",
+                    "waypoint/**",
+                ],
             },
         },
         "multitenant-agent": {
@@ -469,6 +488,13 @@ def setup_cloudapi(build_enabled, expose):
             ],
             "image": {
                 "dockerfile": "./dockerfiles/agents/Dockerfile.author.agent",
+                "ignore": [
+                    "app/**",
+                    "endorser/**",
+                    "shared/**",
+                    "trustregistry/**",
+                    "waypoint/**",
+                ],
             },
         },
         "multitenant-web": {
@@ -492,6 +518,12 @@ def setup_cloudapi(build_enabled, expose):
                     ],
                     enabled=build_enabled,
                 ),
+                "ignore": [
+                    "endorser/**",
+                    "scripts/**",
+                    "trustregistry/**",
+                    "waypoint/**",
+                ],
             },
         },
         "tenant-web": {
@@ -511,6 +543,12 @@ def setup_cloudapi(build_enabled, expose):
                     ],
                     enabled=build_enabled,
                 ),
+                "ignore": [
+                    "endorser/**",
+                    "scripts/**",
+                    "trustregistry/**",
+                    "waypoint/**",
+                ],
             },
         },
         "public-web": {
@@ -530,6 +568,12 @@ def setup_cloudapi(build_enabled, expose):
                     ],
                     enabled=build_enabled,
                 ),
+                "ignore": [
+                    "endorser/**",
+                    "scripts/**",
+                    "trustregistry/**",
+                    "waypoint/**",
+                ],
             },
         },
         "trust-registry": {
@@ -552,6 +596,12 @@ def setup_cloudapi(build_enabled, expose):
                     ],
                     enabled=build_enabled,
                 ),
+                "ignore": [
+                    "app/**",
+                    "endorser/**",
+                    "scripts/**",
+                    "waypoint/**",
+                ],
             },
         },
         "waypoint": {
@@ -568,6 +618,12 @@ def setup_cloudapi(build_enabled, expose):
                     ],
                     enabled=build_enabled,
                 ),
+                "ignore": [
+                    "app/**",
+                    "endorser/**",
+                    "scripts/**",
+                    "trustregistry/**",
+                ],
             },
         },
         "ledger-browser": {

--- a/tilt/acapy-cloud/Tiltfile
+++ b/tilt/acapy-cloud/Tiltfile
@@ -240,6 +240,7 @@ def build_cloudapi_service(service, image={}):
         deps=["./"],
         live_update=image.get("live_update", []),
         skips_local_docker=True,
+        ignore=["**/__pycache__/**", "**/tests/**"],
     )
     return [registry + "/" + service]
 


### PR DESCRIPTION
* Ignore `tests` in Tilt docker builds
* Resolves very annoying issue where modifying tests causes almost
everything to restart
* Also expand the ignore patterns
  * Updating code should only update the affected resource
    * e.g: Modifying `endorser/main.py` should not cause `tenant-web` to roll