### PR TITLE
:white_check_mark: Add xdist group to run tests sequentially

### DIFF
--- a/app/tests/e2e/test_wallet_dids.py
+++ b/app/tests/e2e/test_wallet_dids.py
@@ -18,6 +18,9 @@ from app.tests.util.ledger import create_public_did, post_to_ledger
 from app.tests.util.regression_testing import TestMode
 from shared import RichAsyncClient
 
+# Tests can conflict if they run in parallel, e.g. test_set_did_endpoint during test_list_dids changes expected response
+pytestmark = pytest.mark.xdist_group(name="sequential_test_group")
+
 WALLET_BASE_PATH = router.prefix
 
 # The setting public did test should be skipped in prod.

--- a/trustregistry/tests/e2e/test_actor.py
+++ b/trustregistry/tests/e2e/test_actor.py
@@ -7,7 +7,7 @@ from shared import TRUST_REGISTRY_URL
 from shared.util.rich_async_client import RichAsyncClient
 
 # Apply the marker to all tests in this module. Tests must run sequentially in same xdist group.
-pytestmark = pytest.mark.xdist_group(name="trust_registry_test_group")
+pytestmark = pytest.mark.xdist_group(name="sequential_test_group")
 
 new_actor = {
     "id": "darth-vader",

--- a/trustregistry/tests/e2e/test_schema.py
+++ b/trustregistry/tests/e2e/test_schema.py
@@ -5,7 +5,7 @@ from shared.util.rich_async_client import RichAsyncClient
 from trustregistry.registry.registry_schemas import SchemaID, _get_schema_attrs
 
 # Apply the marker to all tests in this module. Tests must run sequentially in same xdist group.
-pytestmark = pytest.mark.xdist_group(name="trust_registry_test_group")
+pytestmark = pytest.mark.xdist_group(name="sequential_test_group")
 
 schema_id = "string:2:string:string"
 updated_schema_id = "string_updated:2:string_updated:string_updated"


### PR DESCRIPTION
Wallet DID tests can conflict if they run in parallel, e.g. `test_set_did_endpoint` during `test_list_dids` changes the expected response