### PR TITLE
🔨  align local dev pgpool & db max connections

### DIFF
--- a/tilt/acapy-cloud/postgres.yaml
+++ b/tilt/acapy-cloud/postgres.yaml
@@ -27,6 +27,7 @@ postgresql:
       EOSQL
   # https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15
   resourcesPreset: none
+  maxConnections: 1010
 persistentVolumeClaimRetentionPolicy:
   enabled: true
   whenDeleted: Delete
@@ -40,7 +41,8 @@ pgpool:
     passwords: trust-registry;governance;multitenant;mediator
   adminUsername: admin
   adminPassword: admin
-  maxPool: 1000
+  numInitChildren: 100
+  maxPool: 10
   # https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15
   resourcesPreset: none
   tls:


### PR DESCRIPTION
The config was misaligned between postgres and pgpool leading to the following error:
```
2025-02-12 09:39:36.084 GMT [1171] FATAL: remaining connection slots are reserved for roles with the SUPERUSER attribute
``` 

This config aligns for supporting 1000 client connections on postgres with a buffer of 10 reserved for SUPERUSER