### PR TITLE
:technologist: Fix Ledger Browser Health Probes

### DIFF
--- a/helm/acapy-cloud/conf/dev/ledger-browser.yaml
+++ b/helm/acapy-cloud/conf/dev/ledger-browser.yaml
@@ -61,7 +61,7 @@ livenessProbe:
   timeoutSeconds: 10
 readinessProbe:
   httpGet:
-    path: /status
+    path: /status/text
     port: "{{ trunc 15 .Release.Name }}"
 
 terminationGracePeriodSeconds: 10

--- a/helm/acapy-cloud/conf/local/ledger-browser.yaml
+++ b/helm/acapy-cloud/conf/local/ledger-browser.yaml
@@ -61,7 +61,7 @@ livenessProbe:
   timeoutSeconds: 10
 readinessProbe:
   httpGet:
-    path: /status
+    path: /status/text
     port: "{{ trunc 15 .Release.Name }}"
 
 terminationGracePeriodSeconds: 10


### PR DESCRIPTION
* Readiness - should this container receive traffic?
  * `/status` -> `/status/text`
  * Actually checks if Ledger Browser can talk to Nodes
* Liveness - should this container be restarted?
  * `/status`
  * Just checks if Ledger Browser Web Service is running