### PR TITLE
:rewind: Revert SHA pinning Docker Python images

### DIFF
--- a/dockerfiles/app/Dockerfile
+++ b/dockerfiles/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim@sha256:85824326bc4ae27a1abb5bc0dd9e08847aa5fe73d8afb593b1b45b7cb4180f57
+FROM python:3.12.10-slim
 
 WORKDIR /app
 

--- a/dockerfiles/endorser/Dockerfile
+++ b/dockerfiles/endorser/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim@sha256:85824326bc4ae27a1abb5bc0dd9e08847aa5fe73d8afb593b1b45b7cb4180f57
+FROM python:3.12.10-slim
 
 WORKDIR /endorser
 

--- a/dockerfiles/tests/Dockerfile
+++ b/dockerfiles/tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim@sha256:85824326bc4ae27a1abb5bc0dd9e08847aa5fe73d8afb593b1b45b7cb4180f57
+FROM python:3.12.10-slim
 
 # Copy the pyproject.toml and lock file
 COPY pyproject.toml cloudapi-tests/

--- a/dockerfiles/trustregistry/Dockerfile
+++ b/dockerfiles/trustregistry/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim@sha256:85824326bc4ae27a1abb5bc0dd9e08847aa5fe73d8afb593b1b45b7cb4180f57
+FROM python:3.12.10-slim
 
 WORKDIR /trustregistry
 

--- a/dockerfiles/waypoint/Dockerfile
+++ b/dockerfiles/waypoint/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim@sha256:85824326bc4ae27a1abb5bc0dd9e08847aa5fe73d8afb593b1b45b7cb4180f57
+FROM python:3.12.10-slim
 
 WORKDIR /waypoint
 


### PR DESCRIPTION
* It causes Dependabot to always want to upgrade to latest and ignore
the version constraints
* But, to be a little more pinned, add patch version
  * `3.12.10-slim` instead of just `3.12-slim`