### PR TITLE
:technologist: :ambulance: Fix Init Containers

### DIFF
--- a/helm/acapy-cloud/conf/dev/governance-web.yaml
+++ b/helm/acapy-cloud/conf/dev/governance-web.yaml
@@ -85,7 +85,7 @@ initContainers:
       - sh
       - -c
       - |
-        until curl -s http://governance-agent:3020 -o /dev/null; do
+        until curl -s {{ .Values.env.ACAPY_GOVERNANCE_AGENT_URL }} -o /dev/null; do
           echo "waiting for governance-agent to be healthy"
           sleep 2
         done

--- a/helm/acapy-cloud/conf/dev/mediator.yaml
+++ b/helm/acapy-cloud/conf/dev/mediator.yaml
@@ -135,7 +135,7 @@ initContainers:
       - sh
       - -c
       - |
-        until curl -s http://governance-agent:3020 -o /dev/null; do
+        until curl -s http://governance-agent:3021 -o /dev/null; do
           echo "waiting for governance-agent to be healthy"
           sleep 2
         done
@@ -145,7 +145,7 @@ initContainers:
       - sh
       - -c
       - |
-        until curl -s http://multitenant-agent:3020; do
+        until curl -s http://multitenant-agent:3021 -o /dev/null; do
           echo "waiting for multitenant-agent to be healthy"
           sleep 2
         done

--- a/helm/acapy-cloud/conf/dev/multitenant-web.yaml
+++ b/helm/acapy-cloud/conf/dev/multitenant-web.yaml
@@ -85,7 +85,7 @@ initContainers:
       - sh
       - -c
       - |
-        until curl -s http://multitenant-agent:3020; do
+        until curl -s {{ .Values.env.ACAPY_TENANT_AGENT_URL }} -o /dev/null; do
           echo "waiting for multitenant-agent to be healthy"
           sleep 2
         done

--- a/helm/acapy-cloud/conf/dev/public-web.yaml
+++ b/helm/acapy-cloud/conf/dev/public-web.yaml
@@ -85,7 +85,7 @@ initContainers:
       - sh
       - -c
       - |
-        until curl -s http://governance-agent:3020 -o /dev/null; do
+        until curl -s http://governance-agent:3021 -o /dev/null; do
           echo "waiting for governance-agent to be healthy"
           sleep 2
         done
@@ -95,7 +95,7 @@ initContainers:
       - sh
       - -c
       - |
-        until curl -s http://multitenant-agent:3020; do
+        until curl -s http://multitenant-agent:3021 -o /dev/null; do
           echo "waiting for multitenant-agent to be healthy"
           sleep 2
         done

--- a/helm/acapy-cloud/conf/dev/tenant-web.yaml
+++ b/helm/acapy-cloud/conf/dev/tenant-web.yaml
@@ -93,7 +93,7 @@ initContainers:
       - sh
       - -c
       - |
-        until curl -s http://governance-agent:3020 -o /dev/null; do
+        until curl -s {{ .Values.env.ACAPY_GOVERNANCE_AGENT_URL }} -o /dev/null; do
           echo "waiting for governance-agent to be healthy"
           sleep 2
         done
@@ -103,7 +103,7 @@ initContainers:
       - sh
       - -c
       - |
-        until curl -s http://multitenant-agent:3020; do
+        until curl -s {{ .Values.env.ACAPY_TENANT_AGENT_URL }} -o /dev/null; do
           echo "waiting for multitenant-agent to be healthy"
           sleep 2
         done

--- a/helm/acapy-cloud/conf/local/governance-web.yaml
+++ b/helm/acapy-cloud/conf/local/governance-web.yaml
@@ -75,7 +75,7 @@ initContainers:
       - sh
       - -c
       - |
-        until curl -s http://governance-agent:3020 -o /dev/null; do
+        until curl -s {{ .Values.env.ACAPY_GOVERNANCE_AGENT_URL }} -o /dev/null; do
           echo "waiting for governance-agent to be healthy"
           sleep 2
         done

--- a/helm/acapy-cloud/conf/local/mediator.yaml
+++ b/helm/acapy-cloud/conf/local/mediator.yaml
@@ -126,7 +126,7 @@ initContainers:
       - sh
       - -c
       - |
-        until curl -s http://governance-agent:3020 -o /dev/null; do
+        until curl -s http://governance-agent:3021 -o /dev/null; do
           echo "waiting for governance-agent to be healthy"
           sleep 2
         done
@@ -136,7 +136,7 @@ initContainers:
       - sh
       - -c
       - |
-        until curl -s http://multitenant-agent:3020; do
+        until curl -s http://multitenant-agent:3021 -o /dev/null; do
           echo "waiting for multitenant-agent to be healthy"
           sleep 2
         done

--- a/helm/acapy-cloud/conf/local/multitenant-web.yaml
+++ b/helm/acapy-cloud/conf/local/multitenant-web.yaml
@@ -75,7 +75,7 @@ initContainers:
       - sh
       - -c
       - |
-        until curl -s http://governance-agent:3020 -o /dev/null; do
+        until curl -s {{ .Values.env.ACAPY_GOVERNANCE_AGENT_URL }} -o /dev/null; do
           echo "waiting for governance-agent to be healthy"
           sleep 2
         done

--- a/helm/acapy-cloud/conf/local/public-web.yaml
+++ b/helm/acapy-cloud/conf/local/public-web.yaml
@@ -75,7 +75,7 @@ initContainers:
       - sh
       - -c
       - |
-        until curl -s http://governance-agent:3020 -o /dev/null; do
+        until curl -s http://governance-agent:3021 -o /dev/null; do
           echo "waiting for governance-agent to be healthy"
           sleep 2
         done
@@ -85,7 +85,7 @@ initContainers:
       - sh
       - -c
       - |
-        until curl -s http://multitenant-agent:3020; do
+        until curl -s http://multitenant-agent:3021 -o /dev/null; do
           echo "waiting for multitenant-agent to be healthy"
           sleep 2
         done

--- a/helm/acapy-cloud/conf/local/tenant-web.yaml
+++ b/helm/acapy-cloud/conf/local/tenant-web.yaml
@@ -79,7 +79,7 @@ initContainers:
       - sh
       - -c
       - |
-        until curl -s http://governance-agent:3020 -o /dev/null; do
+        until curl -s {{ .Values.env.ACAPY_GOVERNANCE_AGENT_URL }} -o /dev/null; do
           echo "waiting for governance-agent to be healthy"
           sleep 2
         done
@@ -89,7 +89,7 @@ initContainers:
       - sh
       - -c
       - |
-        until curl -s http://multitenant-agent:3020; do
+        until curl -s {{ .Values.env.ACAPY_TENANT_AGENT_URL }} -o /dev/null; do
           echo "waiting for multitenant-agent to be healthy"
           sleep 2
         done


### PR DESCRIPTION
* For some reason `3020` (DIDComm) is always up even if Agents are down
* Switch to using `3021` (Admin HTTP) instead in Init Containers
* Also use templating where possible to keep things consistent