### PR TITLE
:bug: Add `credential_id` on matching proofs

### DIFF
--- a/app/models/verifier.py
+++ b/app/models/verifier.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Optional, Union
 
-from aries_cloudcontroller import DIFPresSpec, DIFProofRequest, IndyPresSpec
+from aries_cloudcontroller import DIFPresSpec, DIFProofRequest, IndyPresSpec, IndyNonRevocationInterval
 from aries_cloudcontroller import IndyProofRequest as AcaPyIndyProofRequest
 from pydantic import BaseModel, Field, ValidationInfo, field_validator, model_validator
 
@@ -120,3 +120,33 @@ class RejectProofRequest(ProofId):
         if value == "":
             raise CloudApiValueError("problem_report cannot be an empty string")
         return value
+
+
+class CredInfo(BaseModel):
+    attrs: dict = Field(
+        default=None, description="Attribute names and value"
+    )
+    cred_def_id: str = Field(
+        default=None, description="Credential definition identifier"
+    )
+    referent: str = Field(default=None, description="Credential identifier")
+    credential_id: str = Field(default=None, description="Credential identifier")
+    cred_rev_id: Optional[str] = Field(
+        default=None, description="Credential revocation identifier"
+    )
+    rev_reg_id: Optional[str] = Field(
+        default=None, description="Revocation registry identifier"
+    )
+    schema_id: Optional[str] = Field(
+        default=None, description="Schema identifier"
+    )
+
+
+class CredPrecis(BaseModel):
+    cred_info: CredInfo = Field(description="Credential info")
+    interval: Optional[IndyNonRevocationInterval] = Field(
+        default=None, description="Non-revocation interval from presentation request"
+    )
+    presentation_referents: Optional[list] = Field(
+        default=None, description="Presentation referents"
+    )

--- a/app/models/verifier.py
+++ b/app/models/verifier.py
@@ -1,7 +1,12 @@
 from enum import Enum
 from typing import Optional, Union
 
-from aries_cloudcontroller import DIFPresSpec, DIFProofRequest, IndyPresSpec, IndyNonRevocationInterval
+from aries_cloudcontroller import (
+    DIFPresSpec,
+    DIFProofRequest,
+    IndyNonRevocationInterval,
+    IndyPresSpec,
+)
 from aries_cloudcontroller import IndyProofRequest as AcaPyIndyProofRequest
 from pydantic import BaseModel, Field, ValidationInfo, field_validator, model_validator
 
@@ -123,9 +128,7 @@ class RejectProofRequest(ProofId):
 
 
 class CredInfo(BaseModel):
-    attrs: dict = Field(
-        default=None, description="Attribute names and value"
-    )
+    attrs: dict = Field(default=None, description="Attribute names and value")
     cred_def_id: str = Field(
         default=None, description="Credential definition identifier"
     )
@@ -137,9 +140,7 @@ class CredInfo(BaseModel):
     rev_reg_id: Optional[str] = Field(
         default=None, description="Revocation registry identifier"
     )
-    schema_id: Optional[str] = Field(
-        default=None, description="Schema identifier"
-    )
+    schema_id: Optional[str] = Field(default=None, description="Schema identifier")
 
 
 class CredPrecis(BaseModel):

--- a/app/routes/verifier.py
+++ b/app/routes/verifier.py
@@ -1,7 +1,6 @@
 from typing import List, Optional
 from uuid import UUID
 
-from aries_cloudcontroller import IndyCredPrecis
 from fastapi import APIRouter, Depends
 
 from app.dependencies.acapy_clients import client_from_auth

--- a/app/routes/verifier.py
+++ b/app/routes/verifier.py
@@ -9,10 +9,10 @@ from app.exceptions import CloudApiException
 from app.models.verifier import (
     AcceptProofRequest,
     CreateProofRequest,
+    CredInfo,
+    CredPrecis,
     RejectProofRequest,
     SendProofRequest,
-    CredPrecis,
-    CredInfo,
 )
 from app.services.verifier.acapy_verifier_v2 import VerifierV2
 from app.util.acapy_verifier_utils import assert_valid_prover, assert_valid_verifier
