### PR TITLE
:construction_worker: Tweak pytest output

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -312,9 +312,7 @@ jobs:
             --dist loadgroup \
             --durations=25 \
             --ignore ./tilt \
-            --cov \
-            --skip-covered \
-            | tee test_output.txt
+            --cov | tee test_output.txt
 
           EXIT_CODE=${PIPESTATUS[0]}
           set -e

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -310,9 +310,11 @@ jobs:
           poetry run pytest \
             --numprocesses 4 \
             --dist loadgroup \
-            --durations=0 \
+            --durations=25 \
             --ignore ./tilt \
-            --cov | tee test_output.txt
+            --cov \
+            --skip-covered \
+            | tee test_output.txt
 
           EXIT_CODE=${PIPESTATUS[0]}
           set -e

--- a/app/tests/e2e/test_did_rotate.py
+++ b/app/tests/e2e/test_did_rotate.py
@@ -15,7 +15,7 @@ CONNECTIONS_BASE_PATH = connections_router.prefix
 @pytest.mark.anyio
 @pytest.mark.parametrize("did_method", ["did:peer:2", "did:peer:4"])
 @pytest.mark.xdist_group(name="issuer_test_group")
-@pytest.mark.filterwarnings("ignore:DeprecationWarning")  # options is deprecated
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")  # options is deprecated
 async def test_rotate_did(
     alice_member_client: RichAsyncClient,
     alice_acapy_client: AcaPyClient,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ omit = ["*/tests/*"]
 profile = "black"
 
 [tool.pytest.ini_options]
-addopts = "--junitxml=junit.xml -p no:cacheprovider --cov-report=xml --cov-report=term"
+addopts = "--junitxml=junit.xml -p no:cacheprovider --cov-report=xml --cov-report=term:skip-covered"
 junit_family = "xunit2"
 
 [build-system]


### PR DESCRIPTION
Only print the 25 slowest tests, and skip coverage results in terminal output for 100% covered modules

Ultimately reduces noise in output of test jobs