### PR TITLE
🔨  Add deep connect-cloud liveness probes

### DIFF
--- a/.github/actions/deploy-eks/action.yml
+++ b/.github/actions/deploy-eks/action.yml
@@ -41,10 +41,10 @@ inputs:
   namespace:
     description: The Kubernetes namespace to deploy to
     required: true
-  pipelines-dir:
-    description: The directory containing the Redpanda Connect pipelines
+  connect-configs-dir:
+    description: The directory containing the Redpanda Connect configurations
     required: true
-    default: ./resources/connect-processors/cloud/pipelines
+    default: ./resources/connect-processors/cloud
 
 runs:
   using: composite
@@ -84,15 +84,19 @@ runs:
       # https://docs.redpanda.com/redpanda-connect/get-started/quickstarts/helm-chart/#run-multiple-pipelines-in-streams-mode
       run: |
         kubectl create configmap connect-cloud-pipelines \
-          --from-file=$PIPELINES_DIR \
+          --from-file=${CONFIGS_DIR}/pipelines \
+          --dry-run=client \
+          -o yaml \
+          -n $NAMESPACE | kubectl apply -f -
+        kubectl create configmap connect-cloud-resources \
+          --from-file=${CONFIGS_DIR}/resources \
           --dry-run=client \
           -o yaml \
           -n $NAMESPACE | kubectl apply -f -
         kubectl -n $NAMESPACE rollout restart deploy/connect-cloud || true
       env:
         NAMESPACE: ${{ inputs.namespace }}
-        PIPELINES_DIR: ${{ inputs.pipelines-dir }}
-
+        CONFIGS_DIR: ${{ inputs.connect-configs-dir }}
     - name: Helmfile Apply
       # https://github.com/helmfile/helmfile-action
       uses: helmfile/helmfile-action@v2