@@ -511,8 +511,7 @@ async def get_credentials_by_proof_id(
     return [
         CredPrecis(
             cred_info=CredInfo(
-                **cred.cred_info.model_dump(),
-                credential_id=cred.cred_info.referent
+                **cred.cred_info.model_dump(), credential_id=cred.cred_info.referent
             ),
             interval=cred.interval,
             presentation_referents=cred.presentation_referents,

--- a/app/tests/e2e/verifier/test_verifier.py
+++ b/app/tests/e2e/verifier/test_verifier.py
@@ -445,12 +445,14 @@ async def test_get_credentials_for_request(
 
         result = response.json()[0]
         assert "cred_info" in result
+        assert result["cred_info"]["referent"] == result["cred_info"]["credential_id"]
         assert [
             attr
             in [
                 "attrs",
                 "cred_def_info",
                 "referent",
+                "credential_id",
                 "interval",
                 "presentation_referents",
             ]

--- a/app/tests/services/verifier/test_verifier.py
+++ b/app/tests/services/verifier/test_verifier.py
@@ -6,11 +6,11 @@ from fastapi.testclient import TestClient
 from mockito import verify, when
 from pytest_mock import MockerFixture
 
-from app.models.verifier import CredInfo, CredPrecis
 import app.routes.verifier as test_module
 from app.dependencies.auth import AcaPyAuth
 from app.exceptions.cloudapi_exception import CloudApiException
 from app.main import app
+from app.models.verifier import CredInfo, CredPrecis
 from app.routes.verifier import acapy_auth_from_header, get_credentials_by_proof_id
 from app.services.verifier.acapy_verifier_v2 import VerifierV2
 from app.tests.services.verifier.utils import indy_pres_spec, sample_indy_proof_request
@@ -301,19 +301,25 @@ async def test_get_credentials_by_proof_id(
         "client_from_auth",
         return_value=mock_context_managed_controller(mock_agent_controller),
     )
-    cred_precis = [IndyCredPrecis(
-        cred_info=IndyCredInfo(cred_def_id="WgWxqztrNooG92RXvxSTWv:3:CL:20:tag", referent="abcde", attrs={"attr1": "value1"}),
-    )]
+    cred_precis = [
+        IndyCredPrecis(
+            cred_info=IndyCredInfo(
+                cred_def_id="WgWxqztrNooG92RXvxSTWv:3:CL:20:tag",
+                referent="abcde",
+                attrs={"attr1": "value1"},
+            ),
+        )
+    ]
     returned_cred_precis = [
         CredPrecis(
             cred_info=CredInfo(
-                **cred.cred_info.model_dump(),
-                credential_id=cred.cred_info.referent
+                **cred.cred_info.model_dump(), credential_id=cred.cred_info.referent
             ),
             interval=cred.interval,
             presentation_referents=cred.presentation_referents,
         )
-        for cred in cred_precis ]
+        for cred in cred_precis
+    ]
 
     # V2
     when(VerifierV2).get_credentials_by_proof_id(

--- a/docs/openapi/tenant-openapi.json
+++ b/docs/openapi/tenant-openapi.json
@@ -2850,7 +2850,7 @@
           "verifier"
         ],
         "summary": "Get Matching Credentials for a Proof",
-        "description": "Get matching credentials for a presentation exchange\n---\nThis endpoint returns a list of possible credentials that the prover can use to respond to a given proof request.\n\nThe `presentation_referents` field (in the response) indicates which of the fields\nin the proof request that credential satisfies.\n\nParameters:\n---\n    proof_id: str\n        The relevant proof exchange ID for the prover\n    referent: Optional str\n        The presentation_referent of the proof to match, comma separated str of presentation_referents\n    limit: Optional int\n        The number of credentials to fetch\n    offset: Optional int\n        The index to start fetching credentials from\n\nReturns:\n---\n    List[IndyCredPrecis]\n        A list of applicable Indy credentials",
+        "description": "Get matching credentials for a presentation exchange\n---\nThis endpoint returns a list of possible credentials that the prover can use to respond to a given proof request.\n\nThe `presentation_referents` field (in the response) indicates which of the fields\nin the proof request that credential satisfies.\n\nParameters:\n---\n    proof_id: str\n        The relevant proof exchange ID for the prover\n    referent: Optional str\n        The presentation_referent of the proof to match, comma separated str of presentation_referents\n    limit: Optional int\n        The number of credentials to fetch\n    offset: Optional int\n        The index to start fetching credentials from\n\nReturns:\n---\n    List[CredPrecis]\n        A list of applicable credentials",
         "operationId": "get_credentials_by_proof_id_v1_verifier_proofs__proof_id__credentials_get",
         "security": [
           {
@@ -2933,7 +2933,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/IndyCredPrecis"
+                    "$ref": "#/components/schemas/CredPrecis"
                   },
                   "title": "Response Get Credentials By Proof Id V1 Verifier Proofs  Proof Id  Credentials Get"
                 }
@@ -3079,7 +3079,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/app__models__wallet__IndyCredInfo"
+                  "$ref": "#/components/schemas/IndyCredInfo"
                 }
               }
             }
@@ -5434,13 +5434,75 @@
         ],
         "title": "CreateSchema"
       },
