### PR TITLE
✨1 Anoncreds schemas

### DIFF
--- a/app/models/definitions.py
+++ b/app/models/definitions.py
@@ -29,7 +29,10 @@ class CredentialDefinition(BaseModel):
 
 
 class CreateSchema(BaseModel):
-    schema_type: SchemaType = SchemaType.INDY
+    schema_type: SchemaType = Field(
+        default=SchemaType.INDY,
+        description="The type of schema to create. Supported values are 'indy' and 'anoncreds'.",
+    )
     name: str = Field(..., examples=[sample_name])
     version: str = Field(..., examples=[sample_version])
     attribute_names: List[str] = Field(..., examples=[sample_attribute_names])

--- a/app/models/definitions.py
+++ b/app/models/definitions.py
@@ -29,7 +29,7 @@ class CredentialDefinition(BaseModel):
 
 
 class CreateSchema(BaseModel):
-    schema_type: SchemaType = SchemaType.ANONCREDS
+    schema_type: SchemaType = SchemaType.INDY
     name: str = Field(..., examples=[sample_name])
     version: str = Field(..., examples=[sample_version])
     attribute_names: List[str] = Field(..., examples=[sample_attribute_names])

--- a/app/routes/definitions.py
+++ b/app/routes/definitions.py
@@ -136,7 +136,6 @@ async def get_schemas(
                 schema_name=schema_name,
                 schema_version=schema_version,
             )
