### PR TITLE
:technologist: :arrow_up: Bump Ingress Nginx

### DIFF
--- a/.mise/tasks/kind/install/nginx
+++ b/.mise/tasks/kind/install/nginx
@@ -19,4 +19,4 @@ helm upgrade \
   --wait \
   --timeout 300s \
   ingress-nginx/ingress-nginx \
-  --version 4.12.0
+  --version 4.12.1


### PR DESCRIPTION
* Resolves CVE-2025-1098, CVE-2025-1974, CVE-2025-1097, CVE-2025-24514, and CVE-2025-24513
* Only affects publicly exposed local dev