+      "CredInfo": {
+        "properties": {
+          "attrs": {
+            "type": "object",
+            "title": "Attrs",
+            "description": "Attribute names and value"
+          },
+          "cred_def_id": {
+            "type": "string",
+            "title": "Cred Def Id",
+            "description": "Credential definition identifier"
+          },
+          "referent": {
+            "type": "string",
+            "title": "Referent",
+            "description": "Credential identifier"
+          },
+          "credential_id": {
+            "type": "string",
+            "title": "Credential Id",
+            "description": "Credential identifier"
+          },
+          "cred_rev_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cred Rev Id",
+            "description": "Credential revocation identifier"
+          },
+          "rev_reg_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rev Reg Id",
+            "description": "Revocation registry identifier"
+          },
+          "schema_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Schema Id",
+            "description": "Schema identifier"
+          }
+        },
+        "type": "object",
+        "title": "CredInfo"
+      },
       "CredInfoList": {
         "properties": {
           "results": {
             "anyOf": [
               {
                 "items": {
-                  "$ref": "#/components/schemas/app__models__wallet__IndyCredInfo"
+                  "$ref": "#/components/schemas/IndyCredInfo"
                 },
                 "type": "array"
               },
@@ -5453,6 +5515,43 @@
         },
         "type": "object",
         "title": "CredInfoList"
+      },
+      "CredPrecis": {
+        "properties": {
+          "cred_info": {
+            "$ref": "#/components/schemas/CredInfo",
+            "description": "Credential info"
+          },
+          "interval": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/IndyNonRevocationInterval"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Non-revocation interval from presentation request"
+          },
+          "presentation_referents": {
+            "anyOf": [
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Presentation Referents",
+            "description": "Presentation referents"
+          }
+        },
+        "type": "object",
+        "required": [
+          "cred_info"
+        ],
+        "title": "CredPrecis"
       },
       "CredRevokedResult": {
         "properties": {
@@ -5530,7 +5629,14 @@
             "description": "The ID of the credential"
           },
           "issuanceDate": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Issuancedate",
             "description": "The issuance date"
           },
@@ -5565,6 +5671,30 @@
             "title": "Type",
             "description": "The JSON-LD type of the credential"
           },
+          "validFrom": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Validfrom",
+            "description": "The valid from date"
+          },
+          "validUntil": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Validuntil",
+            "description": "The valid until date"
+          },
           "additional_properties": {
             "type": "object",
             "title": "Additional Properties",
@@ -5575,7 +5705,6 @@
         "required": [
           "@context",
           "credentialSubject",
-          "issuanceDate",
           "issuer",
           "type"
         ],
@@ -6515,44 +6644,89 @@
         "title": "Hangup",
         "description": "Hangup"
       },
