### PR TITLE
:construction_worker: Notify didx-cloud

### DIFF
--- a/.github/actions/test-eks/action.yml
+++ b/.github/actions/test-eks/action.yml
@@ -204,7 +204,7 @@ runs:
 
         # Clean up: delete the temporary pod
         echo "Cleaning up..."
-        kubectl -n $NAMESPACE delete pod $POD_NAME
+        kubectl -n $NAMESPACE delete pod $POD_NAME --force
 
         echo "Done!"
       env:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -529,7 +529,7 @@ jobs:
               const result = await github.rest.actions.createWorkflowDispatch({
                 owner: process.env.REPO_OWNER,
                 repo: process.env.REPO_NAME,
-                workflow_id: 'cd.yml',
+                workflow_id: 'notify.yml',
                 ref: 'master',
                 inputs: {
                   'helm-version': process.env.HELM_VERSION,


### PR DESCRIPTION
* Don't trigger CD directly
* Rather notify
* Notify will then handle triggering CD
* Also forcefully delete the pod that fetches the EKS test results
  * Speed things up a bit