### PR TITLE
:construction_worker: :memo: Add OpenAPI spec automation workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -8,21 +8,23 @@ title: CI/CD Pipeline
 ---
 flowchart LR
     ExportVersions(Export tool versions)
-    Format(Format Check)
-    Unit(Unit Tests)
-    Docker(Docker Build/Push)
-    Test(Local Tests)
-    DeployTest(Deploy and Test EKS)
-    Notify(Notify didx-cloud)
+    Lint(Lint / Format)
+    TestsUnit(Tests / Unit)
+    Docker(Docker / Build/Push)
+    TestsLocal(Tests / Local)
+    EKS(EKS / Deploy and Test)
+    Notify(Notify / didx-cloud)
+    OpenAPI(OpenAPI / Diff)
 
-    ExportVersions --> Format
-    ExportVersions --> Unit
-    Format --> Docker
-    Unit --> Docker
-    Docker --> Test
-    Docker --> DeployTest
-    DeployTest --> Notify
-    Test --> Notify
+    ExportVersions --> Lint
+    ExportVersions --> TestsUnit
+    Lint --> Docker
+    TestsUnit --> Docker
+    Docker --> TestsLocal
+    Docker --> EKS
+    EKS --> Notify
+    TestsLocal --> Notify
+    Docker --> OpenAPI
 ```
 
 Refer to the [helm](../../helm) directory for the Helm charts and Helmfile

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -123,6 +123,23 @@ jobs:
       group: docker-${{ github.ref_name }}
       cancel-in-progress: true
 
+  openapi:
+    name: OpenAPI
+    needs: docker
+    uses: ./.github/workflows/update-openapi.yml
+    with:
+      image-version: ${{ needs.docker.outputs.image_version }}
+      pr-number: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
+    secrets:
+      devops-app-id: ${{ secrets.DEVOPS_APP_ID }}
+      devops-private-key: ${{ secrets.DEVOPS_PRIVATE_KEY }}
+    concurrency:
+      group: update-openapi-${{ github.ref_name }}
+      cancel-in-progress: true
+    permissions:
+      contents: write # Required to push changes to the repository
+      pull-requests: write # Required to comment on PRs about OpenAPI spec changes
+
   local-test:
     name: Tests
     needs:

--- a/.github/workflows/update-openapi.yml
+++ b/.github/workflows/update-openapi.yml
@@ -1,0 +1,300 @@
+name: Update OpenAPI
+
+on:
+  workflow_call:
+    inputs:
+      image-version:
+        description: Image version to run
+        required: true
+        type: string
+      pr-number:
+        description: Pull request number (if triggered by a PR)
+        required: false
+        type: number
+    secrets:
+      devops-app-id:
+        required: true
+      devops-private-key:
+        required: true
+
+permissions: {}
+
+jobs:
+  diff:
+    name: Diff
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    services:
+      tenant-admin:
+        image: ghcr.io/didx-xyz/acapy-cloud/app:${{ inputs.image-version }}
+        ports:
+          - 8080:8000
+        env:
+          OPENAPI_NAME: CloudAPI Multitenant Admin
+          ROLE: tenant-admin
+          ROOT_PATH: /tenant-admin
+      tenant:
+        image: ghcr.io/didx-xyz/acapy-cloud/app:${{ inputs.image-version }}
+        ports:
+          - 8181:8000
+        env:
+          OPENAPI_NAME: CloudAPI Tenant
+          ROLE: tenant
+          ROOT_PATH: /tenant
+
+    steps:
+      - name: Log in to DIDx DevOps
+        id: devops_login
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        with:
+          app-id: ${{ secrets.devops-app-id }}
+          private-key: ${{ secrets.devops-private-key }}
+
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: true
+          token: ${{ steps.devops_login.outputs.token }}
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Check if services are up
+        run: |
+          for i in {1..10}; do
+            if curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/tenant-admin/openapi.json; then
+              echo "Tenant Admin service is up"
+              break
+            fi
+            sleep 5
+          done
+
+          for i in {1..10}; do
+            if curl -s -o /dev/null -w "%{http_code}" http://localhost:8181/tenant/openapi.json; then
+              echo "Tenant service is up"
+              break
+            fi
+            sleep 5
+          done
+
+      - name: Download OpenAPI Specs
+        run: |
+          mkdir -p ./tmp
+
+          curl -s http://localhost:8080/tenant-admin/openapi.json | jq . > ./tmp/tenant-admin-openapi.json
+          curl -s http://localhost:8080/tenant-admin/openapi.yaml | yq . > ./tmp/tenant-admin-openapi.yaml
+
+          curl -s http://localhost:8181/tenant/openapi.json | jq . > ./tmp/tenant-openapi.json
+          curl -s http://localhost:8181/tenant/openapi.yaml | yq . > ./tmp/tenant-openapi.yaml
+
+      - name: Detecting diffs in OpenAPI Spec - Tenant Admin JSON
+        uses: oasdiff/oasdiff-action/diff@d68e4d01cb0ba24b6811df1e190f2a640169ea6d # main
+        id: tenant-admin-json
+        with:
+          base: ./docs/openapi/tenant-admin-openapi.json
+          revision: ./tmp/tenant-admin-openapi.json
+          format: markdown
+          include-path-params: true
+
+      - name: Detecting diffs in OpenAPI Spec - Tenant Admin YAML
+        uses: oasdiff/oasdiff-action/diff@d68e4d01cb0ba24b6811df1e190f2a640169ea6d # main
+        id: tenant-admin-yaml
+        with:
+          base: ./docs/openapi/tenant-admin-openapi.yaml
+          revision: ./tmp/tenant-admin-openapi.yaml
+          format: markdown
+          include-path-params: true
+
+      - name: Detecting diffs in OpenAPI Spec - Tenant JSON
+        uses: oasdiff/oasdiff-action/diff@d68e4d01cb0ba24b6811df1e190f2a640169ea6d # main
+        id: tenant-json
+        with:
+          base: ./docs/openapi/tenant-openapi.json
+          revision: ./tmp/tenant-openapi.json
+          format: markdown
+          include-path-params: true
+
+      - name: Detecting diffs in OpenAPI Spec - Tenant YAML
+        uses: oasdiff/oasdiff-action/diff@d68e4d01cb0ba24b6811df1e190f2a640169ea6d # main
+        id: tenant-yaml
+        with:
+          base: ./docs/openapi/tenant-openapi.yaml
+          revision: ./tmp/tenant-openapi.yaml
+          format: markdown
+          include-path-params: true
+
+      - name: Comment on PR
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        if: inputs.pr-number != ''
+        with:
+          github-token: ${{ steps.devops_login.outputs.token }}
+          script: |
+            const tenantAdminJsonDiff = `${{ steps.tenant-admin-json.outputs.diff }}`;
+            const tenantAdminYamlDiff = `${{ steps.tenant-admin-yaml.outputs.diff }}`;
+            const tenantJsonDiff = `${{ steps.tenant-json.outputs.diff }}`;
+            const tenantYamlDiff = `${{ steps.tenant-yaml.outputs.diff }}`;
+
+            // Unique identifier for our comment
+            const COMMENT_IDENTIFIER = "<!-- openapi-diff-check -->";
+
+            // Spec information
+            const specs = [
+              {
+                name: 'Tenant Admin API (JSON)',
+                path: 'docs/openapi/tenant-admin-openapi.json',
+                diff: tenantAdminJsonDiff,
+                hasChanges: tenantAdminJsonDiff !== 'No changes'
+              },
+              {
+                name: 'Tenant Admin API (YAML)',
+                path: 'docs/openapi/tenant-admin-openapi.yaml',
+                diff: tenantAdminYamlDiff,
+                hasChanges: tenantAdminYamlDiff !== 'No changes'
+              },
+              {
+                name: 'Tenant API (JSON)',
+                path: 'docs/openapi/tenant-openapi.json',
+                diff: tenantJsonDiff,
+                hasChanges: tenantJsonDiff !== 'No changes'
+              },
+              {
+                name: 'Tenant API (YAML)',
+                path: 'docs/openapi/tenant-openapi.yaml',
+                diff: tenantYamlDiff,
+                hasChanges: tenantYamlDiff !== 'No changes'
+              }
+            ];
+
+            // Count changed and resolved specs
+            const specsWithChanges = specs.filter(spec => spec.hasChanges);
+
+            // Always create a step summary
+            const fs = require('fs');
+            let summaryContent = '## OpenAPI Specification Changes\n\n';
+
+            if (specsWithChanges.length > 0) {
+              // Add warning header for specs with changes
+              summaryContent += `### ⚠️ Changes detected in the following specifications:\n\n`;
+
+              // Generate detailed summary using details/summary tags
+              specs.forEach(spec => {
+                if (spec.hasChanges) {
+                  summaryContent += `<details>\n<summary><strong>🔍 ${spec.name}</strong> - Changes detected</summary>\n\n`;
+                  summaryContent += `${spec.diff}\n\n`;
+                  summaryContent += `</details>\n\n`;
+                }
+              });
+            } else {
+              // All specs are in sync
+              summaryContent += `## ✅ All OpenAPI Specifications are in sync\n\n`;
+              summaryContent += `No differences were detected in the OpenAPI specifications.`;
+            }
+
+            fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, summaryContent);
+            console.log('Added OpenAPI diff results to the step summary');
+
+            // Check if PR number is provided
+            const prNumber = parseInt('${{ inputs.pr-number }}', 10);
+            if (!prNumber) {
+              console.log('PR number not provided, skipping PR comment creation');
+              return;
+            }
+
+            // Get existing comments
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber
+            });
+
+            // Find our existing comment
+            const existingComment = comments.data.find(comment =>
+              comment.body.includes(COMMENT_IDENTIFIER)
+            );
+
+            // Create comment body
+            let commentBody = `${COMMENT_IDENTIFIER}\n## OpenAPI Specification Changes\n\n`;
+
+            if (specsWithChanges.length > 0) {
+              // Add details for specs with changes
+              commentBody += `### ⚠️ Merging this PR will result in the following changes to the OpenAPI Specification:\n\n`;
+
+              specsWithChanges.forEach(spec => {
+                commentBody += `<details>\n<summary><strong>🔍 ${spec.name}</strong> - Changes detected</summary>\n\n`;
+                commentBody += `${spec.diff}\n\n`;
+                commentBody += `</details>\n\n`;
+              });
+
+              commentBody += `\nPlease update the OpenAPI specifications to resolve these differences.\n`;
+            } else {
+              // All specs are in sync
+              commentBody = `${COMMENT_IDENTIFIER}\n## ✅ All OpenAPI Specifications are in sync\n\n`;
+              commentBody += `No differences were detected in the OpenAPI specifications.`;
+            }
+
+            // Either update the existing comment or create a new one
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existingComment.id,
+                body: commentBody
+              });
+              console.log('Updated existing OpenAPI diff comment');
+            } else if (specsWithChanges.length > 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: commentBody
+              });
+              console.log(`Created OpenAPI diff comment on PR #${prNumber}`);
+            }
+
+      - name: Commit and open PR for OpenAPI spec changes
+        if: inputs.pr-number == '' && github.ref_name == github.event.repository.default_branch
+        env:
+          HEAD_BRANCH: devops/sync-openapi
+          BASE_BRANCH: ${{ github.event.repository.default_branch }}
+          GITHUB_TOKEN: ${{ steps.devops_login.outputs.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          git config --global user.name "DIDx DevOps"
+          git config --global user.email "devops@didx.co.za"
+
+          # Ensure we are on the correct branch
+          git checkout -b ${HEAD_BRANCH}
+
+          # Move new specs to the docs directory
+          mv ./tmp/* ./docs/openapi/
+
+          # Check if there are any changes
+          if [[ -n "$(git status --porcelain ./docs/openapi)" ]]; then
+            echo "Changes detected in OpenAPI specs, preparing to commit and push"
+
+            # Commit and push changes
+            git add ./docs/openapi/
+            git commit -m ":memo: Sync OpenAPI Spec"
+            git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${REPO}.git
+            git push --set-upstream origin ${HEAD_BRANCH} --force
+            echo "OpenAPI specs updated and pushed to repository"
+
+            # Check if PR already exists
+            pr_exists=$(gh pr list --repo ${REPO} --base ${BASE_BRANCH} --head ${HEAD_BRANCH} --json number --jq '.[0].number')
+            if [[ -n "${pr_exists}" ]]; then
+              echo "Pull request #${pr_exists} already exists for syncing OpenAPI Spec"
+            else
+              gh pr create \
+                --repo ${REPO} \
+                --base ${BASE_BRANCH} \
+                --head ${HEAD_BRANCH} \
+                --title ":memo: Sync OpenAPI Spec" \
+                --body "This PR syncs the OpenAPI Spec with the latest code changes.\n\nPlease review and merge." \
+                --label documentation
+              echo "Pull request created for OpenAPI spec changes"
+            fi
+          else
+            echo "No changes to OpenAPI specs detected"
+          fi

--- a/dockerfiles/app/Dockerfile
+++ b/dockerfiles/app/Dockerfile
@@ -20,4 +20,6 @@ EXPOSE 8000
 
 USER nobody
 
+ENV PYTHONPATH=/
+
 CMD ["poetry", "run", "uvicorn", "app.main:app", "--reload", "--host", "0.0.0.0", "--port", "8000"]

--- a/dockerfiles/endorser/Dockerfile
+++ b/dockerfiles/endorser/Dockerfile
@@ -20,4 +20,6 @@ EXPOSE 3009
 
 USER nobody
 
+ENV PYTHONPATH=/
+
 CMD ["poetry", "run", "uvicorn", "endorser.main:app", "--reload", "--host", "0.0.0.0", "--port", "3009"]

--- a/dockerfiles/trustregistry/Dockerfile
+++ b/dockerfiles/trustregistry/Dockerfile
@@ -20,4 +20,6 @@ EXPOSE 8001
 
 USER nobody
 
+ENV PYTHONPATH=/
+
 CMD ["poetry", "run", "uvicorn", "trustregistry.main:app", "--reload", "--host", "0.0.0.0", "--port", "8001"]

--- a/dockerfiles/waypoint/Dockerfile
+++ b/dockerfiles/waypoint/Dockerfile
@@ -20,4 +20,6 @@ EXPOSE 3011
 
 USER nobody
 
+ENV PYTHONPATH=/
+
 CMD ["poetry", "run", "uvicorn", "waypoint.main:app", "--reload", "--host", "0.0.0.0", "--port", "3011"]

--- a/scripts/download_openapi_specs.sh
+++ b/scripts/download_openapi_specs.sh
@@ -34,6 +34,12 @@ for ENDPOINT in "${!ENDPOINTS[@]}"; do
       echo "Formatted JSON: $FILEPATH"
     fi
 
+    # Format YAML files
+    if [[ "$FILENAME" == *.yaml ]]; then
+      yq . "$FILEPATH" > "$TEMPFILE" && mv "$TEMPFILE" "$FILEPATH"
+      echo "Formatted JSON: $FILEPATH"
+    fi
+
     # Remove temporary file if it exists
     if [[ -f "$TEMPFILE" ]]; then
       rm "$TEMPFILE"


### PR DESCRIPTION
Add GitHub workflow for automatically managing OpenAPI specifications:
- Create new OpenAPI workflow job in the CI/CD pipeline
- Add tooling to compare and diff API specs
- Automatically comment on PRs with API changes
- Create PRs for syncing OpenAPI specs with code changes
- Set `PYTHONPATH` in all service Dockerfiles for proper imports