### PR TITLE
:test_tube: Add AnonCreds credential fixtures

### DIFF
--- a/app/tests/e2e/conftest.py
+++ b/app/tests/e2e/conftest.py
@@ -13,12 +13,20 @@ from app.services.trust_registry.actors import (
     remove_actor_by_id,
 )
 from app.tests.fixtures.credentials import (
+    get_or_issue_regression_anoncreds_revoked,
+    get_or_issue_regression_anoncreds_valid,
     get_or_issue_regression_indy_cred_revoked,
     get_or_issue_regression_indy_cred_valid,
+    issue_alice_anoncreds,
     issue_alice_indy_creds,
+    issue_alice_many_anoncreds,
     issue_alice_many_indy_creds,
+    issue_anoncreds_credential_to_alice,
     issue_indy_credential_to_alice,
+    meld_co_issue_anoncreds_credential_to_alice,
     meld_co_issue_indy_credential_to_alice,
+    revoke_alice_anoncreds,
+    revoke_alice_anoncreds_and_publish,
     revoke_alice_indy_creds,
     revoke_alice_indy_creds_and_publish,
 )

--- a/app/tests/fixtures/credentials.py
+++ b/app/tests/fixtures/credentials.py
@@ -278,7 +278,7 @@ async def issue_alice_anoncreds(
     anoncreds_credential_definition_id_revocable: str,
     faber_anoncreds_and_alice_connection: FaberAliceConnect,
 ) -> List[CredentialExchange]:
-    await issue_alice_creds(
+    return await issue_alice_creds(
         credential_type="anoncreds",
         faber_client=faber_anoncreds_client,
         alice_member_client=alice_member_client,
@@ -294,7 +294,7 @@ async def issue_alice_indy_creds(
     indy_credential_definition_id_revocable: str,
     faber_indy_and_alice_connection: FaberAliceConnect,
 ) -> List[CredentialExchange]:
-    await issue_alice_creds(
+    return await issue_alice_creds(
         credential_type="indy",
         faber_client=faber_indy_client,
         alice_member_client=alice_member_client,

--- a/app/tests/fixtures/credentials.py
+++ b/app/tests/fixtures/credentials.py
@@ -737,7 +737,8 @@ async def issue_alice_many_anoncreds(
     faber_anoncreds_and_alice_connection: FaberAliceConnect,
 ) -> List[CredentialExchange]:
     return await issue_alice_many_creds(
-        request,
+        credential_type="anoncreds",
+        request=request,
         faber_client=faber_anoncreds_client,
         alice_member_client=alice_member_client,
         credential_definition_id=anoncreds_credential_definition_id,
@@ -754,7 +755,8 @@ async def issue_alice_many_indy_creds(
     faber_indy_and_alice_connection: FaberAliceConnect,
 ) -> List[CredentialExchange]:
     return await issue_alice_many_creds(
-        request,
+        credential_type="indy",
+        request=request,
         faber_client=faber_indy_client,
         alice_member_client=alice_member_client,
         credential_definition_id=indy_credential_definition_id,

--- a/app/tests/fixtures/credentials.py
+++ b/app/tests/fixtures/credentials.py
@@ -305,10 +305,10 @@ async def issue_alice_indy_creds(
 
 async def revoke_alice_creds(
     faber_client: RichAsyncClient,
-    issue_alice_creds: List[CredentialExchange],
+    alice_issued_creds: List[CredentialExchange],
 ) -> List[CredentialExchange]:
 
-    for cred in issue_alice_creds:
+    for cred in alice_issued_creds:
         await faber_client.post(
             f"{REVOCATION_BASE_PATH}/revoke",
             json={
@@ -316,7 +316,7 @@ async def revoke_alice_creds(
             },
         )
 
-    return issue_alice_creds
+    return alice_issued_creds
 
 
 @pytest.fixture(scope="function")
@@ -326,7 +326,7 @@ async def revoke_alice_anoncreds(
 ) -> List[CredentialExchange]:
     return await revoke_alice_creds(
         faber_client=faber_anoncreds_client,
-        issue_alice_creds=issue_alice_anoncreds,
+        alice_issued_creds=issue_alice_anoncreds,
     )
 
 
@@ -337,7 +337,7 @@ async def revoke_alice_indy_creds(
 ) -> List[CredentialExchange]:
     return await revoke_alice_creds(
         faber_client=faber_indy_client,
-        issue_alice_creds=issue_alice_indy_creds,
+        alice_issued_creds=issue_alice_indy_creds,
     )
 
 

--- a/app/tests/routes/definitions/test_create_credential_definition.py
+++ b/app/tests/routes/definitions/test_create_credential_definition.py
@@ -65,8 +65,6 @@ async def test_create_credential_definition_fail_acapy_error(
 ):
     mock_aries_controller = AsyncMock()
 
-    mock_create_credential_definition = AsyncMock()
-
     with patch(
         "app.routes.definitions.client_from_auth"
     ) as mock_get_client_controller, patch(


### PR DESCRIPTION
Deduplicates existing indy credential fixtures, to add fixtures for issuing one or many anoncreds, revoking many anoncreds, etc

:boom: Yet again breaks existing regression tests by renaming long-lived credential, in order to distinguish indy from anoncreds