--- a/helm/acapy-cloud/README.md
+++ b/helm/acapy-cloud/README.md
@@ -49,12 +49,17 @@ Replace `<component>` with one of the available components (e.g., `endorser`, `g
 acapy-cloud uses Redpanda Connect for event processing. The pipelines are defined in the
 [connect-processors](../../resources/connect-processors) directory.
 
-Before installing Redpanda Connect, you will need to manually create a Config Map with the processor pipelines:
-
-```bash
-kubectl create configmap connect-cloud-pipelines \
-  --from-file=resources/connect-processors/cloud/pipelines
-```
+Before installing Redpanda Connect, you will need to manually create therequired config maps:
+-  Config Map with the processor pipelines:
+  ```bash
+  kubectl create configmap connect-cloud-pipelines \
+    --from-file=resources/connect-processors/cloud/pipelines
+  ```
+-  Config Map with the processor resources:
+  ```bash
+  kubectl create configmap connect-cloud-resources \
+    --from-file=resources/connect-processors/cloud/resources
+  ```
 
 Refer to [`acapy-cloud.yaml.gotmpl`](../acapy-cloud.yaml.gotmpl) and
 [`connect-cloud.yaml`](./conf/local/connect-cloud.yaml) for an example on installing/configuring Redpanda Connect.

--- a/helm/acapy-cloud/README.md
+++ b/helm/acapy-cloud/README.md
@@ -50,12 +50,16 @@ acapy-cloud uses Redpanda Connect for event processing. The pipelines are define
 [connect-processors](../../resources/connect-processors) directory.
 
 Before installing Redpanda Connect, you will need to manually create therequired config maps:
+
 -  Config Map with the processor pipelines:
+
   ```bash
   kubectl create configmap connect-cloud-pipelines \
     --from-file=resources/connect-processors/cloud/pipelines
   ```
+
 -  Config Map with the processor resources:
+
   ```bash
   kubectl create configmap connect-cloud-resources \
     --from-file=resources/connect-processors/cloud/resources

--- a/helm/acapy-cloud/conf/dev/connect-cloud.yaml
+++ b/helm/acapy-cloud/conf/dev/connect-cloud.yaml
@@ -21,6 +21,23 @@ streams:
 deployment:
   podLabels:
     sidecar.istio.io/inject: "false"
+  livenessProbe:
+    failureThreshold: 3
+    #NOTE: The periodSeconds is the default value for the liveness probe. If this is overridden, a corresponding value should be set in the env for PROBE_INTERVAL.
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 5
+    httpGet:
+      path: /probes/livez
+      port: http
+
+args:
+  - -r
+  - /resources/*.yaml
+  - "-c"
+  - "/redpanda-connect.yaml"
+  - "streams"
+  - /streams/*.yaml
 
 env:
   - name: GOVERNANCE_ACAPY_LABEL
@@ -44,7 +61,20 @@ initContainers:
           echo waiting for nats cloudapi_aries_events stream;
           sleep 2;
         done
+        until nats --server nats://nats:4222 str info cloudapi_aries_events_probes >/dev/null 2>&1; do
+          echo waiting for nats cloudapi_aries_events_probes stream;
+          sleep 2;
+        done
         until nats --server nats://nats:4222 str info cloudapi_aries_state_monitoring >/dev/null 2>&1; do
           echo waiting for nats cloudapi_aries_state_monitoring stream;
           sleep 2;
         done
+
+extraVolumes:
+  - name: resources
+    configMap:
+      name: connect-cloud-resources
+extraVolumeMounts:
+  - name: resources
+    mountPath: /resources
+    readOnly: true

--- a/helm/acapy-cloud/conf/local/connect-cloud.yaml
+++ b/helm/acapy-cloud/conf/local/connect-cloud.yaml
@@ -21,6 +21,23 @@ streams:
 deployment:
   podLabels:
     sidecar.istio.io/inject: "false"
+  livenessProbe:
+    failureThreshold: 3
+    #NOTE: The periodSeconds is the default value for the liveness probe. If this is overridden, a corresponding value should be set in the env for PROBE_INTERVAL.
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 5
+    httpGet:
+      path: /probes/livez
+      port: http
+
+args:
+  - -r
+  - /resources/*.yaml
+  - "-c"
+  - "/redpanda-connect.yaml"
+  - "streams"
+  - /streams/*.yaml
 
 env:
   - name: GOVERNANCE_ACAPY_LABEL
@@ -44,7 +61,20 @@ initContainers:
           echo waiting for nats cloudapi_aries_events stream;
           sleep 2;
         done
+        until nats --server nats://nats:4222 str info cloudapi_aries_events_probes >/dev/null 2>&1; do
+          echo waiting for nats cloudapi_aries_events_probes stream;
+          sleep 2;
+        done
         until nats --server nats://nats:4222 str info cloudapi_aries_state_monitoring >/dev/null 2>&1; do
           echo waiting for nats cloudapi_aries_state_monitoring stream;
           sleep 2;
         done
+
+extraVolumes:
+  - name: resources
+    configMap:
+      name: connect-cloud-resources
+extraVolumeMounts:
+  - name: resources
+    mountPath: /resources
+    readOnly: true

--- a/helm/nats/values.yaml
+++ b/helm/nats/values.yaml
@@ -14,6 +14,15 @@ postInstall:
         - cloudapi.aries.events.*.*
       defaults: true
       storage: file
+    cloudapi_aries_events_probes:
+      subjects:
+        - cloudapi.aries.events.probe
+      defaults: true
+      storage: file
+      retention: limits
+      discard: old
+      maxAge: 10m
+      maxMsgsPerSubject: 100
     cloudapi_aries_state_monitoring:
       subjects:
         - cloudapi.aries.state_monitoring.*.*.>

--- a/resources/connect-processors/cloud/pipelines/probe-nats-read.yaml
+++ b/resources/connect-processors/cloud/pipelines/probe-nats-read.yaml
@@ -1,0 +1,35 @@
+input:
+  label: "nats_input"
+  nats_jetstream:
+    urls:
+      - ${NATS_URL:nats://nats:4222}
+    subject: ${PROBE_NATS_INPUT_SUBJECT:cloudapi.aries.events.probe}
+    stream: ${PROBE_NATS_INPUT_STREAM:"cloudapi_aries_events_probes"}
+    durable: ${PROBE_NATS_INPUT_CONSUMER_NAME:probe-read-cloud-events}
+    queue: ${PROBE_NATS_INPUT_QUEUE_GROUP:""}
+    bind: ${PROBE_NATS_INPUT_BIND:false}
+    deliver: ${PROBE_NATS_INPUT_DELIVER:"last"}
+    auth:
+      user_credentials_file: ${NATS_AUTH_CREDENTIALS_FILE:""}
+    max_ack_pending: ${PROBE_NATS_INPUT_MAX_ACK_PENDING:1}
+
+output:
+  fallback:
+    - reject_errored:
+        label: "update_read_cache"
+        cache:
+          target: probe_read_cache
+          key: ${PROBE_NATS_OUTPUT_SUBJECT:cloudapi.aries.events.probe.read}
+    - label: "dead_letter_queue"
+      processors:
+      - label: "dead_letter_queue_mapping"
+        mapping: |
+          #!blobl
+          root.message = this
+          root.metadata = metadata()
+          root.error = error()
+      - label: "dead_letter_queue_log"
+        log:
+          level: ERROR
+          message: "Processing failed due to: ${!error()}"
+      stdout: {}

--- a/resources/connect-processors/cloud/pipelines/probe-nats-write.yaml
+++ b/resources/connect-processors/cloud/pipelines/probe-nats-write.yaml
@@ -1,0 +1,40 @@
+input:
+  label: generate_heartbeat
+  generate:
+    interval: ${PROBE_INTERVAL:10s}
+    mapping: |
+      #!blobl
+      root = timestamp_unix()
+
+output:
+  fallback:
+    - reject_errored:
+        label: "publish_heartbeat"
+        broker:
+          pattern: fan_out_sequential
+          outputs:
+            - label: "publish_heartbeat_nats"
+              nats_jetstream:
+                urls:
+                  - ${NATS_URL:nats://nats:4222}
+                subject: ${PROBE_NATS_OUTPUT_SUBJECT:cloudapi.aries.events.probe}
+                auth:
+                  user_credentials_file: ${NATS_AUTH_CREDENTIALS_FILE:""}
+                max_in_flight: ${PROBE_NATS_OUTPUT_MAX_IN_FLIGHT:1}
+            - label: "update_cache"
+              cache:
+                target: probe_write_cache
+                key: ${PROBE_NATS_OUTPUT_SUBJECT:cloudapi.aries.events.probe.write}
+    - label: "dead_letter_queue"
+      processors:
+      - label: "dead_letter_queue_mapping"
+        mapping: |
+          #!blob
+          root.message = this
+          root.metadata = metadata()
+          root.error = error()
+      - label: "dead_letter_queue_log"
+        log:
+          level: ERROR
+          message: "Processing failed due to: ${!error()}"
+      stdout: {}

--- a/resources/connect-processors/cloud/pipelines/probes.yaml
+++ b/resources/connect-processors/cloud/pipelines/probes.yaml
@@ -1,0 +1,124 @@
+input:
+  label: "probe_liveness"
+  http_server:
+    address: ""
+    path: /livez
+    allowed_verbs:
+      - GET
+    timeout: ${PROBE_TIMEOUT:5s}
+    rate_limit: probe_rate_limit
+    sync_response:
+      status: ${! @status }
+      headers:
+        Content-Type: application/json
+
+pipeline:
+  processors:
+    - label: query_time
+      mapping: |
+        #!blobl
+        meta query_time = timestamp_unix()
+        meta probe_interval = env("PROBE_INTERVAL").or("10s").parse_duration() / 1000000000
+    - label: "log_request"
+      log:
+        level: DEBUG
+        message: 'Request received'
+        fields_mapping: |
+          #!blobl
+          if (content() != null) {
+            root.connect.message = content()
+          }
+          root.connect.metadata = metadata()
+    - label: "process_write_probe"
+      branch:
+        processors:
+          - label: "check_write_cache"
+            cache:
+              resource: probe_write_cache
+              operator: get
+              key: ${PROBE_NATS_OUTPUT_SUBJECT:cloudapi.aries.events.probe.write}
+          - label: "log_write_cache"
+            log:
+              level: DEBUG
+              message: 'Write cache:'
+              fields_mapping: |
+                #!blobl
+                root.connect.message = this
+          - label: "map_write_cache"
+            mapping: |
+              #!blobl
+              let ts = this
+              if (this != null) {
+                root.cached_timestamp = $ts.ts_format()
+                root.is_cached = true
+                root.is_live = (metadata("query_time").number() - $ts) <= metadata("probe_interval").number()
+              } else {
+                root.cached_timestamp = null
+                root.is_cached = false
+                root.is_live = false
+              }
+          - label: "log_probe_write_cache"
+            log:
+              level: DEBUG
+              message: 'Probe write cache:'
+              fields_mapping: |
+                #!blobl
+                root.connect.message = this
+        result_map: |
+          #!blobl
+          root.nats.write = this
+          meta = metadata()
+    - label: "process_read_probe"
+      branch:
+        processors:
+          - label: "check_read_cache"
+            cache:
+              resource: probe_read_cache
+              operator: get
+              key: ${PROBE_NATS_OUTPUT_SUBJECT:cloudapi.aries.events.probe.read}
+          - label: "map_read_cache"
+            mapping: |
+              #!blobl
+              let ts = this
+              if (this != null) {
+                root.cached_timestamp = $ts.ts_format()
+                root.is_cached = true
+                root.is_live = (metadata("query_time").number() - $ts) <= metadata("probe_interval").number()
+              } else {
+                root.cached_timestamp = null
+                root.is_cached = false
+                root.is_live = false
+              }
+          - label: "log_probe_read_cache"
+            log:
+              level: DEBUG
+              message: 'Probe read cache:'
+              fields_mapping: |
+                #!blobl
+                root.connect.message = this
+        result_map: |
+          #!blobl
+          root.nats.read = this
+          meta = metadata()
+    - label: probe_result
+      mapping: |
+        #!blobl
+        root = this
+        meta status = 200
+        root.is_live = true
+        if (this.nats.write.is_live == false || this.nats.read.is_live == false) {
+          meta status = 503
+          root.is_live = false
+        }
+    - label: "log_probe_result"
+      log:
+        level: DEBUG
+        message: 'Probe result:'
+        fields_mapping: |
+          #!blobl
+          root.connect.message = this
+          root.connect.metadata = metadata()
+
+output:
+  label: "probe_endpoints_output"
+  sync_response: {}

--- a/resources/connect-processors/cloud/resources/probe-resources.yaml
+++ b/resources/connect-processors/cloud/resources/probe-resources.yaml
@@ -1,0 +1,14 @@
+cache_resources:
+  - label: probe_write_cache
+    memory:
+      default_ttl: ${PROBE_CACHE_TTL:60s}
+
+  - label: probe_read_cache
+    memory:
+      default_ttl: ${PROBE_CACHE_TTL:60s}
+
+rate_limit_resources:
+  - label: probe_rate_limit
+    local:
+      count: ${PROBE_RATE_LIMIT_COUNT:5}
+      interval: ${PROBE_RATE_LIMIT_INTERVAL:1s}

--- a/tilt/acapy-cloud/Tiltfile
+++ b/tilt/acapy-cloud/Tiltfile
@@ -137,6 +137,36 @@ def setup_nats(namespace):
         ],
     )
 
+def apply_connect_config_map(namespace, resource_name, config_dir, from_file_args, deps=[]):
+    print(color.green("Applying Redpanda Connect Config Map..."))
+    k8s_context = os.environ.get("KIND_K8S_CONTEXT")
+
+    local_resource(
+        name=resource_name,
+        cmd="kubectl --context="
+        + k8s_context
+        + " create configmap "
+        + resource_name
+        + " "
+        + from_file_args
+        + " --dry-run=client -o yaml"
+        + " -n "
+        + namespace
+        + " | kubectl --context="
+        + k8s_context
+        + " apply -f - && "
+        + "kubectl --context="
+        + k8s_context
+        + " delete pod -n "
+        + namespace
+        + " -l 'app.kubernetes.io/instance="
+        + resource_name
+        + "' --ignore-not-found=true",
+        deps=deps,
+        labels=["03-streaming"],
+        allow_parallel=True,
+        resource_deps=["cloudapi-ns"],
+    )
 
 def setup_redpanda_connect_cloud(namespace):
     print(color.green("Installing Redpanda Connect Cloud Processor..."))
@@ -153,42 +183,53 @@ def setup_redpanda_connect_cloud(namespace):
         labels=["10-helm-repos"],
     )
 
-    pipeline_config_dir = project_root + "/resources/connect-processors/cloud/pipelines"
+    connect_config_dir = project_root + "/resources/connect-processors/cloud"
     pipeline_config_files = str(
-        local("find " + pipeline_config_dir + ' -type f -name "*.yaml"', quiet=True)
+        local("find " + connect_config_dir + '/pipelines -type f -name "*.yaml"', quiet=True)
     ).splitlines()
     print(color.green("Pipeline config files: " + str(pipeline_config_files)))
-    from_file_args = " ".join(["--from-file=" + f for f in pipeline_config_files])
+    pipeline_from_file_args = " ".join(["--from-file=" + f for f in pipeline_config_files])
 
     # Create ConfigMap using kubectl but output only the YAML
-    k8s_context = os.environ.get("KIND_K8S_CONTEXT")
-    local_resource(
-        name=resource_name + "-pipelines",
-        cmd="kubectl --context="
-        + k8s_context
-        + " create configmap "
-        + resource_name
-        + "-pipelines"
-        + " "
-        + from_file_args
-        + " --dry-run=client -o yaml"
-        + " -n "
-        + namespace
-        + " | kubectl --context="
-        + k8s_context
-        + " apply -f - && "
-        + "kubectl --context="
-        + k8s_context
-        + " delete pod -n "
-        + namespace
-        + " -l 'app.kubernetes.io/instance="
-        + resource_name
-        + "' --ignore-not-found=true",
-        deps=pipeline_config_files,
-        labels=["03-streaming"],
-        allow_parallel=True,
-        resource_deps=["cloudapi-ns"],
-    )
+    apply_connect_config_map(namespace, resource_name + '-pipelines', connect_config_dir + '/pipelines', pipeline_from_file_args, pipeline_config_files)
+
+    resource_config_files = str(
+        local("find " + connect_config_dir + '/resources -type f -name "*.yaml"', quiet=True)
+    ).splitlines()
+    print(color.green("Resource config files: " + str(resource_config_files)))
+    resource_from_file_args = " ".join(["--from-file=" + f for f in resource_config_files])
+
+    apply_connect_config_map(namespace, resource_name + '-resources', connect_config_dir + '/resources', resource_from_file_args, resource_config_files)
+
+    # apply_connect_config_map(namespace, resource_name + '-resources', connect_config_dir + '/resources', from_file_args, pipeline_config_files)
+    # k8s_context = os.environ.get("KIND_K8S_CONTEXT")
+    # local_resource(
+    #     name=resource_name + "-pipelines",
+    #     cmd="kubectl --context="
+    #     + k8s_context
+    #     + " create configmap "
+    #     + resource_name
+    #     + "-pipelines"
+    #     + " "
+    #     + from_file_args
+    #     + " --dry-run=client -o yaml"
+    #     + " -n "
+    #     + namespace
+    #     + " | kubectl --context="
+    #     + k8s_context
+    #     + " apply -f - && "
+    #     + "kubectl --context="
+    #     + k8s_context
+    #     + " delete pod -n "
+    #     + namespace
+    #     + " -l 'app.kubernetes.io/instance="
+    #     + resource_name
+    #     + "' --ignore-not-found=true",
+    #     deps=pipeline_config_files,
+    #     labels=["03-streaming"],
+    #     allow_parallel=True,
+    #     resource_deps=["cloudapi-ns"],
+    # )
 
     ## Create helm release
     # https://github.com/redpanda-data/helm-charts/tree/main/charts/connect

--- a/tilt/acapy-cloud/Tiltfile
+++ b/tilt/acapy-cloud/Tiltfile
@@ -227,36 +227,6 @@ def setup_redpanda_connect_cloud(namespace):
         resource_config_files,
     )
 
-    # apply_connect_config_map(namespace, resource_name + '-resources', connect_config_dir + '/resources', from_file_args, pipeline_config_files)
-    # k8s_context = os.environ.get("KIND_K8S_CONTEXT")
-    # local_resource(
-    #     name=resource_name + "-pipelines",
-    #     cmd="kubectl --context="
-    #     + k8s_context
-    #     + " create configmap "
-    #     + resource_name
-    #     + "-pipelines"
-    #     + " "
-    #     + from_file_args
-    #     + " --dry-run=client -o yaml"
-    #     + " -n "
-    #     + namespace
-    #     + " | kubectl --context="
-    #     + k8s_context
-    #     + " apply -f - && "
-    #     + "kubectl --context="
-    #     + k8s_context
-    #     + " delete pod -n "
-    #     + namespace
-    #     + " -l 'app.kubernetes.io/instance="
-    #     + resource_name
-    #     + "' --ignore-not-found=true",
-    #     deps=pipeline_config_files,
-    #     labels=["03-streaming"],
-    #     allow_parallel=True,
-    #     resource_deps=["cloudapi-ns"],
-    # )
-
     ## Create helm release
     # https://github.com/redpanda-data/helm-charts/tree/main/charts/connect
     helm_resource(

--- a/tilt/acapy-cloud/Tiltfile
+++ b/tilt/acapy-cloud/Tiltfile
@@ -137,7 +137,10 @@ def setup_nats(namespace):
         ],
     )
 
-def apply_connect_config_map(namespace, resource_name, config_dir, from_file_args, deps=[]):
+
+def apply_connect_config_map(
+    namespace, resource_name, config_dir, from_file_args, deps=[]
+):
     print(color.green("Applying Redpanda Connect Config Map..."))
     k8s_context = os.environ.get("KIND_K8S_CONTEXT")
 
@@ -168,6 +171,7 @@ def apply_connect_config_map(namespace, resource_name, config_dir, from_file_arg
         resource_deps=["cloudapi-ns"],
     )
 
+
 def setup_redpanda_connect_cloud(namespace):
     print(color.green("Installing Redpanda Connect Cloud Processor..."))
 
@@ -185,21 +189,43 @@ def setup_redpanda_connect_cloud(namespace):
 
     connect_config_dir = project_root + "/resources/connect-processors/cloud"
     pipeline_config_files = str(
-        local("find " + connect_config_dir + '/pipelines -type f -name "*.yaml"', quiet=True)
+        local(
+            "find " + connect_config_dir + '/pipelines -type f -name "*.yaml"',
+            quiet=True,
+        )
     ).splitlines()
     print(color.green("Pipeline config files: " + str(pipeline_config_files)))
-    pipeline_from_file_args = " ".join(["--from-file=" + f for f in pipeline_config_files])
+    pipeline_from_file_args = " ".join(
+        ["--from-file=" + f for f in pipeline_config_files]
+    )
 
     # Create ConfigMap using kubectl but output only the YAML
-    apply_connect_config_map(namespace, resource_name + '-pipelines', connect_config_dir + '/pipelines', pipeline_from_file_args, pipeline_config_files)
+    apply_connect_config_map(
+        namespace,
+        resource_name + "-pipelines",
+        connect_config_dir + "/pipelines",
+        pipeline_from_file_args,
+        pipeline_config_files,
+    )
 
     resource_config_files = str(
-        local("find " + connect_config_dir + '/resources -type f -name "*.yaml"', quiet=True)
+        local(
+            "find " + connect_config_dir + '/resources -type f -name "*.yaml"',
+            quiet=True,
+        )
     ).splitlines()
     print(color.green("Resource config files: " + str(resource_config_files)))
-    resource_from_file_args = " ".join(["--from-file=" + f for f in resource_config_files])
+    resource_from_file_args = " ".join(
+        ["--from-file=" + f for f in resource_config_files]
+    )
 
-    apply_connect_config_map(namespace, resource_name + '-resources', connect_config_dir + '/resources', resource_from_file_args, resource_config_files)
+    apply_connect_config_map(
+        namespace,
+        resource_name + "-resources",
+        connect_config_dir + "/resources",
+        resource_from_file_args,
+        resource_config_files,
+    )
 
     # apply_connect_config_map(namespace, resource_name + '-resources', connect_config_dir + '/resources', from_file_args, pipeline_config_files)
     # k8s_context = os.environ.get("KIND_K8S_CONTEXT")


### PR DESCRIPTION
Adds probe processor to facilitate deep liveness checks:

- probes.yml: provides the http endpoint at /probes/livez
  - aggregates the various probes to give a global result: e.g.
    - 200 response:
      ```json
      {
        "is_live": true,
        "nats": {
          "read": {
            "cached_timestamp": "2025-03-19T12:44:00Z",
            "is_cached": true,
            "is_live": true
          },
          "write": {
            "cached_timestamp": "2025-03-19T12:44:00Z",
            "is_cached": true,
            "is_live": true
          }
        }
      }
      ```
    - 503 response:
      ```json
      {
        "is_live": false,
        "nats": {
          "read": {
            "cached_timestamp": "2025-03-19T12:44:00Z",
            "is_cached": true,
            "is_live": false
          },
          "write": {
            "cached_timestamp": "2025-03-19T12:44:00Z",
            "is_cached": true,
            "is_live": true
          }
        }
      }
      ```
- probe-nats-write.yml: provides the probe for the nats write endpoint
  - uses an in memory cache to facilitate the live probe check
  - publishes a timestamp to a probe subject at a configurable interval
  - updates write cache with the timestamp if nats publish succeeds
- probe-nats-read.yml: provides the probe for the nats read endpoint
  - uses an in memory cache to facilitate the live probe check
  - subscribes to the probe subject
  - updates the read cache with the timestamp of if a message is received
- probe-resources.yml: provides the resources for the probes
  - a cache for storing the timestamps of the heartbeats
  - a rate limit for the number of heartbeats that can be emitted in a given time