### PR TITLE
:construction_worker: Don't evict test pods

### DIFF
--- a/helm/acapy-test/values.yaml
+++ b/helm/acapy-test/values.yaml
@@ -14,7 +14,8 @@ imagePullSecrets: []
 labels: {}
 podLabels:
   sidecar.istio.io/inject: "false"
-podAnnotations: {}
+podAnnotations:
+  cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
 
 # This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
 serviceAccount:


### PR DESCRIPTION
* Prevent EKS Cluster Autoscaler from evicting tests