### PR TITLE
:technologist: 🛡️ Improve stability of Ledger Nodes

### DIFF
--- a/helm/acapy-cloud/conf/dev/ledger-browser.yaml
+++ b/helm/acapy-cloud/conf/dev/ledger-browser.yaml
@@ -56,13 +56,15 @@ command:
 
 livenessProbe:
   httpGet:
-    path: /status/text
+    path: /status
     port: "{{ trunc 15 .Release.Name }}"
   timeoutSeconds: 10
 readinessProbe:
   httpGet:
-    path: /status/text
+    path: /status
     port: "{{ trunc 15 .Release.Name }}"
+
+terminationGracePeriodSeconds: 10
 
 # resources:
 #   requests:

--- a/helm/acapy-cloud/conf/local/ledger-browser.yaml
+++ b/helm/acapy-cloud/conf/local/ledger-browser.yaml
@@ -56,13 +56,15 @@ command:
 
 livenessProbe:
   httpGet:
-    path: /status/text
+    path: /status
     port: "{{ trunc 15 .Release.Name }}"
   timeoutSeconds: 10
 readinessProbe:
   httpGet:
-    path: /status/text
+    path: /status
     port: "{{ trunc 15 .Release.Name }}"
+
+terminationGracePeriodSeconds: 10
 
 # resources:
 #   requests:

--- a/helm/ledger-nodes/values.yaml
+++ b/helm/ledger-nodes/values.yaml
@@ -78,6 +78,10 @@ livenessProbe:
       if ! grep -q '"Has_write_consensus": true' "$INFO_FILE"; then
         echo "Error: No write consensus"
         exit 1
+      fi &&
+      if ! (timeout 1 bash -c "</dev/tcp/localhost/9701" 2>/dev/null); then
+        echo "Error: Port 9701 is not open"
+        exit 1
       fi
   initialDelaySeconds: 60
   periodSeconds: 10


### PR DESCRIPTION
Sometimes, after a spot reclaim event, 3/4 of the Ledger Nodes will
successfully recover, however, 1/4 of them will be stuck in a recovering
state.
Added a TCP Port check to the liveness probe to restart the pod if it
gets stuck in a recovering state.