### PR TITLE
:construction_worker: Append SHA to manual builds

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -228,6 +228,7 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{version}}-{{sha}},priority=901
 
       - name: Build and push Docker images
         uses: docker/build-push-action@v6

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -223,7 +223,7 @@ jobs:
           tags: |
             type=raw,value=latest,enable=${{ github.event.repository.default_branch == github.ref_name }}
             type=sha,prefix=pr-${{ github.event.pull_request.number }}-,priority=601,enable=${{ github.event_name == 'pull_request' }}
-            type=sha,prefix={{branch}}-,priority=601,enable=${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+            type=sha,prefix={{branch}}-,priority=601,enable=${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref_type == 'branch' }}
             type=ref,event=branch,priority=600
             type=ref,event=pr
             type=semver,pattern={{version}}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -223,7 +223,7 @@ jobs:
           tags: |
             type=raw,value=latest,enable=${{ github.event.repository.default_branch == github.ref_name }}
             type=sha,prefix=pr-${{ github.event.pull_request.number }}-,priority=601,enable=${{ github.event_name == 'pull_request' }}
-            type=sha,prefix={{branch}}-,priority=601,enable=${{ github.event_name == 'push' && github.ref_type == 'branch' }}
+            type=sha,prefix={{branch}}-,priority=601,enable=${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
             type=ref,event=branch,priority=600
             type=ref,event=pr
             type=semver,pattern={{version}}


### PR DESCRIPTION
* When manually triggering a build, only `:branch` is tagged
* Tweak the docker metadata so it does `:branch-sha`