-      "IndyCredPrecis": {
+      "IndyCredInfo": {
         "properties": {
-          "cred_info": {
-            "$ref": "#/components/schemas/aries_cloudcontroller__models__indy_cred_info__IndyCredInfo",
-            "description": "Credential info"
-          },
-          "interval": {
+          "attrs": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/IndyNonRevocationInterval"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Non-revocation interval from presentation request"
-          },
-          "presentation_referents": {
-            "anyOf": [
-              {
-                "items": {
+                "additionalProperties": {
                   "type": "string"
                 },
-                "type": "array"
+                "type": "object"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Presentation Referents"
+            "title": "Attrs",
+            "description": "Attribute names and value"
+          },
+          "cred_def_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cred Def Id",
+            "description": "Credential definition identifier"
+          },
+          "cred_rev_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cred Rev Id",
+            "description": "Credential revocation identifier"
+          },
+          "credential_id": {
+            "type": "string",
+            "title": "Credential Id",
+            "description": "(deprecated - renamed to credential_id) Credential identifier",
+            "deprecated": true
+          },
+          "rev_reg_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rev Reg Id",
+            "description": "Revocation registry identifier"
+          },
+          "schema_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Schema Id",
+            "description": "Schema identifier"
+          },
+          "referent": {
+            "type": "string",
+            "title": "Referent",
+            "description": "Credential identifier"
           }
         },
         "type": "object",
         "required": [
-          "cred_info"
+          "credential_id",
+          "referent"
         ],
-        "title": "IndyCredPrecis",
-        "description": "IndyCredPrecis"
+        "title": "IndyCredInfo"
       },
       "IndyCredential": {
         "properties": {
@@ -6819,8 +6993,8 @@
             "anyOf": [
               {
                 "type": "integer",
-                "maximum": 18446744073709552000,
-                "minimum": 0
+                "maximum": 1.8446744073709552E+19,
+                "minimum": 0.0
               },
               {
                 "type": "null"
@@ -6833,8 +7007,8 @@
             "anyOf": [
               {
                 "type": "integer",
-                "maximum": 18446744073709552000,
-                "minimum": 0
+                "maximum": 1.8446744073709552E+19,
+                "minimum": 0.0
               },
               {
                 "type": "null"
@@ -7015,8 +7189,8 @@
             "anyOf": [
               {
                 "type": "integer",
-                "maximum": 18446744073709552000,
-                "minimum": 0
+                "maximum": 1.8446744073709552E+19,
+                "minimum": 0.0
               },
               {
                 "type": "null"
@@ -7197,8 +7371,8 @@
             "anyOf": [
               {
                 "type": "integer",
-                "maximum": 18446744073709552000,
-                "minimum": 0
+                "maximum": 1.8446744073709552E+19,
+                "minimum": 0.0
               },
               {
                 "type": "null"
@@ -7211,8 +7385,8 @@
             "anyOf": [
               {
                 "type": "integer",
-                "maximum": 18446744073709552000,
-                "minimum": 0
+                "maximum": 1.8446744073709552E+19,
+                "minimum": 0.0
               },
               {
                 "type": "null"
@@ -7287,8 +7461,8 @@
             "anyOf": [
               {
                 "type": "integer",
-                "maximum": 18446744073709552000,
-                "minimum": 0
+                "maximum": 1.8446744073709552E+19,
+                "minimum": 0.0
               },
               {
                 "type": "null"
@@ -7301,8 +7475,8 @@
             "anyOf": [
               {
                 "type": "integer",
-                "maximum": 18446744073709552000,
-                "minimum": 0
+                "maximum": 1.8446744073709552E+19,
+                "minimum": 0.0
               },
               {
                 "type": "null"
@@ -7455,8 +7629,8 @@
             "anyOf": [
               {
                 "type": "integer",
-                "maximum": 18446744073709552000,
-                "minimum": 0
+                "maximum": 1.8446744073709552E+19,
+                "minimum": 0.0
               },
               {
                 "type": "null"
@@ -7469,8 +7643,8 @@
             "anyOf": [
               {
                 "type": "integer",
-                "maximum": 18446744073709552000,
-                "minimum": 0
+                "maximum": 1.8446744073709552E+19,
+                "minimum": 0.0
               },
               {
                 "type": "null"
@@ -7694,8 +7868,8 @@
             "anyOf": [
               {
                 "type": "integer",
-                "maximum": 18446744073709552000,
-                "minimum": 0
+                "maximum": 1.8446744073709552E+19,
+                "minimum": 0.0
               },
               {
                 "type": "null"
@@ -10336,172 +10510,6 @@
           "type"
         ],
         "title": "ValidationError"
-      },
-      "app__models__wallet__IndyCredInfo": {
-        "properties": {
-          "attrs": {
-            "anyOf": [
-              {
-                "additionalProperties": {
-                  "type": "string"
-                },
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Attrs",
-            "description": "Attribute names and value"
-          },
-          "cred_def_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Cred Def Id",
-            "description": "Credential definition identifier"
-          },
-          "cred_rev_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Cred Rev Id",
-            "description": "Credential revocation identifier"
-          },
-          "credential_id": {
-            "type": "string",
-            "title": "Credential Id",
-            "description": "(deprecated - renamed to credential_id) Credential identifier",
-            "deprecated": true
-          },
-          "rev_reg_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Rev Reg Id",
-            "description": "Revocation registry identifier"
-          },
-          "schema_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Schema Id",
-            "description": "Schema identifier"
-          },
-          "referent": {
-            "type": "string",
-            "title": "Referent",
-            "description": "Credential identifier"
-          }
-        },
-        "type": "object",
-        "required": [
-          "credential_id",
-          "referent"
-        ],
-        "title": "IndyCredInfo"
-      },
-      "aries_cloudcontroller__models__indy_cred_info__IndyCredInfo": {
-        "properties": {
-          "attrs": {
-            "anyOf": [
-              {
-                "additionalProperties": {
-                  "type": "string"
-                },
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Attrs",
-            "description": "Attribute names and value"
-          },
-          "cred_def_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Cred Def Id",
-            "description": "Credential definition identifier"
-          },
-          "cred_rev_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Cred Rev Id",
-            "description": "Credential revocation identifier"
-          },
-          "referent": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Referent",
-            "description": "Wallet referent"
-          },
-          "rev_reg_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Rev Reg Id",
-            "description": "Revocation registry identifier"
-          },
-          "schema_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Schema Id",
-            "description": "Schema identifier"
-          }
-        },
-        "type": "object",
-        "title": "IndyCredInfo",
-        "description": "IndyCredInfo"
       }
     },
     "securitySchemes": {

--- a/docs/openapi/tenant-openapi.yaml
+++ b/docs/openapi/tenant-openapi.yaml
@@ -2134,8 +2134,8 @@ paths:
         \        The presentation_referent of the proof to match, comma separated\
         \ str of presentation_referents\n    limit: Optional int\n        The number\
         \ of credentials to fetch\n    offset: Optional int\n        The index to\
-        \ start fetching credentials from\n\nReturns:\n---\n    List[IndyCredPrecis]\n\
-        \        A list of applicable Indy credentials"
+        \ start fetching credentials from\n\nReturns:\n---\n    List[CredPrecis]\n\
+        \        A list of applicable credentials"
       operationId: get_credentials_by_proof_id_v1_verifier_proofs__proof_id__credentials_get
       security:
       - APIKeyHeader: []
@@ -2187,7 +2187,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/IndyCredPrecis'
+                  $ref: '#/components/schemas/CredPrecis'
                 title: Response Get Credentials By Proof Id V1 Verifier Proofs  Proof
                   Id  Credentials Get
         '422':
@@ -2284,7 +2284,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/app__models__wallet__IndyCredInfo'
+                $ref: '#/components/schemas/IndyCredInfo'
         '422':
           description: Validation Error
           content:
@@ -3760,17 +3760,76 @@ components:
       - version
       - attribute_names
       title: CreateSchema
+    CredInfo:
+      properties:
+        attrs:
+          type: object
+          title: Attrs
+          description: Attribute names and value
+        cred_def_id:
+          type: string
+          title: Cred Def Id
+          description: Credential definition identifier
+        referent:
+          type: string
+          title: Referent
+          description: Credential identifier
+        credential_id:
+          type: string
+          title: Credential Id
+          description: Credential identifier
+        cred_rev_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Cred Rev Id
+          description: Credential revocation identifier
+        rev_reg_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Rev Reg Id
+          description: Revocation registry identifier
+        schema_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Schema Id
+          description: Schema identifier
+      type: object
+      title: CredInfo
     CredInfoList:
       properties:
         results:
           anyOf:
           - items:
-              $ref: '#/components/schemas/app__models__wallet__IndyCredInfo'
+              $ref: '#/components/schemas/IndyCredInfo'
             type: array
           - type: 'null'
           title: Results
       type: object
       title: CredInfoList
+    CredPrecis:
+      properties:
+        cred_info:
+          $ref: '#/components/schemas/CredInfo'
+          description: Credential info
+        interval:
+          anyOf:
+          - $ref: '#/components/schemas/IndyNonRevocationInterval'
+          - type: 'null'
+          description: Non-revocation interval from presentation request
+        presentation_referents:
+          anyOf:
+          - items: {}
+            type: array
+          - type: 'null'
+          title: Presentation Referents
+          description: Presentation referents
+      type: object
+      required:
+      - cred_info
+      title: CredPrecis
     CredRevokedResult:
       properties:
         revoked:
@@ -3813,7 +3872,9 @@ components:
           title: Id
           description: The ID of the credential
         issuanceDate:
-          type: string
+          anyOf:
+          - type: string
+          - type: 'null'
           title: Issuancedate
           description: The issuance date
         issuer:
@@ -3834,6 +3895,18 @@ components:
           type: array
           title: Type
           description: The JSON-LD type of the credential
+        validFrom:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Validfrom
+          description: The valid from date
+        validUntil:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Validuntil
+          description: The valid until date
         additional_properties:
           type: object
           title: Additional Properties
@@ -3842,7 +3915,6 @@ components:
       required:
       - '@context'
       - credentialSubject
-      - issuanceDate
       - issuer
       - type
       title: Credential
@@ -4409,28 +4481,54 @@ components:
       type: object
       title: Hangup
       description: Hangup
-    IndyCredPrecis:
+    IndyCredInfo:
       properties:
-        cred_info:
-          $ref: '#/components/schemas/aries_cloudcontroller__models__indy_cred_info__IndyCredInfo'
-          description: Credential info
-        interval:
+        attrs:
           anyOf:
-          - $ref: '#/components/schemas/IndyNonRevocationInterval'
-          - type: 'null'
-          description: Non-revocation interval from presentation request
-        presentation_referents:
-          anyOf:
-          - items:
+          - additionalProperties:
               type: string
-            type: array
+            type: object
           - type: 'null'
-          title: Presentation Referents
+          title: Attrs
+          description: Attribute names and value
+        cred_def_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Cred Def Id
+          description: Credential definition identifier
+        cred_rev_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Cred Rev Id
+          description: Credential revocation identifier
+        credential_id:
+          type: string
+          title: Credential Id
+          description: (deprecated - renamed to credential_id) Credential identifier
+          deprecated: true
+        rev_reg_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Rev Reg Id
+          description: Revocation registry identifier
+        schema_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Schema Id
+          description: Schema identifier
+        referent:
+          type: string
+          title: Referent
+          description: Credential identifier
       type: object
       required:
-      - cred_info
-      title: IndyCredPrecis
-      description: IndyCredPrecis
+      - credential_id
+      - referent
+      title: IndyCredInfo
     IndyCredential:
       properties:
         credential_definition_id:
@@ -6600,97 +6698,6 @@ components:
       - msg
       - type
       title: ValidationError
-    app__models__wallet__IndyCredInfo:
-      properties:
-        attrs:
-          anyOf:
-          - additionalProperties:
-              type: string
-            type: object
-          - type: 'null'
-          title: Attrs
-          description: Attribute names and value
-        cred_def_id:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Cred Def Id
-          description: Credential definition identifier
-        cred_rev_id:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Cred Rev Id
-          description: Credential revocation identifier
-        credential_id:
-          type: string
-          title: Credential Id
-          description: (deprecated - renamed to credential_id) Credential identifier
-          deprecated: true
-        rev_reg_id:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Rev Reg Id
-          description: Revocation registry identifier
-        schema_id:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Schema Id
-          description: Schema identifier
-        referent:
-          type: string
-          title: Referent
-          description: Credential identifier
-      type: object
-      required:
-      - credential_id
-      - referent
-      title: IndyCredInfo
-    aries_cloudcontroller__models__indy_cred_info__IndyCredInfo:
-      properties:
-        attrs:
-          anyOf:
-          - additionalProperties:
-              type: string
-            type: object
-          - type: 'null'
-          title: Attrs
-          description: Attribute names and value
-        cred_def_id:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Cred Def Id
-          description: Credential definition identifier
-        cred_rev_id:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Cred Rev Id
-          description: Credential revocation identifier
-        referent:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Referent
-          description: Wallet referent
-        rev_reg_id:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Rev Reg Id
-          description: Revocation registry identifier
-        schema_id:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Schema Id
-          description: Schema identifier
-      type: object
-      title: IndyCredInfo
-      description: IndyCredInfo
   securitySchemes:
     APIKeyHeader:
       type: apiKey


### PR DESCRIPTION
Add `credential_id` to results of matching proof as referent is deprecated 