### PR TITLE
:test_tube: Migrate e2e tests from indy to anoncreds

### DIFF
--- a/app/tests/e2e/issuer/test_save_exchange_record.py
+++ b/app/tests/e2e/issuer/test_save_exchange_record.py
@@ -17,18 +17,18 @@ CREDENTIALS_BASE_PATH = router.prefix
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("save_exchange_record", [None, False, True])
-@pytest.mark.xdist_group(name="issuer_test_group_3")
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_issue_credential_with_save_exchange_record(
-    faber_indy_client: RichAsyncClient,
-    indy_credential_definition_id: str,
-    faber_indy_and_alice_connection: FaberAliceConnect,
+    faber_anoncreds_client: RichAsyncClient,
+    anoncreds_credential_definition_id: str,
+    faber_anoncreds_and_alice_connection: FaberAliceConnect,
     alice_member_client: RichAsyncClient,
     save_exchange_record: Optional[bool],
 ) -> CredentialExchange:
     credential = {
-        "connection_id": faber_indy_and_alice_connection.faber_connection_id,
-        "indy_credential_detail": {
-            "credential_definition_id": indy_credential_definition_id,
+        "connection_id": faber_anoncreds_and_alice_connection.faber_connection_id,
+        "anoncreds_credential_detail": {
+            "credential_definition_id": anoncreds_credential_definition_id,
             "attributes": sample_credential_attributes,
         },
         "save_exchange_record": save_exchange_record,
@@ -36,7 +36,7 @@ async def test_issue_credential_with_save_exchange_record(
 
     # create and send credential offer- issuer
     faber_send_response = (
-        await faber_indy_client.post(
+        await faber_anoncreds_client.post(
             CREDENTIALS_BASE_PATH,
             json=credential,
         )
@@ -84,7 +84,7 @@ async def test_issue_credential_with_save_exchange_record(
         if save_exchange_record:
             # get exchange records from faber side:
             faber_cred_ex_record = (
-                await faber_indy_client.get(
+                await faber_anoncreds_client.get(
                     f"{CREDENTIALS_BASE_PATH}/{faber_credential_exchange_id}"
                 )
             ).json()
@@ -97,7 +97,7 @@ async def test_issue_credential_with_save_exchange_record(
         else:
             # If save_exchange_record was not set, credential should not exist
             with pytest.raises(HTTPException) as exc:
-                await faber_indy_client.get(
+                await faber_anoncreds_client.get(
                     f"{CREDENTIALS_BASE_PATH}/{faber_credential_exchange_id}"
                 )
             assert exc.value.status_code == 404
@@ -105,26 +105,26 @@ async def test_issue_credential_with_save_exchange_record(
     finally:
         # Clean up
         if save_exchange_record:
-            await faber_indy_client.delete(
+            await faber_anoncreds_client.delete(
                 f"{CREDENTIALS_BASE_PATH}/{faber_credential_exchange_id}"
             )
 
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("save_exchange_record", [None, False, True])
-@pytest.mark.xdist_group(name="issuer_test_group_4")
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_request_credential_with_save_exchange_record(
-    faber_indy_client: RichAsyncClient,
-    indy_credential_definition_id: str,
-    faber_indy_and_alice_connection: FaberAliceConnect,
+    faber_anoncreds_client: RichAsyncClient,
+    anoncreds_credential_definition_id: str,
+    faber_anoncreds_and_alice_connection: FaberAliceConnect,
     alice_member_client: RichAsyncClient,
     save_exchange_record: bool,
 ):
     # This test asserts that the holder can control `save_exchange_records` behaviour
     credential = {
-        "connection_id": faber_indy_and_alice_connection.faber_connection_id,
-        "indy_credential_detail": {
-            "credential_definition_id": indy_credential_definition_id,
+        "connection_id": faber_anoncreds_and_alice_connection.faber_connection_id,
+        "anoncreds_credential_detail": {
+            "credential_definition_id": anoncreds_credential_definition_id,
             "attributes": {"speed": "20", "name": "Alice", "age": "44"},
         },
         "save_exchange_record": True,  # so we can safely delete faber cred ex record in finally block
@@ -132,7 +132,7 @@ async def test_request_credential_with_save_exchange_record(
 
     # Create and send credential offer - issuer
     faber_send_response = (
-        await faber_indy_client.post(
+        await faber_anoncreds_client.post(
             CREDENTIALS_BASE_PATH,
             json=credential,
         )
@@ -201,17 +201,17 @@ async def test_request_credential_with_save_exchange_record(
             await alice_member_client.delete(
                 f"{CREDENTIALS_BASE_PATH}/{alice_credential_exchange_id}"
             )
-        await faber_indy_client.delete(
+        await faber_anoncreds_client.delete(
             f"{CREDENTIALS_BASE_PATH}/{faber_credential_exchange_id}"
         )
 
 
 @pytest.mark.anyio
-@pytest.mark.xdist_group(name="issuer_test_group_3")
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_get_cred_exchange_records(
-    faber_indy_client: RichAsyncClient,
-    indy_credential_definition_id: str,
-    faber_indy_and_alice_connection: FaberAliceConnect,
+    faber_anoncreds_client: RichAsyncClient,
+    anoncreds_credential_definition_id: str,
+    faber_anoncreds_and_alice_connection: FaberAliceConnect,
     alice_member_client: RichAsyncClient,
 ):
     # Fetch existing records so we can filter to exclude them. Necessary to cater for long running / regression tests
@@ -220,18 +220,18 @@ async def test_get_cred_exchange_records(
     ).json()
 
     credential = {
-        "connection_id": faber_indy_and_alice_connection.faber_connection_id,
-        "indy_credential_detail": {
-            "credential_definition_id": indy_credential_definition_id,
+        "connection_id": faber_anoncreds_and_alice_connection.faber_connection_id,
+        "anoncreds_credential_detail": {
+            "credential_definition_id": anoncreds_credential_definition_id,
             "attributes": {"speed": "20", "name": "Alice", "age": "44"},
         },
         "save_exchange_record": True,
     }
 
-    faber_send_response_1 = await faber_indy_client.post(
+    faber_send_response_1 = await faber_anoncreds_client.post(
         CREDENTIALS_BASE_PATH, json=credential
     )
-    faber_send_response_2 = await faber_indy_client.post(
+    faber_send_response_2 = await faber_anoncreds_client.post(
         CREDENTIALS_BASE_PATH, json=credential
     )
 
@@ -283,10 +283,10 @@ async def test_get_cred_exchange_records(
         )
 
     await asyncio.sleep(1)  # short sleep to allow records to update
-    faber_records = (await faber_indy_client.get(CREDENTIALS_BASE_PATH)).json()
+    faber_records = (await faber_anoncreds_client.get(CREDENTIALS_BASE_PATH)).json()
 
     faber_cred_ex_response = (
-        await faber_indy_client.get(CREDENTIALS_BASE_PATH + "?state=done")
+        await faber_anoncreds_client.get(CREDENTIALS_BASE_PATH + "?state=done")
     ).json()
     filtered_cred_ex_records = [
         record
@@ -296,7 +296,7 @@ async def test_get_cred_exchange_records(
     assert len(filtered_cred_ex_records) == 2
 
     faber_cred_ex_response = (
-        await faber_indy_client.get(CREDENTIALS_BASE_PATH + "?role=issuer")
+        await faber_anoncreds_client.get(CREDENTIALS_BASE_PATH + "?role=issuer")
     ).json()
     filtered_cred_ex_records = [
         record
@@ -306,14 +306,14 @@ async def test_get_cred_exchange_records(
     assert len(filtered_cred_ex_records) == 2
 
     faber_cred_ex_response = (
-        await faber_indy_client.get(
+        await faber_anoncreds_client.get(
             f"{CREDENTIALS_BASE_PATH}?thread_id={faber_records[0]['thread_id']}"
         )
     ).json()
     assert len(faber_cred_ex_response) == 1
 
     with pytest.raises(HTTPException) as exc:
-        await faber_indy_client.get(
+        await faber_anoncreds_client.get(
             f"{CREDENTIALS_BASE_PATH}?connection_id=123&thread_id=123&role=asf&state=asd"
         )
     assert exc.value.status_code == 422

--- a/app/tests/e2e/issuer/test_save_exchange_record.py
+++ b/app/tests/e2e/issuer/test_save_exchange_record.py
@@ -26,6 +26,7 @@ async def test_issue_credential_with_save_exchange_record(
     save_exchange_record: Optional[bool],
 ) -> CredentialExchange:
     credential = {
+        "type": "anoncreds",
         "connection_id": faber_anoncreds_and_alice_connection.faber_connection_id,
         "anoncreds_credential_detail": {
             "credential_definition_id": anoncreds_credential_definition_id,
@@ -122,6 +123,7 @@ async def test_request_credential_with_save_exchange_record(
 ):
     # This test asserts that the holder can control `save_exchange_records` behaviour
     credential = {
+        "type": "anoncreds",
         "connection_id": faber_anoncreds_and_alice_connection.faber_connection_id,
         "anoncreds_credential_detail": {
             "credential_definition_id": anoncreds_credential_definition_id,
@@ -220,6 +222,7 @@ async def test_get_cred_exchange_records(
     ).json()
 
     credential = {
+        "type": "anoncreds",
         "connection_id": faber_anoncreds_and_alice_connection.faber_connection_id,
         "anoncreds_credential_detail": {
             "credential_definition_id": anoncreds_credential_definition_id,

--- a/app/tests/e2e/test_did_rotate.py
+++ b/app/tests/e2e/test_did_rotate.py
@@ -19,12 +19,12 @@ CONNECTIONS_BASE_PATH = connections_router.prefix
 async def test_rotate_did(
     alice_member_client: RichAsyncClient,
     alice_acapy_client: AcaPyClient,
-    faber_indy_acapy_client: AcaPyClient,
+    faber_anoncreds_acapy_client: AcaPyClient,
     did_method: str,
 ):
     # First, create did-exchange connections between Alice and Faber:
     faber_public_did = await acapy_wallet.get_public_did(
-        controller=faber_indy_acapy_client
+        controller=faber_anoncreds_acapy_client
     )
 
     request_data = {"their_public_did": qualified_did_sov(faber_public_did.did)}
@@ -60,12 +60,12 @@ async def test_rotate_did(
 @pytest.mark.xdist_group(name="issuer_test_group")
 async def test_hangup_did_rotation(
     alice_member_client: RichAsyncClient,
-    faber_indy_client: RichAsyncClient,
-    faber_indy_acapy_client: AcaPyClient,
+    faber_anoncreds_client: RichAsyncClient,
+    faber_anoncreds_acapy_client: AcaPyClient,
 ):
     # First, create did-exchange connections between Alice and Faber:
     faber_public_did = await acapy_wallet.get_public_did(
-        controller=faber_indy_acapy_client
+        controller=faber_anoncreds_acapy_client
     )
 
     request_data = {"their_public_did": qualified_did_sov(faber_public_did.did)}
@@ -84,7 +84,7 @@ async def test_hangup_did_rotation(
     )
 
     faber_event = await check_webhook_state(
-        faber_indy_client,
+        faber_anoncreds_client,
         topic="connections",
         state="completed",
         filter_map={"their_did": alice_did},
@@ -105,7 +105,7 @@ async def test_hangup_did_rotation(
         filter_map={"connection_id": alice_connection_id},
     )
     assert await check_webhook_state(
-        faber_indy_client,
+        faber_anoncreds_client,
         topic="connections",
         state="deleted",
         filter_map={"connection_id": faber_connection_id},
@@ -117,5 +117,7 @@ async def test_hangup_did_rotation(
     assert exc_info.value.status_code == 404
 
     with pytest.raises(HTTPException) as exc_info:
-        await faber_indy_client.get(f"{CONNECTIONS_BASE_PATH}/{faber_connection_id}")
+        await faber_anoncreds_client.get(
+            f"{CONNECTIONS_BASE_PATH}/{faber_connection_id}"
+        )
     assert exc_info.value.status_code == 404

--- a/app/tests/e2e/test_oob.py
+++ b/app/tests/e2e/test_oob.py
@@ -75,9 +75,9 @@ async def test_accept_invitation_oob(
 @pytest.mark.xdist_group(name="issuer_test_group")
 async def test_oob_connect_via_public_did(
     bob_member_client: RichAsyncClient,
-    faber_indy_acapy_client: AcaPyClient,
+    faber_anoncreds_acapy_client: AcaPyClient,
 ):
-    faber_public_did = await faber_indy_acapy_client.wallet.get_public_did()
+    faber_public_did = await faber_anoncreds_acapy_client.wallet.get_public_did()
     connect_response = await bob_member_client.post(
         OOB_BASE_PATH + "/connect-public-did",
         json={"public_did": faber_public_did.result.did},

--- a/app/tests/e2e/test_proof_request_models.py
+++ b/app/tests/e2e/test_proof_request_models.py
@@ -96,7 +96,6 @@ async def test_proof_model_failures(
                         "requested_predicates": {},
                         "self_attested_attributes": {},
                     },
-                    "dif_presentation_spec": {},
                 },
             )
             assert exc.value.status_code == 422

--- a/app/tests/e2e/test_proof_request_models.py
+++ b/app/tests/e2e/test_proof_request_models.py
@@ -26,7 +26,7 @@ VERIFIER_BASE_PATH = verifier_router.prefix
 )
 @pytest.mark.xdist_group(name="issuer_test_group")
 async def test_proof_model_failures(
-    issue_indy_credential_to_alice: CredentialExchange,  # pylint: disable=unused-argument
+    issue_anoncreds_credential_to_alice: CredentialExchange,  # pylint: disable=unused-argument
     acme_acapy_client: AcaPyClient,
     acme_and_alice_connection: AcmeAliceConnect,
     alice_member_client: RichAsyncClient,
@@ -41,7 +41,7 @@ async def test_proof_model_failures(
         connection_id=acme_connection_id,
         comment="Test proof",
         presentation_request=V20PresRequestByFormat(
-            indy={
+            anoncreds={
                 "name": name,
                 "version": version,
                 "requested_attributes": {
@@ -88,8 +88,8 @@ async def test_proof_model_failures(
                 f"{VERIFIER_BASE_PATH}/accept-request",
                 json={
                     "proof_id": alice_proof_exchange_id,
-                    "type": "indy",
-                    "indy_presentation_spec": {
+                    "type": "anoncreds",
+                    "anoncreds_presentation_spec": {
                         "requested_attributes": {
                             "THE_SPEED": {"cred_id": referent, "revealed": True}
                         },

--- a/app/tests/e2e/test_wallet_credentials.py
+++ b/app/tests/e2e/test_wallet_credentials.py
@@ -21,10 +21,10 @@ async def test_get_credentials(alice_member_client: RichAsyncClient):
     TestMode.regression_run in TestMode.fixture_params,
     reason="Don't delete credentials in regression run",
 )
-@pytest.mark.xdist_group(name="issuer_test_group_4")
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_get_and_delete_credential_record(
     alice_member_client: RichAsyncClient,
-    issue_indy_credential_to_alice: CredentialExchange,  # pylint: disable=unused-argument
+    issue_anoncreds_credential_to_alice: CredentialExchange,  # pylint: disable=unused-argument
 ):
     credentials_response = await alice_member_client.get(WALLET_CREDENTIALS_PATH)
 
@@ -66,12 +66,12 @@ async def test_get_and_delete_credential_record(
     reason="Skipping due to regression run",
 )
 @pytest.mark.parametrize(
-    "issue_alice_many_indy_creds", [3], indirect=True
+    "issue_alice_many_anoncreds", [3], indirect=True
 )  # issue alice 3 creds
-@pytest.mark.xdist_group(name="issuer_test_group_4")
+@pytest.mark.xdist_group(name="issuer_test_group")
 async def test_get_credential_record_with_limit(
     alice_member_client: RichAsyncClient,
-    issue_alice_many_indy_creds,  # pylint: disable=unused-argument
+    issue_alice_many_anoncreds,  # pylint: disable=unused-argument
 ):
     valid_params = [
         {"limit": 1},

--- a/docs/src/examples/7. Verify Credential.md
+++ b/docs/src/examples/7. Verify Credential.md
@@ -228,9 +228,8 @@ curl -X 'POST' \
       }
     },
     "requested_predicates": {},
-    "self_attested_attributes": {},
-  },
-  "dif_presentation_spec": {}
+    "self_attested_attributes": {}
+  }
 }'
 ```
 

--- a/docs/src/examples/Self-Attested Attributes/1. Self-Attested Attributes.md
+++ b/docs/src/examples/Self-Attested Attributes/1. Self-Attested Attributes.md
@@ -60,8 +60,7 @@ POST /v1/verifier/accept-request
     "self_attested_attributes": {
       "cellphone": "0123456789"
     }
-  },
-  "dif_presentation_spec": {}
+  }
 }
 ```
 


### PR DESCRIPTION
Includes:
- test saving exchange records
- testing did exchange and rotate methods
- testing jsonld sign/verifying
- test getting and deleting a wallet credential