### PR TITLE
✅  Anoncreds test for Self-attested/predicate proofs 

### DIFF
--- a/app/models/verifier.py
+++ b/app/models/verifier.py
@@ -2,7 +2,9 @@ from enum import Enum
 from typing import Optional, Union
 
 from aries_cloudcontroller import (
-    AnoncredsPresentationRequest,
+    AnoncredsPresentationRequest as AcaPyAnoncredsPresentationRequest,
+)
+from aries_cloudcontroller import (
     AnoncredsPresSpec,
     DIFPresSpec,
     DIFProofRequest,
@@ -21,6 +23,11 @@ class ProofRequestType(str, Enum):
     JWT: str = "jwt"
     LD_PROOF: str = "ld_proof"
     ANONCREDS: str = "anoncreds"
+
+
+class AnoncredsPresentationRequest(AcaPyAnoncredsPresentationRequest):
+    name: str = Field(default="Proof", description="Proof request name")
+    version: str = Field(default="1.0", description="Proof request version")
 
 
 class IndyProofRequest(AcaPyIndyProofRequest):

--- a/app/tests/e2e/verifier/anoncreds/test_predicate_proofs_anoncreds.py
+++ b/app/tests/e2e/verifier/anoncreds/test_predicate_proofs_anoncreds.py
@@ -1,0 +1,104 @@
+import pytest
+from aries_cloudcontroller import AnoncredsPresSpec
+from fastapi import HTTPException
+
+from app.routes.verifier import AcceptProofRequest, router
+from app.tests.util.connections import AcmeAliceConnect
+from app.tests.util.verifier import send_proof_request
+from app.tests.util.webhooks import check_webhook_state
+from shared import RichAsyncClient
+from shared.models.credential_exchange import CredentialExchange
+from shared.models.presentation_exchange import PresentationExchange
+
+VERIFIER_BASE_PATH = router.prefix
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("predicate", ["<", ">", "<=", ">="])
+@pytest.mark.xdist_group(name="issuer_test_group_3")
+async def test_predicate_proofs_anoncreds(
+    acme_client: RichAsyncClient,
+    acme_and_alice_connection: AcmeAliceConnect,
+    alice_member_client: RichAsyncClient,
+    issue_anoncreds_credential_to_alice: CredentialExchange,  # pylint: disable=unused-argument
+    predicate: str,
+):
+    request_body = {
+        "type": "anoncreds",
+        "anoncreds_proof_request": {
+            "requested_attributes": {},
+            "requested_predicates": {
+                "over_18": {
+                    "name": "age",
+                    "p_type": predicate,
+                    "p_value": 18,
+                }
+            },
+        },
+        "connection_id": acme_and_alice_connection.acme_connection_id,
+        "save_exchange_record": True,
+    }
+
+    send_proof_response = await send_proof_request(acme_client, request_body)
+
+    thread_id = send_proof_response["thread_id"]
+
+    alice_event = await check_webhook_state(
+        client=alice_member_client,
+        topic="proofs",
+        filter_map={"thread_id": thread_id},
+        state="request-received",
+    )
+
+    alice_proof_id = alice_event["proof_id"]
+
+    requested_credentials = await alice_member_client.get(
+        f"{VERIFIER_BASE_PATH}/proofs/{alice_proof_id}/credentials"
+    )
+
+    referent = requested_credentials.json()[0]["cred_info"]["referent"]
+
+    proof_accept = AcceptProofRequest(
+        proof_id=alice_proof_id,
+        type="anoncreds",
+        anoncreds_presentation_spec=AnoncredsPresSpec(
+            requested_attributes={},
+            requested_predicates={
+                "over_18": {
+                    "cred_id": referent,
+                }
+            },
+            self_attested_attributes={},
+        ),
+    )
+
+    if predicate in [">", ">="]:
+        response = await alice_member_client.post(
+            f"{VERIFIER_BASE_PATH}/accept-request",
+            json=proof_accept.model_dump(),
+        )
+
+        result = response.json()
+
+        pres_exchange_result = PresentationExchange(**result)
+        assert isinstance(pres_exchange_result, PresentationExchange)
+
+        acme_proof_event = await check_webhook_state(
+            client=acme_client,
+            topic="proofs",
+            state="done",
+            filter_map={"thread_id": thread_id},
+        )
+        assert acme_proof_event["verified"] is True
+
+    else:
+        with pytest.raises(HTTPException) as exc:
+            await alice_member_client.post(
+                f"{VERIFIER_BASE_PATH}/accept-request", json=proof_accept.model_dump()
+            )
+
+        assert exc.value.status_code == 400
+        assert exc.value.detail.startswith(
+            '{"detail":"Failed to send proof presentation: '
+            'Error creating presentation. Invalid state: Predicate is not satisfied."}'
+        )

--- a/app/tests/e2e/verifier/anoncreds/test_predicate_proofs_anoncreds.py
+++ b/app/tests/e2e/verifier/anoncreds/test_predicate_proofs_anoncreds.py
@@ -15,7 +15,7 @@ VERIFIER_BASE_PATH = router.prefix
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("predicate", ["<", ">", "<=", ">="])
-@pytest.mark.xdist_group(name="issuer_test_group_3")
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_predicate_proofs_anoncreds(
     acme_client: RichAsyncClient,
     acme_and_alice_connection: AcmeAliceConnect,

--- a/app/tests/e2e/verifier/anoncreds/test_self_attested_anoncreds.py
+++ b/app/tests/e2e/verifier/anoncreds/test_self_attested_anoncreds.py
@@ -1,0 +1,101 @@
+import pytest
+from aries_cloudcontroller import AnoncredsPresSpec
+
+from app.routes.verifier import AcceptProofRequest, router
+from app.tests.util.connections import AcmeAliceConnect
+from app.tests.util.verifier import send_proof_request
+from app.tests.util.webhooks import check_webhook_state
+from shared import RichAsyncClient
+from shared.models.credential_exchange import CredentialExchange
+from shared.models.presentation_exchange import PresentationExchange
+
+VERIFIER_BASE_PATH = router.prefix
+
+
+@pytest.mark.anyio
+@pytest.mark.xdist_group(name="issuer_test_group")
+async def test_self_attested_attributes_anoncreds(
+    acme_client: RichAsyncClient,
+    acme_and_alice_connection: AcmeAliceConnect,
+    alice_member_client: RichAsyncClient,
+    issue_anoncreds_credential_to_alice: CredentialExchange,  # pylint: disable=unused-argument
+):
+
+    request_body = {
+        "type": "anoncreds",
+        "anoncreds_proof_request": {
+            "requested_attributes": {
+                "name_attribute": {
+                    "name": "name",
+                },
+                "self_attested_cell_nr": {
+                    "name": "my_cell_nr",
+                },
+            },
+            "requested_predicates": {},
+        },
+        "connection_id": acme_and_alice_connection.acme_connection_id,
+        "save_exchange_record": True,
+    }
+
+    send_proof_response = await send_proof_request(acme_client, request_body)
+
+    thread_id = send_proof_response["thread_id"]
+    acme_proof_id = send_proof_response["proof_id"]
+
+    alice_event = await check_webhook_state(
+        client=alice_member_client,
+        topic="proofs",
+        filter_map={"thread_id": thread_id},
+        state="request-received",
+    )
+
+    alice_proof_id = alice_event["proof_id"]
+
+    requested_credentials = await alice_member_client.get(
+        f"{VERIFIER_BASE_PATH}/proofs/{alice_proof_id}/credentials"
+    )
+
+    referent = requested_credentials.json()[0]["cred_info"]["referent"]
+
+    proof_accept = AcceptProofRequest(
+        proof_id=alice_proof_id,
+        type="anoncreds",
+        anoncreds_presentation_spec=AnoncredsPresSpec(
+            requested_attributes={
+                "name_attribute": {
+                    "cred_id": referent,
+                    "revealed": True,
+                }
+            },
+            requested_predicates={},
+            self_attested_attributes={
+                "self_attested_cell_nr": "1234567890",
+            },
+        ),
+    )
+
+    response = await alice_member_client.post(
+        f"{VERIFIER_BASE_PATH}/accept-request",
+        json=proof_accept.model_dump(),
+    )
+
+    result = response.json()
+    pres_exchange_result = PresentationExchange(**result)
+
+    assert isinstance(pres_exchange_result, PresentationExchange)
+
+    acme_proof_event = await check_webhook_state(
+        client=acme_client,
+        topic="proofs",
+        state="done",
+        filter_map={"thread_id": thread_id},
+    )
+
+    assert acme_proof_event["verified"] is True
+
+    proof = (
+        await acme_client.get(f"{VERIFIER_BASE_PATH}/proofs/{acme_proof_id}")
+    ).json()["presentation"]["requested_proof"]["self_attested_attrs"]
+
+    assert proof["self_attested_cell_nr"] == "1234567890"

--- a/app/tests/e2e/verifier/anoncreds/test_verifier.py
+++ b/app/tests/e2e/verifier/anoncreds/test_verifier.py
@@ -674,10 +674,6 @@ async def test_saving_of_anoncreds_presentation_exchange_records(
     TestMode.clean_run in TestMode.fixture_params,
     reason="Run only in regression mode",
 )
-@pytest.mark.skip(
-    "FIXME: `Failed to send proof presentation: "
-    "Error creating presentation. Input error [missing field `name`]`"
-)
 @pytest.mark.xdist_group(name="issuer_test_group_3")
 async def test_regression_proof_valid_anoncreds_credential(
     get_or_issue_regression_anoncreds_valid: ReferentCredDef,

--- a/app/tests/e2e/verifier/test_proof_revoked_credential.py
+++ b/app/tests/e2e/verifier/test_proof_revoked_credential.py
@@ -185,10 +185,6 @@ async def test_regression_proof_revoked_indy_credential(
     TestMode.clean_run in TestMode.fixture_params,
     reason="Run only in regression mode",
 )
-@pytest.mark.skip(
-    "FIXME: `Failed to send proof presentation: "
-    "Error creating presentation. Input error [missing field `name`]`"
-)
 @pytest.mark.xdist_group(name="issuer_test_group")
 async def test_regression_proof_revoked_anoncreds_credential(
     get_or_issue_regression_anoncreds_revoked: ReferentCredDef,

--- a/app/tests/services/verifier/utils.py
+++ b/app/tests/services/verifier/utils.py
@@ -1,6 +1,5 @@
 from aries_cloudcontroller import (
     AnoncredsPresentationReqAttrSpec,
-    AnoncredsPresentationRequest,
     AnoncredsPresentationRequestNonRevoked,
     AttachDecorator,
     AttachDecoratorData,
@@ -21,7 +20,7 @@ from aries_cloudcontroller import (
     V20PresProposal,
 )
 
-from app.models.verifier import IndyProofRequest
+from app.models.verifier import IndyProofRequest, AnoncredsPresentationRequest
 
 indy_proof = IndyProof(
     identifiers=[],

--- a/app/tests/services/verifier/utils.py
+++ b/app/tests/services/verifier/utils.py
@@ -20,7 +20,7 @@ from aries_cloudcontroller import (
     V20PresProposal,
 )
 
-from app.models.verifier import IndyProofRequest, AnoncredsPresentationRequest
+from app.models.verifier import AnoncredsPresentationRequest, IndyProofRequest
 
 indy_proof = IndyProof(
     identifiers=[],


### PR DESCRIPTION
Extended `AnoncredsPresentationRequest` to give default values to `name` and `version` in model. Fix for test that was skipped

