### PR TITLE
:sparkles: Wait for anoncreds schema endorsement

### DIFF
--- a/app/tests/fixtures/definitions.py
+++ b/app/tests/fixtures/definitions.py
@@ -103,9 +103,6 @@ async def anoncreds_schema_definition(
     request,
     faber_anoncreds_client: RichAsyncClient,
 ) -> CredentialSchema:
-    if request.param == TestMode.regression_run:
-        # Todo: fix fetching of anoncreds schema
-        pytest.skip("Skipping regression run for anoncreds schema")
     auth = acapy_auth_verified(
         acapy_auth_from_header(faber_anoncreds_client.headers["x-api-key"])
     )


### PR DESCRIPTION
before publishing it to the trust registry.

Should allow regression mode to pass (previously it tried to fetch schema which was on trust registry, but not on ledger)