### PR TITLE
:sparkles: Allow anoncreds issuers to create schemas

### DIFF
--- a/app/routes/definitions.py
+++ b/app/routes/definitions.py
@@ -85,6 +85,7 @@ async def create_schema(
         )
         raise CloudApiException("Unauthorized", 403)
 
+    public_did = None
     if schema.schema_type == SchemaType.ANONCREDS:
         # Assert request is from valid issuer, with anoncreds wallet type
         async with client_from_auth(auth) as aries_controller:
@@ -107,6 +108,7 @@ async def create_schema(
         schema_response = await schemas_service.create_schema(
             aries_controller=aries_controller,
             schema=schema,
+            public_did=public_did,
         )
     return schema_response
 

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -44,6 +44,7 @@ from shared.util.mock_agent_controller import (
     mock_context_managed_controller,
     mock_governance_auth,
     mock_tenant_auth,
+    mock_tenant_auth_verified,
 )
 
 # Unused imports make pytest fixtures visible to tests within this module

--- a/app/tests/routes/definitions/test_create_schema.py
+++ b/app/tests/routes/definitions/test_create_schema.py
@@ -66,11 +66,12 @@ async def test_create_schema_success(
 
         # Mock the assertion of public DID and wallet type
         if schema_type == "anoncreds":
+            public_did = "public_did"
             # Assert wallet_type checks
             for wallet_type in ["askar-anoncreds", "askar"]:
                 with patch(
                     "app.util.valid_issuer.assert_issuer_public_did",
-                    return_value="public_did",
+                    return_value=public_did,
                 ), patch(
                     "app.util.valid_issuer.get_wallet_type",
                     return_value=wallet_type,
@@ -91,6 +92,7 @@ async def test_create_schema_success(
                             )
                         assert exc.value.status_code == 403
         else:
+            public_did = None
             # Indy request fails with tenant auth
             with pytest.raises(CloudApiException, match="Unauthorized") as exc:
                 await create_schema(schema=request_body, auth=mock_tenant_auth_verified)
@@ -104,6 +106,7 @@ async def test_create_schema_success(
         mock_create_schema_service.assert_called_once_with(
             aries_controller=mock_aries_controller,
             schema=request_body,
+            public_did=public_did,
         )
 
         assert response == create_schema_response
@@ -154,4 +157,5 @@ async def test_create_schema_failure(
         mock_create_schema_service.assert_called_once_with(
             aries_controller=mock_aries_controller,
             schema=create_anoncreds_schema_body,
+            public_did="public_did",
         )

--- a/shared/util/mock_agent_controller.py
+++ b/shared/util/mock_agent_controller.py
@@ -65,7 +65,7 @@ def mock_context_managed_controller():
 
 
 @pytest.fixture(scope="session")
-def mock_governance_auth():
+def mock_governance_auth() -> AcaPyAuthVerified:
     auth = mock(AcaPyAuthVerified)
     auth.role = Role.GOVERNANCE
     auth.token = GOVERNANCE_AGENT_API_KEY
@@ -83,8 +83,17 @@ def mock_admin_auth() -> AcaPyAuthVerified:
 
 
 @pytest.fixture
-def mock_tenant_auth():
+def mock_tenant_auth() -> AcaPyAuth:
     auth = mock(AcaPyAuth)
     auth.role = Role.TENANT
     auth.token = "tenant.test_token"
+    return auth
+
+
+@pytest.fixture
+def mock_tenant_auth_verified() -> AcaPyAuthVerified:
+    auth = mock(AcaPyAuthVerified)
+    auth.role = Role.TENANT
+    auth.token = "tenant.test_token"
+    auth.wallet_id = "tenant_wallet_id"
     return auth


### PR DESCRIPTION
Temporarily removes the restriction that only governance can create schemas.

This is to accommodate for the fact that we want to test both indy and anoncreds for the time being, and we cannot configure governance to be able to create both. So, we will allow anoncreds issuers to create schemas, until indy support is dropped.

- Removes duplicate auth from schema service
- Updates tests