-
         else:  # Governance is calling the endpoint
             try:
                 schemas = await schemas_service.get_schemas_as_governance(
@@ -190,11 +189,9 @@ async def get_schema(
 
     async with client_from_auth(auth) as aries_controller:
         if is_governance:
-            # controller.settings.get_settings() returns None ????
             # Get the wallet type from the server config
             server_config = await aries_controller.server.get_config()
             wallet_type = server_config.config.get("wallet.type")
-
         else:
             wallet_type = await get_wallet_type(
                 aries_controller=aries_controller,
@@ -202,7 +199,6 @@ async def get_schema(
             )
 
         if wallet_type == "askar-anoncreds":
-
             schema = await handle_acapy_call(
                 logger=bound_logger,
                 acapy_call=aries_controller.anoncreds_schemas.get_schema,
@@ -213,9 +209,7 @@ async def get_schema(
                 raise HTTPException(404, f"Schema with id {schema_id} not found.")
 
             result = anoncreds_schema_from_acapy(schema)
-
         elif wallet_type == "askar":
-
             schema = await handle_acapy_call(
                 logger=bound_logger,
                 acapy_call=aries_controller.schema.get_schema,
@@ -226,8 +220,8 @@ async def get_schema(
                 raise HTTPException(404, f"Schema with id {schema_id} not found.")
 
             result = credential_schema_from_acapy(schema.var_schema)
-
         else:
+            # Should never happen
             raise HTTPException(500, "Unknown wallet type")
 
     bound_logger.debug("Successfully fetched schema by id.")

--- a/app/routes/definitions.py
+++ b/app/routes/definitions.py
@@ -22,12 +22,12 @@ from app.models.definitions import (
     CredentialSchema,
 )
 from app.util.definitions import (
-    anon_schema_from_acapy,
+    anoncreds_schema_from_acapy,
     credential_definition_from_acapy,
     credential_schema_from_acapy,
 )
 from app.util.retry_method import coroutine_with_retry
-from app.util.tenants import is_anoncreds_wallet
+from app.util.tenants import get_wallet_type
 from shared.log_config import get_logger
 
 logger = get_logger(__name__)

--- a/app/routes/definitions.py
+++ b/app/routes/definitions.py
@@ -198,7 +198,7 @@ async def get_schema(
         else:
             if await is_anoncreds_wallet(
                 aries_controller=aries_controller,
-                logger=logger,
+                logger=bound_logger,
             ):
                 wallet_type = "askar-anoncreds"
             else:

--- a/app/routes/definitions.py
+++ b/app/routes/definitions.py
@@ -21,8 +21,13 @@ from app.models.definitions import (
     CredentialDefinition,
     CredentialSchema,
 )
-from app.util.definitions import credential_definition_from_acapy, schema_from_acapy
+from app.util.definitions import (
+    anon_schema_from_acapy,
+    credential_definition_from_acapy,
+    credential_schema_from_acapy,
+)
 from app.util.retry_method import coroutine_with_retry
+from app.util.tenants import get_wallet_id_from_b64encoded_jwt, is_anoncreds_wallet
 from shared.log_config import get_logger
 
 logger = get_logger(__name__)

--- a/app/routes/definitions.py
+++ b/app/routes/definitions.py
@@ -27,7 +27,7 @@ from app.util.definitions import (
     credential_schema_from_acapy,
 )
 from app.util.retry_method import coroutine_with_retry
-from app.util.tenants import get_wallet_id_from_b64encoded_jwt, is_anoncreds_wallet
+from app.util.tenants import is_anoncreds_wallet
 from shared.log_config import get_logger
 
 logger = get_logger(__name__)

--- a/app/routes/definitions.py
+++ b/app/routes/definitions.py
@@ -196,7 +196,7 @@ async def get_schema(
             wallet_type = server_config.config.get("wallet.type")
 
         else:
-            wallet_type = get_wallet_type(
+            wallet_type = await get_wallet_type(
                 aries_controller=aries_controller,
                 logger=bound_logger,
             )

--- a/app/routes/definitions.py
+++ b/app/routes/definitions.py
@@ -188,24 +188,24 @@ async def get_schema(
     bound_logger.debug("GET request received: Get schema by id")
     is_governance = auth.role == Role.GOVERNANCE
 
-    if is_governance:
-        # controller.settings.get_settings() returns None ????
-        # Get the wallet type from the server config
-        server_config = await aries_controller.server.get_config()
-        wallet_type = server_config.config.get("wallet.type")
-
-    else:
-        if await is_anoncreds_wallet(
-            wallet_id=get_wallet_id_from_b64encoded_jwt(
-                aries_controller.tenant_jwt.split(".")[1]
-            ),
-            logger=logger,
-        ):
-            wallet_type = "askar-anoncreds"
-        else:
-            wallet_type = "askar"
-
     async with client_from_auth(auth) as aries_controller:
+        if is_governance:
+            # controller.settings.get_settings() returns None ????
+            # Get the wallet type from the server config
+            server_config = await aries_controller.server.get_config()
+            wallet_type = server_config.config.get("wallet.type")
+        
+        else:
+            if await is_anoncreds_wallet(
+                wallet_id=get_wallet_id_from_b64encoded_jwt(
+                    aries_controller.tenant_jwt.split(".")[1]
+                ),
+                logger=logger,
+            ):
+                wallet_type = "askar-anoncreds"
+            else:
+                wallet_type = "askar"
+
         if wallet_type == "askar-anoncreds":
 
             schema = await handle_acapy_call(

--- a/app/routes/definitions.py
+++ b/app/routes/definitions.py
@@ -197,9 +197,7 @@ async def get_schema(
 
         else:
             if await is_anoncreds_wallet(
-                wallet_id=get_wallet_id_from_b64encoded_jwt(
-                    aries_controller.tenant_jwt.split(".")[1]
-                ),
+                aries_controller=aries_controller,
                 logger=logger,
             ):
                 wallet_type = "askar-anoncreds"

--- a/app/routes/definitions.py
+++ b/app/routes/definitions.py
@@ -186,6 +186,13 @@ async def get_schema(
     """
     bound_logger = logger.bind(body={"schema_id": schema_id})
     bound_logger.debug("GET request received: Get schema by id")
+    is_governance = auth.role == Role.GOVERNANCE
+
+    if is_governance:
+        # controller.settings.get_settings() returns None ????
+        # Get the wallet type from the server config
+        server_config = await aries_controller.server.get_config()
+        wallet_type = server_config.config.get("wallet.type")
 
     async with client_from_auth(auth) as aries_controller:
         schema = await handle_acapy_call(

--- a/app/routes/definitions.py
+++ b/app/routes/definitions.py
@@ -206,16 +206,35 @@ async def get_schema(
             wallet_type = "askar"
 
     async with client_from_auth(auth) as aries_controller:
-        schema = await handle_acapy_call(
-            logger=bound_logger,
-            acapy_call=aries_controller.anoncreds_schemas.get_schema,
-            schema_id=schema_id,
-        )
+        if wallet_type == "askar-anoncreds":
 
-    if not schema.var_schema:
-        raise HTTPException(404, f"Schema with id {schema_id} not found.")
+            schema = await handle_acapy_call(
+                logger=bound_logger,
+                acapy_call=aries_controller.anoncreds_schemas.get_schema,
+                schema_id=schema_id,
+            )
 
-    result = schema_from_acapy(schema)
+            if not schema.var_schema:
+                raise HTTPException(404, f"Schema with id {schema_id} not found.")
+
+            result = anon_schema_from_acapy(schema)
+
+        elif wallet_type == "askar":
+
+            schema = await handle_acapy_call(
+                logger=bound_logger,
+                acapy_call=aries_controller.schema.get_schema,
+                schema_id=schema_id,
+            )
+
+            if not schema.var_schema:
+                raise HTTPException(404, f"Schema with id {schema_id} not found.")
+
+            result = credential_schema_from_acapy(schema.var_schema)
+
+        else:
+            raise HTTPException(500, "Unknown wallet type")
+
     bound_logger.debug("Successfully fetched schema by id.")
     return result
 

--- a/app/routes/definitions.py
+++ b/app/routes/definitions.py
@@ -212,7 +212,7 @@ async def get_schema(
             if not schema.var_schema:
                 raise HTTPException(404, f"Schema with id {schema_id} not found.")
 
-            result = anon_schema_from_acapy(schema)
+            result = anoncreds_schema_from_acapy(schema)
 
         elif wallet_type == "askar":
 

--- a/app/routes/definitions.py
+++ b/app/routes/definitions.py
@@ -194,6 +194,17 @@ async def get_schema(
         server_config = await aries_controller.server.get_config()
         wallet_type = server_config.config.get("wallet.type")
 
+    else:
+        if await is_anoncreds_wallet(
+            wallet_id=get_wallet_id_from_b64encoded_jwt(
+                aries_controller.tenant_jwt.split(".")[1]
+            ),
+            logger=logger,
+        ):
+            wallet_type = "askar-anoncreds"
+        else:
+            wallet_type = "askar"
+
     async with client_from_auth(auth) as aries_controller:
         schema = await handle_acapy_call(
             logger=bound_logger,

--- a/app/routes/definitions.py
+++ b/app/routes/definitions.py
@@ -194,7 +194,7 @@ async def get_schema(
             # Get the wallet type from the server config
             server_config = await aries_controller.server.get_config()
             wallet_type = server_config.config.get("wallet.type")
-        
+
         else:
             if await is_anoncreds_wallet(
                 wallet_id=get_wallet_id_from_b64encoded_jwt(

--- a/app/routes/definitions.py
+++ b/app/routes/definitions.py
@@ -196,13 +196,10 @@ async def get_schema(
             wallet_type = server_config.config.get("wallet.type")
 
         else:
-            if await is_anoncreds_wallet(
+            wallet_type = get_wallet_type(
                 aries_controller=aries_controller,
                 logger=bound_logger,
-            ):
-                wallet_type = "askar-anoncreds"
-            else:
-                wallet_type = "askar"
+            )
 
         if wallet_type == "askar-anoncreds":
 

--- a/app/services/definitions/schema_publisher.py
+++ b/app/services/definitions/schema_publisher.py
@@ -13,7 +13,7 @@ from app.exceptions import CloudApiException, handle_acapy_call
 from app.models.definitions import CredentialSchema
 from app.services.trust_registry.schemas import register_schema
 from app.util.definitions import (
-    credential_anon_schema_from_acapy,
+    anoncreds_credential_schema,
     credential_schema_from_acapy,
 )
 
@@ -160,7 +160,7 @@ class SchemaPublisher:
                 "An unexpected error occurred: could not publish schema."
             )
 
-        result = credential_anon_schema_from_acapy(result.schema_state)
+        result = anoncreds_credential_schema(result.schema_state)
         return result
 
     async def _handle_existing_anoncreds_schema(
@@ -231,7 +231,7 @@ class SchemaPublisher:
             )
             raise CloudApiException(error_message, 409)
 
-        result = credential_anon_schema_from_acapy(_schema)
+        result = anoncreds_credential_schema(_schema)
         self._logger.debug(
             "Schema already exists on ledger. Returning schema definition: `{}`.",
             result,

--- a/app/services/definitions/schema_publisher.py
+++ b/app/services/definitions/schema_publisher.py
@@ -155,7 +155,9 @@ class SchemaPublisher:
         if result.schema_state.state == "finished" and result.schema_state.schema_id:
             await register_schema(schema_id=result.schema_state.schema_id)
         else:
-            self._logger.error("No SchemaSendResult in `publish_schema` response.")
+            self._logger.error(
+                "No SchemaSendResult in `publish_schema` response: {}.", result
+            )
             raise CloudApiException(
                 "An unexpected error occurred: could not publish schema."
             )

--- a/app/services/definitions/schema_publisher.py
+++ b/app/services/definitions/schema_publisher.py
@@ -12,7 +12,10 @@ from aries_cloudcontroller import (
 from app.exceptions import CloudApiException, handle_acapy_call
 from app.models.definitions import CredentialSchema
 from app.services.trust_registry.schemas import register_schema
-from app.util.definitions import credential_schema_from_acapy
+from app.util.definitions import (
+    credential_anon_schema_from_acapy,
+    credential_schema_from_acapy,
+)
 
 
 class SchemaPublisher:
@@ -157,7 +160,7 @@ class SchemaPublisher:
                 "An unexpected error occurred: could not publish schema."
             )
 
-        result = credential_schema_from_acapy(result.schema_state)
+        result = credential_anon_schema_from_acapy(result.schema_state)
         return result
 
     async def _handle_existing_anoncreds_schema(
@@ -228,7 +231,7 @@ class SchemaPublisher:
             )
             raise CloudApiException(error_message, 409)
 
-        result = credential_schema_from_acapy(_schema)
+        result = credential_anon_schema_from_acapy(_schema)
         self._logger.debug(
             "Schema already exists on ledger. Returning schema definition: `{}`.",
             result,

--- a/app/services/definitions/schemas.py
+++ b/app/services/definitions/schemas.py
@@ -115,7 +115,15 @@ async def get_schemas_as_tenant(
         }
     )
     bound_logger.debug("Fetching schemas from trust registry")
-
+    if await is_anoncreds_wallet(
+        wallet_id=get_wallet_id_from_b64encoded_jwt(
+            aries_controller.tenant_jwt.split(".")[1]
+        ),
+        logger=logger,
+    ):
+        wallet_type = "askar-anoncreds"
+    else:
+        wallet_type = "askar"
     if schema_id:  # fetch specific id
         trust_registry_schemas = [await get_trust_registry_schema_by_id(schema_id)]
     else:  # client is not filtering by schema_id, fetch all
@@ -127,6 +135,7 @@ async def get_schemas_as_tenant(
     schemas = await get_schemas_by_id(
         aries_controller=aries_controller,
         schema_ids=schema_ids,
+        wallet_type=wallet_type,
     )
 
     if schema_issuer_did:

--- a/app/services/definitions/schemas.py
+++ b/app/services/definitions/schemas.py
@@ -97,13 +97,6 @@ async def create_schema(
 
         result = await publisher.publish_schema(schema_request)
 
-    else:
-        raise CloudApiException(
-            # TODO: Improve message
-            "Wallet type does not match schema type. Cannot create schema.",
-            status_code=400,
-        )
-
     bound_logger.debug("Successfully published and registered schema.")
     return result
 

--- a/app/services/definitions/schemas.py
+++ b/app/services/definitions/schemas.py
@@ -66,6 +66,7 @@ async def create_schema(
             f" '{"askar" if schema.schema_type == "INDY" else "askar-anoncreds"}' wallet types",
             status_code=400,
         )
+    if wallet_type == "askar-anoncreds":
         anoncreds_schema = handle_model_with_validation(
             logger=bound_logger,
             model_class=AnonCredsSchema,
@@ -85,7 +86,7 @@ async def create_schema(
 
         result = await publisher.publish_anoncreds_schema(schema_request)
 
-    elif schema.schema_type == SchemaType.INDY and wallet_type == "askar":
+    elif wallet_type == "askar":
         schema_request = handle_model_with_validation(
             logger=bound_logger,
             model_class=SchemaSendRequest,

--- a/app/services/definitions/schemas.py
+++ b/app/services/definitions/schemas.py
@@ -103,7 +103,6 @@ async def create_schema(
 
 async def get_schemas_as_tenant(
     aries_controller: AcaPyClient,
-    schema_id: Optional[str] = None,
     schema_issuer_did: Optional[str] = None,
     schema_name: Optional[str] = None,
     schema_version: Optional[str] = None,
@@ -113,7 +112,6 @@ async def get_schemas_as_tenant(
     """
     bound_logger = logger.bind(
         body={
-            "schema_id": schema_id,
             "schema_issuer_did": schema_issuer_did,
             "schema_name": schema_name,
             "schema_version": schema_version,
@@ -125,10 +123,7 @@ async def get_schemas_as_tenant(
         logger=bound_logger,
     )
 
-    if schema_id:  # fetch specific id
-        trust_registry_schemas = [await get_trust_registry_schema_by_id(schema_id)]
-    else:  # client is not filtering by schema_id, fetch all
-        trust_registry_schemas = await get_trust_registry_schemas()
+    trust_registry_schemas = await get_trust_registry_schemas()
 
     schema_ids = [schema.id for schema in trust_registry_schemas]
 
@@ -153,7 +148,6 @@ async def get_schemas_as_tenant(
 
 async def get_schemas_as_governance(
     aries_controller: AcaPyClient,
-    schema_id: Optional[str] = None,
     schema_issuer_did: Optional[str] = None,
     schema_name: Optional[str] = None,
     schema_version: Optional[str] = None,
@@ -163,7 +157,6 @@ async def get_schemas_as_governance(
     """
     bound_logger = logger.bind(
         body={
-            "schema_id": schema_id,
             "schema_issuer_did": schema_issuer_did,
             "schema_name": schema_name,
             "schema_version": schema_version,
@@ -198,7 +191,6 @@ async def get_schemas_as_governance(
         response = await handle_acapy_call(
             logger=bound_logger,
             acapy_call=aries_controller.schema.get_created_schemas,
-            schema_id=schema_id,
             schema_issuer_did=schema_issuer_did,
             schema_name=schema_name,
             schema_version=schema_version,

--- a/app/services/definitions/schemas.py
+++ b/app/services/definitions/schemas.py
@@ -22,6 +22,7 @@ from app.routes.trust_registry import (
 from app.routes.trust_registry import get_schemas as get_trust_registry_schemas
 from app.services.definitions.schema_publisher import SchemaPublisher
 from app.util.definitions import schema_from_acapy
+from app.util.tenants import get_wallet_id_from_b64encoded_jwt, is_anoncreds_wallet
 from shared.constants import GOVERNANCE_AGENT_URL
 from shared.log_config import get_logger
 

--- a/app/services/definitions/schemas.py
+++ b/app/services/definitions/schemas.py
@@ -47,7 +47,11 @@ async def create_schema(
     did_result = await aries_controller.wallet.get_public_did()
     endorser_did = did_result.result.did
 
-    wallet_type = (await aries_controller.settings.get_settings())["wallet.type"]
+    # controller.settings.get_settings() returns None ????
+    # Get the wallet type from the server config
+    server_config = await aries_controller.server.get_config()
+    wallet_type = server_config.config.get("wallet.type")
+
     if schema.schema_type == SchemaType.ANONCREDS and wallet_type == "askar-anoncreds":
         anoncreds_schema = handle_model_with_validation(
             logger=bound_logger,

--- a/app/services/definitions/schemas.py
+++ b/app/services/definitions/schemas.py
@@ -21,7 +21,10 @@ from app.routes.trust_registry import (
 )
 from app.routes.trust_registry import get_schemas as get_trust_registry_schemas
 from app.services.definitions.schema_publisher import SchemaPublisher
-from app.util.definitions import anoncreds_schema_from_acapy, credential_schema_from_acapy
+from app.util.definitions import (
+    anoncreds_schema_from_acapy,
+    credential_schema_from_acapy,
+)
 from app.util.tenants import get_wallet_type
 from shared.constants import GOVERNANCE_AGENT_URL
 from shared.log_config import get_logger

--- a/app/services/definitions/schemas.py
+++ b/app/services/definitions/schemas.py
@@ -248,7 +248,7 @@ async def get_schemas_by_id(
 
             # transform all schemas into response model (if schemas returned)
             schemas = [
-                anon_schema_from_acapy(schema)
+                anoncreds_schema_from_acapy(schema)
                 for schema in schema_results
                 if schema.var_schema
             ]

--- a/app/services/definitions/schemas.py
+++ b/app/services/definitions/schemas.py
@@ -67,7 +67,7 @@ async def create_schema(
         )
         bound_logger.info("Bad request: {}", error_message)
         raise CloudApiException(error_message, status_code=400)
-    if wallet_type == "askar-anoncreds":
+    elif wallet_type == "askar-anoncreds":
         anoncreds_schema = handle_model_with_validation(
             logger=bound_logger,
             model_class=AnonCredsSchema,
@@ -86,7 +86,7 @@ async def create_schema(
         )
 
         result = await publisher.publish_anoncreds_schema(schema_request)
-    elif wallet_type == "askar":
+    else:  # wallet_type == "askar"
         schema_request = handle_model_with_validation(
             logger=bound_logger,
             model_class=SchemaSendRequest,

--- a/app/services/definitions/schemas.py
+++ b/app/services/definitions/schemas.py
@@ -5,6 +5,7 @@ from aries_cloudcontroller import (
     AcaPyClient,
     AnonCredsSchema,
     GetSchemaResult,
+    SchemaGetResult,
     SchemaPostRequest,
     SchemaSendRequest,
 )

--- a/app/services/definitions/schemas.py
+++ b/app/services/definitions/schemas.py
@@ -116,9 +116,7 @@ async def get_schemas_as_tenant(
     )
     bound_logger.debug("Fetching schemas from trust registry")
     if await is_anoncreds_wallet(
-        wallet_id=get_wallet_id_from_b64encoded_jwt(
-            aries_controller.tenant_jwt.split(".")[1]
-        ),
+        aries_controller=aries_controller,
         logger=logger,
     ):
         wallet_type = "askar-anoncreds"

--- a/app/services/definitions/schemas.py
+++ b/app/services/definitions/schemas.py
@@ -206,7 +206,7 @@ async def get_schemas_as_governance(
     else:
         raise CloudApiException(
             "Wallet type not supported. Cannot get schemas.",
-            status_code=400,
+            status_code=500,
         )
 
     # Initiate retrieving all schemas
@@ -290,7 +290,7 @@ async def get_schemas_by_id(
     else:
         raise CloudApiException(
             "Wallet type not supported. Cannot get schemas.",
-            status_code=400,
+            status_code=500,
         )
 
     return schemas

--- a/app/services/definitions/schemas.py
+++ b/app/services/definitions/schemas.py
@@ -115,13 +115,10 @@ async def get_schemas_as_tenant(
         }
     )
     bound_logger.debug("Fetching schemas from trust registry")
-    if await is_anoncreds_wallet(
+    wallet_type = await get_wallet_type(
         aries_controller=aries_controller,
         logger=bound_logger,
-    ):
-        wallet_type = "askar-anoncreds"
-    else:
-        wallet_type = "askar"
+    )
 
     if schema_id:  # fetch specific id
         trust_registry_schemas = [await get_trust_registry_schema_by_id(schema_id)]

--- a/app/services/definitions/schemas.py
+++ b/app/services/definitions/schemas.py
@@ -211,6 +211,7 @@ async def get_schemas_as_governance(
     schemas = await get_schemas_by_id(
         aries_controller=aries_controller,
         schema_ids=schema_ids,
+        wallet_type=wallet_type,
     )
 
     return schemas

--- a/app/services/definitions/schemas.py
+++ b/app/services/definitions/schemas.py
@@ -16,9 +16,6 @@ from app.exceptions import (
     handle_model_with_validation,
 )
 from app.models.definitions import CreateSchema, CredentialSchema, SchemaType
-from app.routes.trust_registry import (
-    get_schema_by_id as get_trust_registry_schema_by_id,
-)
 from app.routes.trust_registry import get_schemas as get_trust_registry_schemas
 from app.services.definitions.schema_publisher import SchemaPublisher
 from app.util.definitions import (
@@ -52,7 +49,6 @@ async def create_schema(
     did_result = await aries_controller.wallet.get_public_did()
     endorser_did = did_result.result.did
 
-    # controller.settings.get_settings() returns None ????
     # Get the wallet type from the server config
     server_config = await aries_controller.server.get_config()
     wallet_type = server_config.config.get("wallet.type")

--- a/app/services/definitions/schemas.py
+++ b/app/services/definitions/schemas.py
@@ -62,8 +62,8 @@ async def create_schema(
     )
     if wallet_type != required_wallet_type:
         error_message = (
-            f"{schema.schema_type} can only be created by"
-            f" '{"askar" if schema.schema_type == "INDY" else "askar-anoncreds"}' wallet types"
+            f"{schema.schema_type} schemas can only be created "
+            f"by '{required_wallet_type}' wallet types"
         )
         bound_logger.info("Bad request: {}", error_message)
         raise CloudApiException(error_message, status_code=400)

--- a/app/services/definitions/schemas.py
+++ b/app/services/definitions/schemas.py
@@ -117,7 +117,7 @@ async def get_schemas_as_tenant(
     bound_logger.debug("Fetching schemas from trust registry")
     if await is_anoncreds_wallet(
         aries_controller=aries_controller,
-        logger=logger,
+        logger=bound_logger,
     ):
         wallet_type = "askar-anoncreds"
     else:

--- a/app/services/definitions/schemas.py
+++ b/app/services/definitions/schemas.py
@@ -57,7 +57,15 @@ async def create_schema(
     server_config = await aries_controller.server.get_config()
     wallet_type = server_config.config.get("wallet.type")
 
-    if schema.schema_type == SchemaType.ANONCREDS and wallet_type == "askar-anoncreds":
+    required_wallet_type = (
+        "askar-anoncreds" if schema.schema_type == SchemaType.ANONCREDS else "askar"
+    )
+    if wallet_type != required_wallet_type:
+        raise CloudApiException(
+            f"{schema.schema_type} can only be created by"
+            f" '{"askar" if schema.schema_type == "INDY" else "askar-anoncreds"}' wallet types",
+            status_code=400,
+        )
         anoncreds_schema = handle_model_with_validation(
             logger=bound_logger,
             model_class=AnonCredsSchema,

--- a/app/services/definitions/schemas.py
+++ b/app/services/definitions/schemas.py
@@ -47,22 +47,44 @@ async def create_schema(
     did_result = await aries_controller.wallet.get_public_did()
     endorser_did = did_result.result.did
 
-    anoncreds_schema = handle_model_with_validation(
-        logger=bound_logger,
-        model_class=AnonCredsSchema,
-        attr_names=schema.attribute_names,
-        name=schema.name,
-        version=schema.version,
-        issuer_id=endorser_did,
-    )
+    wallet_type = (await aries_controller.settings.get_settings())["wallet.type"]
+    if schema.schema_type == SchemaType.ANONCREDS and wallet_type == "askar-anoncreds":
+        anoncreds_schema = handle_model_with_validation(
+            logger=bound_logger,
+            model_class=AnonCredsSchema,
+            attr_names=schema.attribute_names,
+            name=schema.name,
+            version=schema.version,
+            issuer_id=endorser_did,
+        )
 
-    # Using the default values for schema_post_option
-    # as the governance agent is the issuer
-    schema_request = handle_model_with_validation(
-        logger=bound_logger, model_class=SchemaPostRequest, var_schema=anoncreds_schema
-    )
+        # Using the default values for schema_post_option
+        # as the governance agent is the issuer
+        schema_request = handle_model_with_validation(
+            logger=bound_logger,
+            model_class=SchemaPostRequest,
+            var_schema=anoncreds_schema,
+        )
 
-    result = await publisher.publish_schema(schema_request)
+        result = await publisher.publish_anoncreds_schema(schema_request)
+
+    elif schema.schema_type == SchemaType.INDY and wallet_type == "askar":
+        schema_request = handle_model_with_validation(
+            logger=bound_logger,
+            model_class=SchemaSendRequest,
+            attributes=schema.attribute_names,
+            schema_name=schema.name,
+            schema_version=schema.version,
+        )
+
+        result = await publisher.publish_schema(schema_request)
+
+    else:
+        raise CloudApiException(
+            # TODO: Improve message
+            "Wallet type does not match schema type. Cannot create schema.",
+            status_code=400,
+        )
 
     bound_logger.debug("Successfully published and registered schema.")
     return result

--- a/app/services/definitions/schemas.py
+++ b/app/services/definitions/schemas.py
@@ -21,8 +21,8 @@ from app.routes.trust_registry import (
 )
 from app.routes.trust_registry import get_schemas as get_trust_registry_schemas
 from app.services.definitions.schema_publisher import SchemaPublisher
-from app.util.definitions import anon_schema_from_acapy, credential_schema_from_acapy
-from app.util.tenants import get_wallet_id_from_b64encoded_jwt, is_anoncreds_wallet
+from app.util.definitions import anoncreds_schema_from_acapy, credential_schema_from_acapy
+from app.util.tenants import get_wallet_type
 from shared.constants import GOVERNANCE_AGENT_URL
 from shared.log_config import get_logger
 

--- a/app/services/definitions/schemas.py
+++ b/app/services/definitions/schemas.py
@@ -176,15 +176,33 @@ async def get_schemas_as_governance(
             status_code=403,
         )
 
-    # Get all created schema ids that match the filter
-    bound_logger.debug("Fetching created schemas")
-    response = await handle_acapy_call(
-        logger=bound_logger,
-        acapy_call=aries_controller.anoncreds_schemas.get_schemas,
-        schema_issuer_id=schema_issuer_did,
-        schema_name=schema_name,
-        schema_version=schema_version,
-    )
+    # controller.settings.get_settings() returns None ????
+    # Get the wallet type from the server config
+    server_config = await aries_controller.server.get_config()
+    wallet_type = server_config.config.get("wallet.type")
+
+    if wallet_type == "askar-anoncreds":
+        # Get all created schema ids that match the filter
+        bound_logger.debug("Fetching created schemas")
+        response = await handle_acapy_call(
+            logger=bound_logger,
+            acapy_call=aries_controller.anoncreds_schemas.get_schemas,
+            schema_issuer_id=schema_issuer_did,
+            schema_name=schema_name,
+            schema_version=schema_version,
+        )
+
+    elif wallet_type == "askar":
+        # Get all created schema ids that match the filter
+        bound_logger.debug("Fetching created schemas")
+        response = await handle_acapy_call(
+            logger=bound_logger,
+            acapy_call=aries_controller.schema.get_created_schemas,
+            schema_id=schema_id,
+            schema_issuer_did=schema_issuer_did,
+            schema_name=schema_name,
+            schema_version=schema_version,
+        )
 
     # Initiate retrieving all schemas
     schema_ids = response.schema_ids or []

--- a/app/services/definitions/schemas.py
+++ b/app/services/definitions/schemas.py
@@ -251,12 +251,12 @@ async def get_schemas_by_id(
             logger.debug("No created schema ids returned")
             schema_results = []
 
-            # transform all schemas into response model (if schemas returned)
-            schemas = [
-                anoncreds_schema_from_acapy(schema)
-                for schema in schema_results
-                if schema.var_schema
-            ]
+        # transform all schemas into response model (if schemas returned)
+        schemas = [
+            anoncreds_schema_from_acapy(schema)
+            for schema in schema_results
+            if schema.var_schema
+        ]
     elif wallet_type == "askar":
         logger.debug("Fetching schemas from askar wallet")
         get_schema_futures = [

--- a/app/services/definitions/schemas.py
+++ b/app/services/definitions/schemas.py
@@ -21,7 +21,7 @@ from app.routes.trust_registry import (
 )
 from app.routes.trust_registry import get_schemas as get_trust_registry_schemas
 from app.services.definitions.schema_publisher import SchemaPublisher
-from app.util.definitions import credential_schema_from_acapy, anon_schema_from_acapy
+from app.util.definitions import anon_schema_from_acapy, credential_schema_from_acapy
 from app.util.tenants import get_wallet_id_from_b64encoded_jwt, is_anoncreds_wallet
 from shared.constants import GOVERNANCE_AGENT_URL
 from shared.log_config import get_logger

--- a/app/services/definitions/schemas.py
+++ b/app/services/definitions/schemas.py
@@ -124,6 +124,7 @@ async def get_schemas_as_tenant(
         wallet_type = "askar-anoncreds"
     else:
         wallet_type = "askar"
+
     if schema_id:  # fetch specific id
         trust_registry_schemas = [await get_trust_registry_schema_by_id(schema_id)]
     else:  # client is not filtering by schema_id, fetch all

--- a/app/tests/routes/definitions/test_get_schema_by_id.py
+++ b/app/tests/routes/definitions/test_get_schema_by_id.py
@@ -1,12 +1,11 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
-
-from app.dependencies.auth import AcaPyAuth
 from aries_cloudcontroller.exceptions import ApiException, BadRequestException
 from aries_cloudcontroller.models.schema_get_result import ModelSchema, SchemaGetResult
 from fastapi import HTTPException
 
+from app.dependencies.auth import AcaPyAuth
 from app.models.definitions import CredentialSchema
 from app.routes.definitions import get_schema
 
@@ -108,7 +107,9 @@ async def test_get_schema_by_id_404():
         return_value=SchemaGetResult(var_schema=None)
     )
     mock_auth = AcaPyAuth(token="mocked_token", role="TENANT")
-    with patch("app.routes.definitions.client_from_auth") as mock_client_from_auth, patch(
+    with patch(
+        "app.routes.definitions.client_from_auth"
+    ) as mock_client_from_auth, patch(
         "app.routes.definitions.get_wallet_type"
     ) as mock_get_wallet_type:
         # Configure client_from_auth to return our mocked aries_controller on enter

--- a/app/tests/routes/definitions/test_get_schemas.py
+++ b/app/tests/routes/definitions/test_get_schemas.py
@@ -31,7 +31,7 @@ schema_response = [
         ({}, schema_response, Role.GOVERNANCE),
         ({}, [], Role.TENANT),
         (
-            {"schema_id": "27aG25kMFticzJ8GHH87BB:2:Test_Schema_1:0.1.0"},
+            {"schema_name": "Test_Schema_1"},
             [schema_response[0]],
             Role.TENANT,
         ),
@@ -44,7 +44,6 @@ schema_response = [
         ),
         (
             {
-                "schema_id": "27aG25kMFticzJ8GHH87BB:2:Test_Schema_1:0.1.0",
                 "schema_name": "Test_Schema_1",
                 "schema_version": "0.1.0",
             },
@@ -72,7 +71,6 @@ async def test_get_schemas_success(params, response, role):
         if role == Role.TENANT:
             mock_get_schemas_as_tenant.assert_called_once_with(
                 aries_controller=mock_aries_controller,
-                schema_id=params.get("schema_id"),
                 schema_issuer_did=params.get("schema_issuer_did"),
                 schema_name=params.get("schema_name"),
                 schema_version=params.get("schema_version"),
@@ -80,7 +78,6 @@ async def test_get_schemas_success(params, response, role):
         else:
             mock_get_schemas_as_governance.assert_called_once_with(
                 aries_controller=mock_aries_controller,
-                schema_id=params.get("schema_id"),
                 schema_issuer_did=params.get("schema_issuer_did"),
                 schema_name=params.get("schema_name"),
                 schema_version=params.get("schema_version"),

--- a/app/tests/services/definitions/schema_publisher/test_schema_publisher_anoncreds.py
+++ b/app/tests/services/definitions/schema_publisher/test_schema_publisher_anoncreds.py
@@ -1,0 +1,327 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aries_cloudcontroller import (
+    AnonCredsSchema,
+    GetSchemaResult,
+    SchemaPostRequest,
+    SchemaResult,
+    SchemaState,
+)
+
+from app.exceptions import CloudApiException
+from app.models.definitions import CredentialSchema
+from app.services.definitions.schema_publisher import SchemaPublisher
+
+# pylint: disable=redefined-outer-name
+# because re-using fixtures in same module
+# pylint: disable=protected-access
+# because we are testing protected methods
+
+
+@pytest.fixture
+def mock_logger():
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_controller():
+    return AsyncMock()
+
+
+@pytest.fixture
+def publisher(mock_controller, mock_logger) -> SchemaPublisher:
+    return SchemaPublisher(mock_controller, mock_logger)
+
+
+sample_issuer_id = "CXQseFxV34pcb8vf32XhEa"
+sample_schema_name = "test_schema"
+sample_schema_version = "1.0"
+sample_schema_id = f"{sample_issuer_id}:2:{sample_schema_name}:{sample_schema_version}"
+sample_attribute_names = ["attr1", "attr2"]
+
+sample_anoncreds_schema = AnonCredsSchema(
+    name=sample_schema_name,
+    version=sample_schema_version,
+    attr_names=sample_attribute_names,
+    issuer_id=sample_issuer_id,
+)
+
+anoncreds_schema_request = SchemaPostRequest(
+    var_schema=sample_anoncreds_schema,
+)
+anoncreds_schema_result = SchemaResult(
+    schema_state=SchemaState(
+        state="finished", schema_id=sample_schema_id, var_schema=sample_anoncreds_schema
+    ),
+)
+anoncreds_get_schema_result = GetSchemaResult(
+    schema_id=sample_schema_id,
+    var_schema=sample_anoncreds_schema,
+)
+credential_schema = CredentialSchema(
+    id=sample_schema_id,
+    name=sample_schema_name,
+    version=sample_schema_version,
+    attribute_names=sample_attribute_names,
+)
+
+
+@pytest.mark.anyio
+async def test_publish_anoncreds_schema_success(publisher):
+    final_result = credential_schema
+    with patch(
+        "app.services.definitions.schema_publisher.handle_acapy_call",
+        return_value=anoncreds_schema_result,
+    ), patch(
+        "app.services.definitions.schema_publisher.register_schema"
+    ) as mock_register_schema:
+        result = await publisher.publish_anoncreds_schema(anoncreds_schema_request)
+
+        assert result == final_result
+        mock_register_schema.assert_called_once_with(schema_id=sample_schema_id)
+
+
+@pytest.mark.anyio
+async def test_publish_anoncreds_schema_already_exists(publisher):
+    mock_schema_request = anoncreds_schema_request
+    mock_existing_schema = credential_schema
+
+    with patch(
+        "app.services.definitions.schema_publisher.handle_acapy_call",
+        side_effect=[
+            CloudApiException(detail="already exist", status_code=400),
+            mock_existing_schema,
+        ],
+    ), patch.object(
+        publisher,
+        "_handle_existing_anoncreds_schema",
+        return_value=mock_existing_schema,
+    ):
+        result = await publisher.publish_anoncreds_schema(mock_schema_request)
+
+        assert result == mock_existing_schema
+
+
+@pytest.mark.anyio
+async def test_publish_anoncreds_schema_unhandled_exception(publisher):
+    mock_schema_request = anoncreds_schema_request
+
+    with patch(
+        "app.services.definitions.schema_publisher.handle_acapy_call",
+        side_effect=CloudApiException(detail="Unhandled error", status_code=500),
+    ):
+        with pytest.raises(CloudApiException) as exc_info:
+            await publisher.publish_anoncreds_schema(mock_schema_request)
+
+        assert "Error while creating schema." in str(exc_info.value)
+
+
+@pytest.mark.anyio
+async def test_publish_anoncreds_schema_no_schema_id(publisher):
+    mock_schema_request = anoncreds_schema_request
+    mock_result = SchemaResult(
+        schema_state=SchemaState(
+            state="finished", schema_id=None, var_schema=sample_anoncreds_schema
+        ),
+    )
+
+    with patch(
+        "app.services.definitions.schema_publisher.handle_acapy_call",
+        return_value=mock_result,
+    ):
+        with pytest.raises(CloudApiException) as exc_info:
+            await publisher.publish_anoncreds_schema(mock_schema_request)
+
+        assert "An unexpected error occurred: could not publish schema." in str(
+            exc_info.value
+        )
+
+
+@pytest.mark.anyio
+async def test_handle_existing_anoncreds_schema_success(publisher):
+    mock_schema_request = anoncreds_schema_request
+    mock_pub_did = MagicMock()
+    mock_pub_did.result.did = "test_did"
+
+    mock_schema = anoncreds_get_schema_result
+    with patch(
+        "app.services.definitions.schema_publisher.handle_acapy_call",
+        side_effect=[mock_pub_did, mock_schema],
+    ), patch(
+        "app.services.definitions.schema_publisher.anoncreds_credential_schema",
+        return_value=MagicMock(spec=CredentialSchema),
+    ):
+        result = await publisher._handle_existing_anoncreds_schema(mock_schema_request)
+
+        assert isinstance(result, CredentialSchema)
+
+
+@pytest.mark.anyio
+async def test_handle_existing_anoncreds_schema_different_attributes(publisher):
+    mock_schema_request = anoncreds_schema_request
+    mock_pub_did = MagicMock()
+    mock_pub_did.result.did = "test_did"
+
+    mock_schema = GetSchemaResult(
+        schema_id=sample_schema_id,
+        var_schema=AnonCredsSchema(
+            name=sample_schema_name,
+            version=sample_schema_version,
+            attr_names=["attr1", "attr3"],
+            issuer_id=sample_issuer_id,
+        ),
+    )
+    with patch(
+        "app.services.definitions.schema_publisher.handle_acapy_call",
+        side_effect=[mock_pub_did, mock_schema],
+    ):
+        with pytest.raises(CloudApiException) as exc_info:
+            await publisher._handle_existing_anoncreds_schema(mock_schema_request)
+
+        assert "Schema already exists with different attribute names" in str(
+            exc_info.value
+        )
+
+
+@pytest.mark.anyio
+async def test_handle_existing_anoncreds_schema_changed_did(publisher):
+    mock_schema_request = anoncreds_schema_request
+    mock_pub_did = MagicMock()
+    mock_pub_did.result.did = "test_did"
+
+    mock_schema_none = GetSchemaResult(
+        var_schema=AnonCredsSchema(
+            name=sample_schema_name,
+            version=sample_schema_version,
+            attr_names=sample_attribute_names,
+            issuer_id="test_did",
+        )
+    )
+    mock_schemas_created_ids = MagicMock()
+    mock_schemas_created_ids.schema_ids = ["schema_id_1"]
+
+    mock_schema = anoncreds_schema_result
+    with patch(
+        "app.services.definitions.schema_publisher.handle_acapy_call",
+        side_effect=[
+            mock_pub_did,
+            mock_schema_none,
+            mock_schemas_created_ids,
+            mock_schema,
+        ],
+    ), patch(
+        "app.services.definitions.schema_publisher.anoncreds_credential_schema",
+        return_value=MagicMock(spec=CredentialSchema),
+    ):
+        result = await publisher._handle_existing_anoncreds_schema(mock_schema_request)
+
+        assert isinstance(result, CredentialSchema)
+
+
+@pytest.mark.anyio
+async def test_handle_existing_anoncreds_schema_no_schemas_found(publisher):
+    mock_schema_request = anoncreds_schema_request
+
+    mock_pub_did = MagicMock()
+    mock_pub_did.result.did = "test_did"
+
+    mock_schema_none = GetSchemaResult(var_schema=None)
+    mock_schemas_created_ids = MagicMock()
+    mock_schemas_created_ids.schema_ids = []
+
+    with patch(
+        "app.services.definitions.schema_publisher.handle_acapy_call",
+        side_effect=[mock_pub_did, mock_schema_none, mock_schemas_created_ids],
+    ):
+        with pytest.raises(CloudApiException) as exc_info:
+            await publisher._handle_existing_anoncreds_schema(mock_schema_request)
+
+        assert str(exc_info.value) == "500: Could not publish schema."
+        assert exc_info.value.status_code == 500
+
+
+@pytest.mark.anyio
+async def test_handle_existing_anoncreds_schema_multiple_schemas_found(publisher):
+    mock_schema_request = anoncreds_schema_request
+
+    mock_pub_did = MagicMock()
+    mock_pub_did.result.did = "test_did"
+
+    mock_schema_none = GetSchemaResult(var_schema=None)
+    mock_schemas_created_ids = MagicMock()
+    mock_schemas_created_ids.schema_ids = [
+        sample_schema_id,
+        "aeXh23fv8bp43VxFesQXC:2:test_schema:1.0",
+    ]
+    mock_schemas = [
+        GetSchemaResult(
+            schema_id=sample_schema_id,
+            var_schema=AnonCredsSchema(
+                issuer_id=sample_issuer_id,
+                name=sample_schema_name,
+                version=sample_schema_version,
+                attr_names=sample_attribute_names,
+            ),
+        ),
+        GetSchemaResult(
+            schema_id="aeXh23fv8bp43VxFesQXC:2:test_schema:1.0",
+            var_schema=AnonCredsSchema(
+                issuer_id="aeXh23fv8bp43VxFesQXC",
+                name=sample_schema_name,
+                version=sample_schema_version,
+                attr_names=["attr3", "attr4"],
+            ),
+        ),
+    ]
+    with patch(
+        "app.services.definitions.schema_publisher.handle_acapy_call",
+        side_effect=[
+            mock_pub_did,
+            mock_schema_none,
+            mock_schemas_created_ids,
+            mock_schemas[0],
+            mock_schemas[1],
+        ],
+    ):
+        with pytest.raises(CloudApiException) as exc_info:
+            await publisher._handle_existing_anoncreds_schema(mock_schema_request)
+
+        assert str(exc_info.value).startswith(
+            "409: Multiple schemas with name test_schema"
+        )
+        assert exc_info.value.status_code == 409
+
+
+@pytest.mark.anyio
+async def test_handle_existing_anoncreds_schema_new_did_one_schema_found(publisher):
+    mock_schema_request = anoncreds_schema_request
+
+    mock_pub_did = MagicMock()
+    mock_pub_did.result.did = "test_did"
+
+    mock_schema_none = GetSchemaResult(var_schema=None)
+    mock_schemas_created_ids = MagicMock()
+    mock_schemas_created_ids.schema_ids = [sample_schema_id]
+    mock_schemas = [
+        GetSchemaResult(
+            schema_id=sample_schema_id,
+            var_schema=AnonCredsSchema(
+                issuer_id=sample_issuer_id,
+                name=sample_schema_name,
+                version=sample_schema_version,
+                attr_names=sample_attribute_names,
+            ),
+        )
+    ]
+    with patch(
+        "app.services.definitions.schema_publisher.handle_acapy_call",
+        side_effect=[
+            mock_pub_did,
+            mock_schema_none,
+            mock_schemas_created_ids,
+            mock_schemas[0],
+        ],
+    ):
+        result = await publisher._handle_existing_anoncreds_schema(mock_schema_request)
+        assert result == credential_schema

--- a/app/tests/services/definitions/schemas/test_create_schemas.py
+++ b/app/tests/services/definitions/schemas/test_create_schemas.py
@@ -1,10 +1,15 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from aries_cloudcontroller import AdminConfig, SchemaSendRequest
+from aries_cloudcontroller import (
+    AdminConfig,
+    AnonCredsSchema,
+    SchemaPostRequest,
+    SchemaSendRequest,
+)
 
 from app.exceptions import CloudApiException
-from app.models.definitions import CreateSchema, CredentialSchema
+from app.models.definitions import CreateSchema, CredentialSchema, SchemaType
 from app.services.definitions.schemas import create_schema
 
 sample_schema_id = "CXQseFxV34pcb8vf32XhEa:2:test_schema:0.3.0"
@@ -91,3 +96,91 @@ async def test_create_schema_non_governance_agent():
         assert "Only governance agents are allowed to access this endpoint." in str(
             exc_info.value
         )
+
+
+@pytest.mark.anyio
+async def test_create_schema_anoncreds_success():
+    mock_aries_controller = AsyncMock()
+    mock_aries_controller.configuration.host = "https://governance-agent-url"
+    mock_aries_controller.server.get_config = AsyncMock(
+        return_value=AdminConfig(config={"wallet.type": "askar-anoncreds"})
+    )
+
+    mock_schema_publisher = AsyncMock()
+    mock_schema_publisher.publish_anoncreds_schema.return_value = CredentialSchema(
+        id=sample_schema_id,
+        name=sample_schema_name,
+        version=sample_schema_version,
+        attribute_names=sample_attribute_names,
+    )
+
+    create_schema_payload = CreateSchema(
+        name=sample_schema_name,
+        version=sample_schema_version,
+        attribute_names=sample_attribute_names,
+        schema_type=SchemaType.ANONCREDS,
+    )
+
+    with patch(
+        "app.services.definitions.schemas.GOVERNANCE_AGENT_URL",
+        "https://governance-agent-url",
+    ), patch(
+        "app.services.definitions.schemas.SchemaPublisher",
+        return_value=mock_schema_publisher,
+    ), patch(
+        "app.services.definitions.schemas.handle_model_with_validation"
+    ) as mock_handle_model:
+
+        mock_handle_model.side_effect = [
+            AnonCredsSchema(
+                name=sample_schema_name,
+                version=sample_schema_version,
+                attr_names=sample_attribute_names,
+                issuer_id="test_did",
+            ),
+            SchemaPostRequest(
+                var_schema=AnonCredsSchema(
+                    name=sample_schema_name,
+                    version=sample_schema_version,
+                    attr_names=sample_attribute_names,
+                    issuer_id="test_did",
+                )
+            ),
+        ]
+
+        result = await create_schema(mock_aries_controller, create_schema_payload)
+
+        assert isinstance(result, CredentialSchema)
+        assert result.id == sample_schema_id
+        assert result.name == sample_schema_name
+        assert result.version == sample_schema_version
+        assert result.attribute_names == sample_attribute_names
+
+        mock_schema_publisher.publish_anoncreds_schema.assert_called_once()
+        assert mock_handle_model.call_count == 2
+
+
+@pytest.mark.anyio
+async def test_create_schema_unsupported_wallet_type():
+    mock_aries_controller = AsyncMock()
+    mock_aries_controller.configuration.host = "https://governance-agent-url"
+    mock_aries_controller.server.get_config = AsyncMock(
+        return_value=AdminConfig(config={"wallet.type": "unsupported"})
+    )
+
+    create_schema_payload = CreateSchema(
+        name=sample_schema_name,
+        version=sample_schema_version,
+        attribute_names=sample_attribute_names,
+        schema_type=SchemaType.ANONCREDS,
+    )
+
+    with patch(
+        "app.services.definitions.schemas.GOVERNANCE_AGENT_URL",
+        "https://governance-agent-url",
+    ):
+        with pytest.raises(CloudApiException) as exc_info:
+            await create_schema(mock_aries_controller, create_schema_payload)
+
+        assert exc_info.value.status_code == 400
+        assert "can only be created by" in str(exc_info.value)

--- a/app/tests/services/definitions/schemas/test_create_schemas.py
+++ b/app/tests/services/definitions/schemas/test_create_schemas.py
@@ -1,7 +1,7 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from aries_cloudcontroller import SchemaSendRequest
+from aries_cloudcontroller import AdminConfig, SchemaSendRequest
 
 from app.exceptions import CloudApiException
 from app.models.definitions import CreateSchema, CredentialSchema
@@ -18,6 +18,9 @@ async def test_create_schema_success():
     # Mock the necessary dependencies
     mock_aries_controller = AsyncMock()
     mock_aries_controller.configuration.host = "https://governance-agent-url"
+    mock_aries_controller.server.get_config = AsyncMock(
+        return_value=AdminConfig(config={"wallet.type": "askar"})
+    )
 
     mock_schema_publisher = AsyncMock()
     mock_schema_publisher.publish_schema.return_value = CredentialSchema(

--- a/app/tests/services/definitions/schemas/test_get_schemas_as_governance.py
+++ b/app/tests/services/definitions/schemas/test_get_schemas_as_governance.py
@@ -7,6 +7,15 @@ from app.exceptions import CloudApiException
 from app.models.definitions import CredentialSchema
 from app.services.definitions.schemas import get_schemas_as_governance
 
+mock_schemas = [
+    CredentialSchema(
+        id="schema1", name="Test Schema 1", version="1.0", attribute_names=["attr1"]
+    ),
+    CredentialSchema(
+        id="schema2", name="Test Schema 2", version="2.0", attribute_names=["attr2"]
+    ),
+]
+
 
 @pytest.mark.anyio
 async def test_get_schemas_as_governance_success():
@@ -16,14 +25,6 @@ async def test_get_schemas_as_governance_success():
         return_value=AdminConfig(config={"wallet.type": "askar"})
     )
     mock_schema_ids = ["schema1", "schema2"]
-    mock_schemas = [
-        CredentialSchema(
-            id="schema1", name="Test Schema 1", version="1.0", attribute_names=["attr1"]
-        ),
-        CredentialSchema(
-            id="schema2", name="Test Schema 2", version="2.0", attribute_names=["attr2"]
-        ),
-    ]
 
     mock_response = MagicMock()
     mock_response.schema_ids = mock_schema_ids
@@ -70,11 +71,6 @@ async def test_get_schemas_as_governance_with_filters():
         return_value=AdminConfig(config={"wallet.type": "askar"})
     )
     mock_schema_ids = ["schema1"]
-    mock_schemas = [
-        CredentialSchema(
-            id="schema1", name="Test Schema 1", version="1.0", attribute_names=["attr1"]
-        ),
-    ]
 
     mock_response = MagicMock()
     mock_response.schema_ids = mock_schema_ids
@@ -85,7 +81,8 @@ async def test_get_schemas_as_governance_with_filters():
     ), patch(
         "app.services.definitions.schemas.handle_acapy_call", return_value=mock_response
     ), patch(
-        "app.services.definitions.schemas.get_schemas_by_id", return_value=mock_schemas
+        "app.services.definitions.schemas.get_schemas_by_id",
+        return_value=[mock_schemas[0]],
     ):
 
         result = await get_schemas_as_governance(
@@ -134,14 +131,6 @@ async def test_get_schemas_as_governance_anoncreds():
         return_value=AdminConfig(config={"wallet.type": "askar-anoncreds"})
     )
     mock_schema_ids = ["schema1", "schema2"]
-    mock_schemas = [
-        CredentialSchema(
-            id="schema1", name="Test Schema 1", version="1.0", attribute_names=["attr1"]
-        ),
-        CredentialSchema(
-            id="schema2", name="Test Schema 2", version="2.0", attribute_names=["attr2"]
-        ),
-    ]
 
     mock_response = MagicMock()
     mock_response.schema_ids = mock_schema_ids

--- a/app/tests/services/definitions/schemas/test_get_schemas_as_governance.py
+++ b/app/tests/services/definitions/schemas/test_get_schemas_as_governance.py
@@ -124,3 +124,58 @@ async def test_get_schemas_as_governance_no_schemas():
         result = await get_schemas_as_governance(mock_aries_controller)
 
         assert len(result) == 0
+
+
+@pytest.mark.anyio
+async def test_get_schemas_as_governance_anoncreds():
+    mock_aries_controller = AsyncMock()
+    mock_aries_controller.configuration.host = "https://governance-agent-url"
+    mock_aries_controller.server.get_config = AsyncMock(
+        return_value=AdminConfig(config={"wallet.type": "askar-anoncreds"})
+    )
+    mock_schema_ids = ["schema1", "schema2"]
+    mock_schemas = [
+        CredentialSchema(
+            id="schema1", name="Test Schema 1", version="1.0", attribute_names=["attr1"]
+        ),
+        CredentialSchema(
+            id="schema2", name="Test Schema 2", version="2.0", attribute_names=["attr2"]
+        ),
+    ]
+
+    mock_response = MagicMock()
+    mock_response.schema_ids = mock_schema_ids
+
+    with patch(
+        "app.services.definitions.schemas.GOVERNANCE_AGENT_URL",
+        "https://governance-agent-url",
+    ), patch(
+        "app.services.definitions.schemas.handle_acapy_call", return_value=mock_response
+    ), patch(
+        "app.services.definitions.schemas.get_schemas_by_id", return_value=mock_schemas
+    ):
+
+        result = await get_schemas_as_governance(mock_aries_controller)
+
+        assert len(result) == 2
+        assert all(isinstance(schema, CredentialSchema) for schema in result)
+        assert [schema.id for schema in result] == mock_schema_ids
+
+
+@pytest.mark.anyio
+async def test_get_schemas_as_governance_unsupported_wallet_type():
+    mock_aries_controller = AsyncMock()
+    mock_aries_controller.configuration.host = "https://governance-agent-url"
+    mock_aries_controller.server.get_config = AsyncMock(
+        return_value=AdminConfig(config={"wallet.type": "unsupported"})
+    )
+
+    with patch(
+        "app.services.definitions.schemas.GOVERNANCE_AGENT_URL",
+        "https://governance-agent-url",
+    ):
+        with pytest.raises(CloudApiException) as exc_info:
+            await get_schemas_as_governance(mock_aries_controller)
+
+        assert exc_info.value.status_code == 500
+        assert "Wallet type not supported. Cannot get schemas." in str(exc_info.value)

--- a/app/tests/services/definitions/schemas/test_get_schemas_as_governance.py
+++ b/app/tests/services/definitions/schemas/test_get_schemas_as_governance.py
@@ -1,6 +1,7 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from aries_cloudcontroller import AdminConfig
 
 from app.exceptions import CloudApiException
 from app.models.definitions import CredentialSchema
@@ -11,7 +12,9 @@ from app.services.definitions.schemas import get_schemas_as_governance
 async def test_get_schemas_as_governance_success():
     mock_aries_controller = AsyncMock()
     mock_aries_controller.configuration.host = "https://governance-agent-url"
-
+    mock_aries_controller.server.get_config = AsyncMock(
+        return_value=AdminConfig(config={"wallet.type": "askar"})
+    )
     mock_schema_ids = ["schema1", "schema2"]
     mock_schemas = [
         CredentialSchema(
@@ -63,7 +66,9 @@ async def test_get_schemas_as_governance_non_governance_agent():
 async def test_get_schemas_as_governance_with_filters():
     mock_aries_controller = AsyncMock()
     mock_aries_controller.configuration.host = "https://governance-agent-url"
-
+    mock_aries_controller.server.get_config = AsyncMock(
+        return_value=AdminConfig(config={"wallet.type": "askar"})
+    )
     mock_schema_ids = ["schema1"]
     mock_schemas = [
         CredentialSchema(
@@ -101,7 +106,9 @@ async def test_get_schemas_as_governance_with_filters():
 async def test_get_schemas_as_governance_no_schemas():
     mock_aries_controller = AsyncMock()
     mock_aries_controller.configuration.host = "https://governance-agent-url"
-
+    mock_aries_controller.server.get_config = AsyncMock(
+        return_value=AdminConfig(config={"wallet.type": "askar"})
+    )
     mock_response = MagicMock()
     mock_response.schema_ids = None
 

--- a/app/tests/services/definitions/schemas/test_get_schemas_as_governance.py
+++ b/app/tests/services/definitions/schemas/test_get_schemas_as_governance.py
@@ -87,7 +87,6 @@ async def test_get_schemas_as_governance_with_filters():
 
         result = await get_schemas_as_governance(
             mock_aries_controller,
-            schema_id="schema1",
             schema_issuer_did="did:sov:123",
             schema_name="Test Schema 1",
             schema_version="1.0",

--- a/app/tests/services/definitions/schemas/test_get_schemas_as_tenant.py
+++ b/app/tests/services/definitions/schemas/test_get_schemas_as_tenant.py
@@ -198,7 +198,10 @@ async def test_get_schemas_as_tenant_unsupported_wallet_type():
 
     with patch(
         "app.services.definitions.schemas.get_wallet_type"
-    ) as mock_get_wallet_type:
+    ) as mock_get_wallet_type, patch(
+        "app.services.definitions.schemas.get_trust_registry_schemas",
+        return_value=[],
+    ):
         mock_get_wallet_type.return_value = "unsupported"
 
         with pytest.raises(CloudApiException) as exc_info:

--- a/app/tests/services/definitions/schemas/test_get_schemas_as_tenant.py
+++ b/app/tests/services/definitions/schemas/test_get_schemas_as_tenant.py
@@ -9,7 +9,7 @@ from app.services.definitions.schemas import get_schemas_as_tenant
 
 schema_1_issuer_did = "abc123"
 schema_id_1 = f"{schema_1_issuer_did}:schema1"
-schema_id_2 = f"xyz456:schema2"
+schema_id_2 = "xyz456:schema2"
 schema_name_1 = "Test Schema 1"
 schema_name_2 = "Test Schema 2"
 schema_version_1 = "1.0"

--- a/app/tests/services/definitions/schemas/test_get_schemas_as_tenant.py
+++ b/app/tests/services/definitions/schemas/test_get_schemas_as_tenant.py
@@ -7,26 +7,40 @@ from app.exceptions import CloudApiException
 from app.models.definitions import CredentialSchema
 from app.services.definitions.schemas import get_schemas_as_tenant
 
+schema_1_issuer_did = "abc123"
+schema_id_1 = f"{schema_1_issuer_did}:schema1"
+schema_id_2 = f"xyz456:schema2"
+schema_name_1 = "Test Schema 1"
+schema_name_2 = "Test Schema 2"
+schema_version_1 = "1.0"
+schema_version_2 = "2.0"
+
+mock_schemas = [
+    CredentialSchema(
+        id=schema_id_1,
+        name=schema_name_1,
+        version=schema_version_1,
+        attribute_names=["attr1"],
+    ),
+    CredentialSchema(
+        id=schema_id_2,
+        name=schema_name_2,
+        version=schema_version_2,
+        attribute_names=["attr2"],
+    ),
+]
+
 
 @pytest.mark.anyio
 async def test_get_schemas_as_tenant_all():
     mock_aries_controller = AsyncMock(spec=AcaPyClient)
 
-    mock_trust_registry_schemas = [
-        CredentialSchema(
-            id="schema1", name="Test Schema 1", version="1.0", attribute_names=["attr1"]
-        ),
-        CredentialSchema(
-            id="schema2", name="Test Schema 2", version="2.0", attribute_names=["attr2"]
-        ),
-    ]
-
     with patch(
         "app.services.definitions.schemas.get_trust_registry_schemas",
-        return_value=mock_trust_registry_schemas,
+        return_value=mock_schemas,
     ), patch(
         "app.services.definitions.schemas.get_schemas_by_id",
-        return_value=mock_trust_registry_schemas,
+        return_value=mock_schemas,
     ), patch(
         "app.services.definitions.schemas.get_wallet_type"
     ) as mock_get_wallet_type:
@@ -35,17 +49,14 @@ async def test_get_schemas_as_tenant_all():
 
         assert len(result) == 2
         assert all(isinstance(schema, CredentialSchema) for schema in result)
-        assert [schema.id for schema in result] == ["schema1", "schema2"]
+        assert [schema.id for schema in result] == [schema_id_1, schema_id_2]
 
 
 @pytest.mark.anyio
 async def test_get_schemas_as_tenant_by_id():
     mock_aries_controller = AsyncMock(spec=AcaPyClient)
 
-    mock_schema = CredentialSchema(
-        id="schema1", name="Test Schema", version="1.0", attribute_names=["attr1"]
-    )
-
+    mock_schema = mock_schemas[0]
     with patch(
         "app.services.definitions.schemas.get_trust_registry_schema_by_id",
         return_value=mock_schema,
@@ -56,32 +67,19 @@ async def test_get_schemas_as_tenant_by_id():
     ) as mock_get_wallet_type:
         mock_get_wallet_type.return_value = "askar"
 
-        result = await get_schemas_as_tenant(mock_aries_controller, schema_id="schema1")
+        result = await get_schemas_as_tenant(
+            mock_aries_controller, schema_id=schema_id_1
+        )
 
         assert len(result) == 1
         assert isinstance(result[0], CredentialSchema)
-        assert result[0].id == "schema1"
+        assert result[0].id == schema_id_1
 
 
 @pytest.mark.anyio
 async def test_get_schemas_as_tenant_filter_issuer_did():
     mock_aries_controller = AsyncMock(spec=AcaPyClient)
 
-    mock_schemas = [
-        CredentialSchema(
-            id="abc123:schema1",
-            name="Test Schema 1",
-            version="1.0",
-            attribute_names=["attr1"],
-        ),
-        CredentialSchema(
-            id="xyz456:schema2",
-            name="Test Schema 2",
-            version="2.0",
-            attribute_names=["attr2"],
-        ),
-    ]
-
     with patch(
         "app.services.definitions.schemas.get_trust_registry_schemas",
         return_value=mock_schemas,
@@ -93,26 +91,17 @@ async def test_get_schemas_as_tenant_filter_issuer_did():
         mock_get_wallet_type.return_value = "askar"
 
         result = await get_schemas_as_tenant(
-            mock_aries_controller, schema_issuer_did="abc123"
+            mock_aries_controller, schema_issuer_did=schema_1_issuer_did
         )
 
         assert len(result) == 1
-        assert result[0].id == "abc123:schema1"
+        assert result[0].id == schema_id_1
 
 
 @pytest.mark.anyio
 async def test_get_schemas_as_tenant_filter_name():
     mock_aries_controller = AsyncMock(spec=AcaPyClient)
 
-    mock_schemas = [
-        CredentialSchema(
-            id="schema1", name="Test Schema 1", version="1.0", attribute_names=["attr1"]
-        ),
-        CredentialSchema(
-            id="schema2", name="Test Schema 2", version="2.0", attribute_names=["attr2"]
-        ),
-    ]
-
     with patch(
         "app.services.definitions.schemas.get_trust_registry_schemas",
         return_value=mock_schemas,
@@ -124,26 +113,17 @@ async def test_get_schemas_as_tenant_filter_name():
         mock_get_wallet_type.return_value = "askar"
 
         result = await get_schemas_as_tenant(
-            mock_aries_controller, schema_name="Test Schema 1"
+            mock_aries_controller, schema_name=schema_name_1
         )
 
         assert len(result) == 1
-        assert result[0].name == "Test Schema 1"
+        assert result[0].name == schema_name_1
 
 
 @pytest.mark.anyio
 async def test_get_schemas_as_tenant_filter_version():
     mock_aries_controller = AsyncMock(spec=AcaPyClient)
 
-    mock_schemas = [
-        CredentialSchema(
-            id="schema1", name="Test Schema 1", version="1.0", attribute_names=["attr1"]
-        ),
-        CredentialSchema(
-            id="schema2", name="Test Schema 2", version="2.0", attribute_names=["attr2"]
-        ),
-    ]
-
     with patch(
         "app.services.definitions.schemas.get_trust_registry_schemas",
         return_value=mock_schemas,
@@ -155,32 +135,23 @@ async def test_get_schemas_as_tenant_filter_version():
         mock_get_wallet_type.return_value = "askar"
 
         result = await get_schemas_as_tenant(
-            mock_aries_controller, schema_version="2.0"
+            mock_aries_controller, schema_version=schema_version_2
         )
 
         assert len(result) == 1
-        assert result[0].version == "2.0"
+        assert result[0].version == schema_version_2
 
 
 @pytest.mark.anyio
 async def test_get_schemas_as_tenant_anoncreds():
     mock_aries_controller = AsyncMock(spec=AcaPyClient)
 
-    mock_trust_registry_schemas = [
-        CredentialSchema(
-            id="schema1", name="Test Schema 1", version="1.0", attribute_names=["attr1"]
-        ),
-        CredentialSchema(
-            id="schema2", name="Test Schema 2", version="2.0", attribute_names=["attr2"]
-        ),
-    ]
-
     with patch(
         "app.services.definitions.schemas.get_trust_registry_schemas",
-        return_value=mock_trust_registry_schemas,
+        return_value=mock_schemas,
     ), patch(
         "app.services.definitions.schemas.get_schemas_by_id",
-        return_value=mock_trust_registry_schemas,
+        return_value=mock_schemas,
     ), patch(
         "app.services.definitions.schemas.get_wallet_type"
     ) as mock_get_wallet_type:
@@ -189,7 +160,7 @@ async def test_get_schemas_as_tenant_anoncreds():
 
         assert len(result) == 2
         assert all(isinstance(schema, CredentialSchema) for schema in result)
-        assert [schema.id for schema in result] == ["schema1", "schema2"]
+        assert [schema.id for schema in result] == [schema_id_1, schema_id_2]
 
 
 @pytest.mark.anyio

--- a/app/tests/services/definitions/schemas/test_get_schemas_as_tenant.py
+++ b/app/tests/services/definitions/schemas/test_get_schemas_as_tenant.py
@@ -26,8 +26,10 @@ async def test_get_schemas_as_tenant_all():
     ), patch(
         "app.services.definitions.schemas.get_schemas_by_id",
         return_value=mock_trust_registry_schemas,
-    ):
-
+    ), patch(
+        "app.services.definitions.schemas.get_wallet_type"
+    ) as mock_get_wallet_type:
+        mock_get_wallet_type.return_value = "askar"
         result = await get_schemas_as_tenant(mock_aries_controller)
 
         assert len(result) == 2
@@ -48,7 +50,10 @@ async def test_get_schemas_as_tenant_by_id():
         return_value=mock_schema,
     ), patch(
         "app.services.definitions.schemas.get_schemas_by_id", return_value=[mock_schema]
-    ):
+    ), patch(
+        "app.services.definitions.schemas.get_wallet_type"
+    ) as mock_get_wallet_type:
+        mock_get_wallet_type.return_value = "askar"
 
         result = await get_schemas_as_tenant(mock_aries_controller, schema_id="schema1")
 
@@ -81,7 +86,10 @@ async def test_get_schemas_as_tenant_filter_issuer_did():
         return_value=mock_schemas,
     ), patch(
         "app.services.definitions.schemas.get_schemas_by_id", return_value=mock_schemas
-    ):
+    ), patch(
+        "app.services.definitions.schemas.get_wallet_type"
+    ) as mock_get_wallet_type:
+        mock_get_wallet_type.return_value = "askar"
 
         result = await get_schemas_as_tenant(
             mock_aries_controller, schema_issuer_did="abc123"
@@ -109,7 +117,10 @@ async def test_get_schemas_as_tenant_filter_name():
         return_value=mock_schemas,
     ), patch(
         "app.services.definitions.schemas.get_schemas_by_id", return_value=mock_schemas
-    ):
+    ), patch(
+        "app.services.definitions.schemas.get_wallet_type"
+    ) as mock_get_wallet_type:
+        mock_get_wallet_type.return_value = "askar"
 
         result = await get_schemas_as_tenant(
             mock_aries_controller, schema_name="Test Schema 1"
@@ -137,7 +148,10 @@ async def test_get_schemas_as_tenant_filter_version():
         return_value=mock_schemas,
     ), patch(
         "app.services.definitions.schemas.get_schemas_by_id", return_value=mock_schemas
-    ):
+    ), patch(
+        "app.services.definitions.schemas.get_wallet_type"
+    ) as mock_get_wallet_type:
+        mock_get_wallet_type.return_value = "askar"
 
         result = await get_schemas_as_tenant(
             mock_aries_controller, schema_version="2.0"

--- a/app/tests/services/definitions/schemas/test_get_schemas_as_tenant.py
+++ b/app/tests/services/definitions/schemas/test_get_schemas_as_tenant.py
@@ -68,7 +68,7 @@ async def test_get_schemas_as_tenant_by_id():
         mock_get_wallet_type.return_value = "askar"
 
         result = await get_schemas_as_tenant(
-            mock_aries_controller, schema_id=schema_id_1
+            mock_aries_controller, schema_name=schema_name_1
         )
 
         assert len(result) == 1

--- a/app/tests/services/definitions/schemas/test_get_schemas_as_tenant.py
+++ b/app/tests/services/definitions/schemas/test_get_schemas_as_tenant.py
@@ -58,8 +58,8 @@ async def test_get_schemas_as_tenant_by_id():
 
     mock_schema = mock_schemas[0]
     with patch(
-        "app.services.definitions.schemas.get_trust_registry_schema_by_id",
-        return_value=mock_schema,
+        "app.services.definitions.schemas.get_trust_registry_schemas",
+        return_value=[mock_schema],
     ), patch(
         "app.services.definitions.schemas.get_schemas_by_id", return_value=[mock_schema]
     ), patch(

--- a/app/tests/services/definitions/schemas/test_get_schemas_by_id.py
+++ b/app/tests/services/definitions/schemas/test_get_schemas_by_id.py
@@ -49,7 +49,9 @@ async def test_get_schemas_by_id_success():
         ),
     ):
 
-        result = await get_schemas_by_id(mock_aries_controller, mock_schema_ids, "askar")
+        result = await get_schemas_by_id(
+            mock_aries_controller, mock_schema_ids, "askar"
+        )
 
         assert len(result) == 2
         assert all(isinstance(schema, CredentialSchema) for schema in result)

--- a/app/tests/services/definitions/schemas/test_get_schemas_by_id.py
+++ b/app/tests/services/definitions/schemas/test_get_schemas_by_id.py
@@ -49,7 +49,7 @@ async def test_get_schemas_by_id_success():
         ),
     ):
 
-        result = await get_schemas_by_id(mock_aries_controller, mock_schema_ids)
+        result = await get_schemas_by_id(mock_aries_controller, mock_schema_ids, "askar")
 
         assert len(result) == 2
         assert all(isinstance(schema, CredentialSchema) for schema in result)
@@ -69,7 +69,7 @@ async def test_get_schemas_by_id_success():
 async def test_get_schemas_by_id_empty_list():
     mock_aries_controller = AsyncMock(spec=AcaPyClient)
 
-    result = await get_schemas_by_id(mock_aries_controller, [])
+    result = await get_schemas_by_id(mock_aries_controller, [], "askar")
 
     assert len(result) == 0
 
@@ -85,6 +85,6 @@ async def test_get_schemas_by_id_error_handling():
         side_effect=Exception("Test error"),
     ):
         with pytest.raises(Exception) as exc_info:
-            await get_schemas_by_id(mock_aries_controller, mock_schema_ids)
+            await get_schemas_by_id(mock_aries_controller, mock_schema_ids, "askar")
 
         assert str(exc_info.value) == "Test error"

--- a/app/tests/services/definitions/schemas/test_get_schemas_by_id.py
+++ b/app/tests/services/definitions/schemas/test_get_schemas_by_id.py
@@ -1,8 +1,15 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from aries_cloudcontroller import AcaPyClient, ModelSchema, SchemaGetResult
+from aries_cloudcontroller import (
+    AcaPyClient,
+    AnonCredsSchema,
+    GetSchemaResult,
+    ModelSchema,
+    SchemaGetResult,
+)
 
+from app.exceptions import CloudApiException
 from app.models.definitions import CredentialSchema
 from app.services.definitions.schemas import get_schemas_by_id
 
@@ -90,3 +97,87 @@ async def test_get_schemas_by_id_error_handling():
             await get_schemas_by_id(mock_aries_controller, mock_schema_ids, "askar")
 
         assert str(exc_info.value) == "Test error"
+
+
+@pytest.mark.anyio
+async def test_get_schemas_by_id_anoncreds_success():
+    mock_aries_controller = AsyncMock()
+    mock_schema_ids = [schema_id_1, schema_id_2]
+    mock_schema_results = [
+        GetSchemaResult(
+            schema_id=schema_id_1,
+            var_schema=AnonCredsSchema(
+                name=schema_name_1,
+                version=schema_version_1,
+                attr_names=attribute_names_1,
+                issuer_id="test_did",
+            ),
+        ),
+        GetSchemaResult(
+            schema_id=schema_id_2,
+            var_schema=AnonCredsSchema(
+                name=schema_name_2,
+                version=schema_version_2,
+                attr_names=attribute_names_2,
+                issuer_id="test_did",
+            ),
+        ),
+    ]
+
+    with patch(
+        "app.services.definitions.schemas.handle_acapy_call",
+        side_effect=mock_schema_results,
+    ), patch(
+        "app.services.definitions.schemas.anoncreds_schema_from_acapy",
+        side_effect=lambda x: CredentialSchema(
+            id=x.schema_id,
+            name=x.var_schema.name,
+            version=x.var_schema.version,
+            attribute_names=x.var_schema.attr_names,
+        ),
+    ):
+
+        result = await get_schemas_by_id(
+            mock_aries_controller, mock_schema_ids, "askar-anoncreds"
+        )
+
+        assert len(result) == 2
+        assert all(isinstance(schema, CredentialSchema) for schema in result)
+        assert [schema.id for schema in result] == mock_schema_ids
+        assert [schema.name for schema in result] == [schema_name_1, schema_name_2]
+        assert [schema.version for schema in result] == [
+            schema_version_1,
+            schema_version_2,
+        ]
+        assert [schema.attribute_names for schema in result] == [
+            attribute_names_1,
+            attribute_names_2,
+        ]
+
+
+@pytest.mark.anyio
+async def test_get_schemas_by_id_unsupported_wallet_type():
+    mock_aries_controller = AsyncMock()
+    mock_schema_ids = [schema_id_1, schema_id_2]
+
+    with pytest.raises(CloudApiException) as exc_info:
+        await get_schemas_by_id(mock_aries_controller, mock_schema_ids, "unsupported")
+
+    assert exc_info.value.status_code == 500
+    assert "Wallet type not supported. Cannot get schemas." in str(exc_info.value)
+
+
+@pytest.mark.anyio
+async def test_get_schemas_by_id_no_schemas_returned():
+    mock_aries_controller = AsyncMock()
+    mock_schema_ids = []
+
+    with patch(
+        "app.services.definitions.schemas.handle_acapy_call",
+        return_value=None,
+    ):
+        result = await get_schemas_by_id(
+            mock_aries_controller, mock_schema_ids, "askar-anoncreds"
+        )
+
+        assert len(result) == 0

--- a/app/util/definitions.py
+++ b/app/util/definitions.py
@@ -1,15 +1,33 @@
 from aries_cloudcontroller import CredentialDefinition as AcaPyCredentialDefinition
-from aries_cloudcontroller import GetSchemaResult, SchemaState
+from aries_cloudcontroller import GetSchemaResult, ModelSchema, SchemaState
 
 from app.models.definitions import CredentialDefinition, CredentialSchema
 
 
-def credential_schema_from_acapy(schema: SchemaState):
+def credential_anon_schema_from_acapy(schema: SchemaState):
     return CredentialSchema(
         id=schema.schema_id,
         name=schema.var_schema.name,
         version=schema.var_schema.version,
         attribute_names=schema.var_schema.attr_names,
+    )
+
+
+def credential_schema_from_acapy(schema: ModelSchema):
+    return CredentialSchema(
+        id=schema.id,
+        name=schema.name,
+        version=schema.version,
+        attribute_names=schema.attr_names,
+    )
+
+
+def anon_schema_from_acapy(schema: GetSchemaResult):
+    return CredentialSchema(
+        id=schema.schema_id,
+        attribute_names=schema.var_schema.attr_names,
+        name=schema.var_schema.name,
+        version=schema.var_schema.version,
     )
 
 
@@ -18,13 +36,4 @@ def credential_definition_from_acapy(credential_definition: AcaPyCredentialDefin
         id=credential_definition.id,
         tag=credential_definition.tag,
         schema_id=credential_definition.schema_id,
-    )
-
-
-def schema_from_acapy(schema: GetSchemaResult):
-    return CredentialSchema(
-        id=schema.schema_id,
-        attribute_names=schema.var_schema.attr_names,
-        name=schema.var_schema.name,
-        version=schema.var_schema.version,
     )

--- a/app/util/definitions.py
+++ b/app/util/definitions.py
@@ -4,7 +4,7 @@ from aries_cloudcontroller import GetSchemaResult, ModelSchema, SchemaState
 from app.models.definitions import CredentialDefinition, CredentialSchema
 
 
-def credential_anon_schema_from_acapy(schema: SchemaState):
+def anoncreds_credential_schema(schema: SchemaState):
     return CredentialSchema(
         id=schema.schema_id,
         name=schema.var_schema.name,
@@ -22,7 +22,7 @@ def credential_schema_from_acapy(schema: ModelSchema):
     )
 
 
-def anon_schema_from_acapy(schema: GetSchemaResult):
+def anoncreds_schema_from_acapy(schema: GetSchemaResult):
     return CredentialSchema(
         id=schema.schema_id,
         attribute_names=schema.var_schema.attr_names,

--- a/app/util/tenants.py
+++ b/app/util/tenants.py
@@ -124,24 +124,26 @@ def assert_valid_group(
     logger.debug("Wallet {} belongs to group {}.", wallet_id, group_id)
 
 
-async def is_anoncreds_wallet(wallet_id: str, logger: Logger) -> bool:
-    """Check if the wallet with wallet_id is an anoncreds wallet.
+async def is_anoncreds_wallet(aries_controller: AcaPyClient, logger: Logger) -> bool:
+    """Check if the aries_controller has an anoncreds wallet.
     Args:
-        wallet_id (str): The wallet_id we want to check.
+        aries_controller (AcaPyClient): The wallet controller to check.
         logger (Logger): A logger object.
 
     Returns:
         bool: True if wallet is anoncreds wallet, False otherwise.
     """
+    controller_token = aries_controller.tenant_jwt.split(".")[1]
+    controller_wallet_id = get_wallet_id_from_b64encoded_jwt(controller_token)
     async with get_tenant_admin_controller() as admin_controller:
         wallet = await handle_acapy_call(
             acapy_call=admin_controller.multitenancy.get_wallet,
-            wallet_id=wallet_id,
+            wallet_id=controller_wallet_id,
             logger=logger,
         )
         if not wallet:
             logger.info("Bad request: Wallet not found.")
-            raise WalletNotFoundException(wallet_id=wallet_id)
+            raise WalletNotFoundException(wallet_id=controller_wallet_id)
 
         wallet_type = wallet.settings.get("wallet.type")
         return wallet_type == "askar-anoncreds"

--- a/app/util/tenants.py
+++ b/app/util/tenants.py
@@ -6,9 +6,8 @@ from typing import Optional
 from aries_cloudcontroller import AcaPyClient, WalletRecordWithGroups
 from fastapi import HTTPException
 
-from app.exceptions import CloudApiException
 from app.dependencies.acapy_clients import get_tenant_admin_controller
-from app.exceptions import handle_acapy_call
+from app.exceptions import CloudApiException, handle_acapy_call
 from app.models.tenants import Tenant
 
 


### PR DESCRIPTION
Add anoncreds schema support

:boom: Removes `schema_id` query parameter from "get_schemas" endpoint (`GET /schemas`) -- since there is already a dedicated endpoint for fetching by schema_id (`GET /schemas/{schema_id}`) -- and the query param was supported in acapy for fetching indy schemas, but no longer for anoncreds schemas, so we adapt and remove it.