### PR TITLE
:arrow_up: Upgrade wallet-group-id plugin and cloudcontroller

### DIFF
--- a/app/models/tenants.py
+++ b/app/models/tenants.py
@@ -1,7 +1,6 @@
 import re
 from typing import Dict, List, Literal, Optional
 
-from aries_cloudcontroller import CreateWalletRequest, UpdateWalletRequest
 from pydantic import BaseModel, Field, field_validator
 
 from shared.exceptions import CloudApiValueError
@@ -47,10 +46,6 @@ ExtraSettings_field = Field(
     description="Optional per-tenant settings to configure wallet behaviour for advanced users.",
     examples=[{"ACAPY_AUTO_ACCEPT_INVITES": False}],
 )
-
-
-class CreateWalletRequestWithGroups(CreateWalletRequest):
-    group_id: Optional[str] = group_id_field
 
 
 class CreateTenantRequest(BaseModel):
@@ -138,12 +133,6 @@ class UpdateTenantRequest(BaseModel):
                 f"spaces, and the following special characters are allowed: {allowable_special_chars}"
             )
         return v
-
-
-class UpdateWalletRequestWithGroupId(UpdateWalletRequest):
-    """Adds group_id to the default UpdateWalletRequest body"""
-
-    group_id: Optional[str] = Field(default=None, examples=["some_group_id"])
 
 
 class Tenant(BaseModel):

--- a/app/routes/admin/tenants.py
+++ b/app/routes/admin/tenants.py
@@ -2,7 +2,10 @@ from secrets import token_urlsafe
 from typing import List, Optional
 
 import base58
-from aries_cloudcontroller import CreateWalletTokenRequest
+from aries_cloudcontroller import (
+    CreateWalletRequestWithGroupId,
+    CreateWalletTokenRequest,
+)
 from fastapi import APIRouter, Depends, HTTPException, Query
 from uuid_utils import uuid4
 
@@ -21,7 +24,6 @@ from app.exceptions import (
 from app.models.tenants import (
     CreateTenantRequest,
     CreateTenantResponse,
-    CreateWalletRequestWithGroups,
     Tenant,
     TenantAuth,
     UpdateTenantRequest,
@@ -155,7 +157,7 @@ async def create_tenant(
     wallet_response = None
     body_request = handle_model_with_validation(
         logger=bound_logger,
-        model_class=CreateWalletRequestWithGroups,
+        model_class=CreateWalletRequestWithGroupId,
         image_url=body.image_url,
         key_management_mode="managed",
         label=wallet_label,

--- a/app/services/onboarding/tenants.py
+++ b/app/services/onboarding/tenants.py
@@ -1,6 +1,10 @@
 from typing import List
 
-from aries_cloudcontroller import AcaPyClient, UpdateWalletRequest, WalletRecord
+from aries_cloudcontroller import (
+    AcaPyClient,
+    UpdateWalletRequest,
+    WalletRecordWithGroupId,
+)
 from fastapi.exceptions import HTTPException
 
 from app.dependencies.acapy_clients import (
@@ -26,7 +30,7 @@ async def handle_tenant_update(
     admin_controller: AcaPyClient,
     wallet_id: str,
     update_request: UpdateTenantRequest,
-) -> WalletRecord:
+) -> WalletRecordWithGroupId:
     bound_logger = logger.bind(body={"wallet_id": wallet_id})
     bound_logger.bind(body=update_request).debug("Handling tenant update")
 

--- a/app/services/onboarding/tenants.py
+++ b/app/services/onboarding/tenants.py
@@ -2,7 +2,7 @@ from typing import List
 
 from aries_cloudcontroller import (
     AcaPyClient,
-    UpdateWalletRequest,
+    UpdateWalletRequestWithGroupId,
     WalletRecordWithGroupId,
 )
 from fastapi.exceptions import HTTPException
@@ -92,7 +92,7 @@ async def handle_tenant_update(
     bound_logger.debug("Updating wallet")
     request_body = handle_model_with_validation(
         logger=bound_logger,
-        model_class=UpdateWalletRequest,
+        model_class=UpdateWalletRequestWithGroupId,
         label=new_label,
         image_url=update_request.image_url,
         extra_settings=update_request.extra_settings,

--- a/app/tests/routes/admin_tenants/test_create_tenant.py
+++ b/app/tests/routes/admin_tenants/test_create_tenant.py
@@ -3,14 +3,13 @@ from unittest.mock import AsyncMock, patch
 
 import base58
 import pytest
-from aries_cloudcontroller import CreateWalletResponse
+from aries_cloudcontroller import CreateWalletRequestWithGroupId, CreateWalletResponse
 from fastapi import HTTPException
 
 from app.dependencies.acapy_clients import TENANT_ADMIN_AUTHED
 from app.exceptions import CloudApiException, TrustRegistryException
 from app.models.tenants import (
     CreateTenantRequest,
-    CreateWalletRequestWithGroups,
     OnboardResult,
 )
 from app.routes.admin.tenants import create_tenant
@@ -60,7 +59,7 @@ async def test_create_tenant_success(roles):
 
     mock_register_actor = AsyncMock()
 
-    expected_wallet_body = CreateWalletRequestWithGroups(
+    expected_wallet_body = CreateWalletRequestWithGroupId(
         image_url=body.image_url,
         key_management_mode="managed",
         label=wallet_label,

--- a/app/util/tenants.py
+++ b/app/util/tenants.py
@@ -3,7 +3,7 @@ import json
 from logging import Logger
 from typing import Optional
 
-from aries_cloudcontroller import AcaPyClient, WalletRecordWithGroups
+from aries_cloudcontroller import AcaPyClient, WalletRecordWithGroupId
 from fastapi import HTTPException
 
 from app.dependencies.acapy_clients import get_tenant_admin_controller
@@ -20,7 +20,7 @@ class WalletNotFoundException(HTTPException):
         )
 
 
-def tenant_from_wallet_record(wallet_record: WalletRecordWithGroups) -> Tenant:
+def tenant_from_wallet_record(wallet_record: WalletRecordWithGroupId) -> Tenant:
     label: str = wallet_record.settings.get("default_label") or ""
     wallet_name: str = wallet_record.settings.get("wallet.name") or ""
     image_url: Optional[str] = wallet_record.settings.get("image_url")
@@ -64,7 +64,7 @@ async def get_wallet_and_assert_valid_group(
     wallet_id: str,
     group_id: Optional[str],
     logger: Logger,
-) -> WalletRecordWithGroups:
+) -> WalletRecordWithGroupId:
     """Fetch the wallet record for wallet_id, and assert it exists and belongs to group.
 
     Args:
@@ -77,7 +77,7 @@ async def get_wallet_and_assert_valid_group(
         HTTPException: If the wallet does not exist or does not belong to group
 
     Returns:
-        WalletRecordWithGroups: When assertions pass, returns the wallet record.
+        WalletRecordWithGroupId: When assertions pass, returns the wallet record.
     """
     logger.debug("Retrieving the wallet record for {}", wallet_id)
     wallet = await handle_acapy_call(
@@ -98,7 +98,7 @@ async def get_wallet_and_assert_valid_group(
 
 
 def assert_valid_group(
-    wallet: WalletRecordWithGroups,
+    wallet: WalletRecordWithGroupId,
     wallet_id: str,
     group_id: Optional[str],
     logger: Logger,
@@ -106,7 +106,7 @@ def assert_valid_group(
     """Assert that wallet record belongs to group, and raise exception if not.
 
     Args:
-        wallet (WalletRecordWithGroups): The wallet record to check.
+        wallet (WalletRecordWithGroupId): The wallet record to check.
         wallet_id (str): The wallet id for the wallet record.
         group_id (Optional[str]): The group to validate against.
         logger (Logger): A logger object.

--- a/dockerfiles/agents/Dockerfile
+++ b/dockerfiles/agents/Dockerfile
@@ -5,8 +5,7 @@ USER root
 # Install Google Protobuf and Plugins
 ARG PROTOBUF_VERSION=5.29.3
 RUN pip install --no-cache-dir protobuf==${PROTOBUF_VERSION} \
-  # acapy-wallet-groups-plugin==1.3.0.post20250505 \
-  git+https://github.com/didx-xyz/acapy-wallet-groups-plugin@2ab60436 \
+  acapy-wallet-groups-plugin==1.3.0.post20250506 \
   git+https://github.com/didx-xyz/aries-acapy-plugins@1.3.0-20250505#subdirectory=nats_events
 
 COPY scripts/startup.sh startup.sh

--- a/dockerfiles/agents/Dockerfile
+++ b/dockerfiles/agents/Dockerfile
@@ -6,7 +6,7 @@ USER root
 ARG PROTOBUF_VERSION=5.29.3
 RUN pip install --no-cache-dir protobuf==${PROTOBUF_VERSION} \
   # acapy-wallet-groups-plugin==1.3.0.post20250505 \
-  git+https://github.com/didx-xyz/acapy-wallet-groups-plugin@update-models \
+  git+https://github.com/didx-xyz/acapy-wallet-groups-plugin@433a7e1d \
   git+https://github.com/didx-xyz/aries-acapy-plugins@1.3.0-20250505#subdirectory=nats_events
 
 COPY scripts/startup.sh startup.sh

--- a/dockerfiles/agents/Dockerfile
+++ b/dockerfiles/agents/Dockerfile
@@ -5,7 +5,8 @@ USER root
 # Install Google Protobuf and Plugins
 ARG PROTOBUF_VERSION=5.29.3
 RUN pip install --no-cache-dir protobuf==${PROTOBUF_VERSION} \
-  acapy-wallet-groups-plugin==1.3.0.post20250505 \
+  # acapy-wallet-groups-plugin==1.3.0.post20250505 \
+  git+https://github.com/didx-xyz/acapy-wallet-groups-plugin@update-models \
   git+https://github.com/didx-xyz/aries-acapy-plugins@1.3.0-20250505#subdirectory=nats_events
 
 COPY scripts/startup.sh startup.sh

--- a/dockerfiles/agents/Dockerfile
+++ b/dockerfiles/agents/Dockerfile
@@ -6,7 +6,7 @@ USER root
 ARG PROTOBUF_VERSION=5.29.3
 RUN pip install --no-cache-dir protobuf==${PROTOBUF_VERSION} \
   # acapy-wallet-groups-plugin==1.3.0.post20250505 \
-  git+https://github.com/didx-xyz/acapy-wallet-groups-plugin@433a7e1d \
+  git+https://github.com/didx-xyz/acapy-wallet-groups-plugin@2ab60436 \
   git+https://github.com/didx-xyz/aries-acapy-plugins@1.3.0-20250505#subdirectory=nats_events
 
 COPY scripts/startup.sh startup.sh

--- a/docs/openapi/tenant-openapi.json
+++ b/docs/openapi/tenant-openapi.json
@@ -6200,7 +6200,8 @@
               "key",
               "web",
               "did:peer:2",
-              "did:peer:4"
+              "did:peer:4",
+              "cheqd"
             ],
             "title": "Method",
             "description": "Did method associated with the DID"

--- a/docs/openapi/tenant-openapi.yaml
+++ b/docs/openapi/tenant-openapi.yaml
@@ -3627,6 +3627,7 @@ components:
             - web
             - did:peer:2
             - did:peer:4
+            - cheqd
           title: Method
           description: Did method associated with the DID
         posture:

--- a/poetry.lock
+++ b/poetry.lock
@@ -216,14 +216,16 @@ test = ["anyio[trio]", "blockbuster (>=1.5.23)", "coverage[toml] (>=7)", "except
 trio = ["trio (>=0.26.1)"]
 
 [[package]]
-name = "aries_cloudcontroller"
+name = "aries-cloudcontroller"
 version = "1.3.0.post20250506"
 description = "A simple python client for controlling an ACA-Py agent"
 optional = false
 python-versions = ">=3.9"
 groups = ["app", "endorser"]
-files = []
-develop = false
+files = [
+    {file = "aries_cloudcontroller-1.3.0.post20250506-py3-none-any.whl", hash = "sha256:cedbd3051a00d7da1d10fded510464b4d5b362b48679fba1b68756fcf21ff875"},
+    {file = "aries_cloudcontroller-1.3.0.post20250506.tar.gz", hash = "sha256:a3e308b062667fc8c88c5ec82f4bc3225414d5d6cb52696ef9c848e32f72ce63"},
+]
 
 [package.dependencies]
 aiohttp = ">=3.9.4,<4.0"
@@ -233,12 +235,6 @@ pydantic = ">=2.6,<3.0"
 python-dateutil = ">=2"
 typing-extensions = ">=4,<5.0"
 urllib3 = ">=2.1,<3"
-
-[package.source]
-type = "git"
-url = "https://github.com/didx-xyz/aries-cloudcontroller-python.git"
-reference = "release-1.3.0-20250505"
-resolved_reference = "447c07f6d20e24b6d72722efdfd891317439a3a2"
 
 [[package]]
 name = "astroid"
@@ -2540,4 +2536,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "~3.13.3"
-content-hash = "4e37a374842f72c788f2490a9f610b3a2cc913a1b56c0b14e027bf4bdeeed88c"
+content-hash = "a219ae1d76db6624f8bcf9370e1deb3eda9e82f0a6109ccf69d1a72a66807c7c"

--- a/poetry.lock
+++ b/poetry.lock
@@ -216,16 +216,14 @@ test = ["anyio[trio]", "blockbuster (>=1.5.23)", "coverage[toml] (>=7)", "except
 trio = ["trio (>=0.26.1)"]
 
 [[package]]
-name = "aries-cloudcontroller"
-version = "1.3.0rc1.post20250417"
+name = "aries_cloudcontroller"
+version = "1.3.0.post20250506"
 description = "A simple python client for controlling an ACA-Py agent"
 optional = false
 python-versions = ">=3.9"
 groups = ["app", "endorser"]
-files = [
-    {file = "aries_cloudcontroller-1.3.0rc1.post20250417-py3-none-any.whl", hash = "sha256:03d4b9592dcff4e93b61f4742db8ad1f4d93591e81be64528e6d15159c5d6766"},
-    {file = "aries_cloudcontroller-1.3.0rc1.post20250417.tar.gz", hash = "sha256:c0ae1c1ac2739522272aa8d4403368a2e8e0225ce543b43dfec4a2527345c864"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 aiohttp = ">=3.9.4,<4.0"
@@ -235,6 +233,12 @@ pydantic = ">=2.6,<3.0"
 python-dateutil = ">=2"
 typing-extensions = ">=4,<5.0"
 urllib3 = ">=2.1,<3"
+
+[package.source]
+type = "git"
+url = "https://github.com/didx-xyz/aries-cloudcontroller-python.git"
+reference = "release-1.3.0-20250505"
+resolved_reference = "a7f12ef0f35f48b706abf84e9391ad5e22a20399"
 
 [[package]]
 name = "astroid"
@@ -1631,7 +1635,6 @@ files = [
     {file = "psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:bb89f0a835bcfc1d42ccd5f41f04870c1b936d8507c6df12b7737febc40f0909"},
     {file = "psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f0c2d907a1e102526dd2986df638343388b94c33860ff3bbe1384130828714b1"},
     {file = "psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f8157bed2f51db683f31306aa497311b560f2265998122abe1dce6428bd86567"},
-    {file = "psycopg2_binary-2.9.10-cp313-cp313-win_amd64.whl", hash = "sha256:27422aa5f11fbcd9b18da48373eb67081243662f9b46e6fd07c3eb46e4535142"},
     {file = "psycopg2_binary-2.9.10-cp38-cp38-macosx_12_0_x86_64.whl", hash = "sha256:eb09aa7f9cecb45027683bb55aebaaf45a0df8bf6de68801a6afdc7947bb09d4"},
     {file = "psycopg2_binary-2.9.10-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b73d6d7f0ccdad7bc43e6d34273f70d587ef62f824d7261c4ae9b8b1b6af90e8"},
     {file = "psycopg2_binary-2.9.10-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ce5ab4bf46a211a8e924d307c1b1fcda82368586a19d0a24f8ae166f5c784864"},
@@ -1820,14 +1823,14 @@ tests = ["coverage[toml] (==5.0.4)", "pytest (>=6.0.0,<7.0.0)"]
 
 [[package]]
 name = "pylint"
-version = "3.3.6"
+version = "3.3.7"
 description = "python code static checker"
 optional = false
 python-versions = ">=3.9.0"
 groups = ["dev"]
 files = [
-    {file = "pylint-3.3.6-py3-none-any.whl", hash = "sha256:8b7c2d3e86ae3f94fb27703d521dd0b9b6b378775991f504d7c3a6275aa0a6a6"},
-    {file = "pylint-3.3.6.tar.gz", hash = "sha256:b634a041aac33706d56a0d217e6587228c66427e20ec21a019bc4cdee48c040a"},
+    {file = "pylint-3.3.7-py3-none-any.whl", hash = "sha256:43860aafefce92fca4cf6b61fe199cdc5ae54ea28f9bf4cd49de267b5195803d"},
+    {file = "pylint-3.3.7.tar.gz", hash = "sha256:2b11de8bde49f9c5059452e0c310c079c746a0a8eeaa789e5aa966ecc23e4559"},
 ]
 
 [package.dependencies]
@@ -2161,14 +2164,14 @@ sqlcipher = ["sqlcipher3_binary"]
 
 [[package]]
 name = "sse-starlette"
-version = "2.3.3"
+version = "2.3.4"
 description = "SSE plugin for Starlette"
 optional = false
 python-versions = ">=3.9"
 groups = ["waypoint"]
 files = [
-    {file = "sse_starlette-2.3.3-py3-none-any.whl", hash = "sha256:8b0a0ced04a329ff7341b01007580dd8cf71331cc21c0ccea677d500618da1e0"},
-    {file = "sse_starlette-2.3.3.tar.gz", hash = "sha256:fdd47c254aad42907cfd5c5b83e2282be15be6c51197bf1a9b70b8e990522072"},
+    {file = "sse_starlette-2.3.4-py3-none-any.whl", hash = "sha256:b8100694f3f892b133d0f7483acb7aacfcf6ed60f863b31947664b6dc74e529f"},
+    {file = "sse_starlette-2.3.4.tar.gz", hash = "sha256:0ffd6bed217cdbb74a84816437c609278003998b4991cd2e6872d0b35130e4d5"},
 ]
 
 [package.dependencies]
@@ -2380,14 +2383,14 @@ test = ["aiohttp (>=3.10.5)", "flake8 (>=5.0,<6.0)", "mypy (>=0.800)", "psutil",
 
 [[package]]
 name = "virtualenv"
-version = "20.30.0"
+version = "20.31.1"
 description = "Virtual Python Environment builder"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "virtualenv-20.30.0-py3-none-any.whl", hash = "sha256:e34302959180fca3af42d1800df014b35019490b119eba981af27f2fa486e5d6"},
-    {file = "virtualenv-20.30.0.tar.gz", hash = "sha256:800863162bcaa5450a6e4d721049730e7f2dae07720e0902b0e4040bd6f9ada8"},
+    {file = "virtualenv-20.31.1-py3-none-any.whl", hash = "sha256:f448cd2f1604c831afb9ea238021060be2c0edbcad8eb0a4e8b4e14ff11a5482"},
+    {file = "virtualenv-20.31.1.tar.gz", hash = "sha256:65442939608aeebb9284cd30baca5865fcd9f12b58bb740a24b220030df46d26"},
 ]
 
 [package.dependencies]
@@ -2537,4 +2540,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "~3.13.3"
-content-hash = "470c611472be34638e1796601275400e448e6b9e683ef8a8c036e93c6d8a14bd"
+content-hash = "4e37a374842f72c788f2490a9f610b3a2cc913a1b56c0b14e027bf4bdeeed88c"

--- a/poetry.lock
+++ b/poetry.lock
@@ -238,7 +238,7 @@ urllib3 = ">=2.1,<3"
 type = "git"
 url = "https://github.com/didx-xyz/aries-cloudcontroller-python.git"
 reference = "release-1.3.0-20250505"
-resolved_reference = "c895da0f1ff358cc4ec016c12900678a675ced54"
+resolved_reference = "447c07f6d20e24b6d72722efdfd891317439a3a2"
 
 [[package]]
 name = "astroid"

--- a/poetry.lock
+++ b/poetry.lock
@@ -238,7 +238,7 @@ urllib3 = ">=2.1,<3"
 type = "git"
 url = "https://github.com/didx-xyz/aries-cloudcontroller-python.git"
 reference = "release-1.3.0-20250505"
-resolved_reference = "a7f12ef0f35f48b706abf84e9391ad5e22a20399"
+resolved_reference = "c895da0f1ff358cc4ec016c12900678a675ced54"
 
 [[package]]
 name = "astroid"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,13 +27,13 @@ uvloop = "^0.21.0"
 [tool.poetry.group.app.dependencies]
 aiohttp = "~3.11.7"
 aiocache = "~0.12.0"
-aries-cloudcontroller = { git = "https://github.com/didx-xyz/aries-cloudcontroller-python.git", branch = "release-1.3.0-20250505" }
+aries-cloudcontroller = "==1.3.0.post20250506"
 base58 = "~2.1.1"
 pyjwt = "~2.10.0"
 uuid_utils = "^0.10.0"
 
 [tool.poetry.group.endorser.dependencies]
-aries-cloudcontroller = { git = "https://github.com/didx-xyz/aries-cloudcontroller-python.git", branch = "release-1.3.0-20250505" }
+aries-cloudcontroller = "==1.3.0.post20250506"
 dependency-injector = "^4.46.0"
 nats-py = { extras = ["nkeys"], version = "^2.10.0" }
 tenacity = "^9.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,13 +27,13 @@ uvloop = "^0.21.0"
 [tool.poetry.group.app.dependencies]
 aiohttp = "~3.11.7"
 aiocache = "~0.12.0"
-aries-cloudcontroller = "==1.3.0rc1.post20250417"
+aries-cloudcontroller = { git = "https://github.com/didx-xyz/aries-cloudcontroller-python.git", branch = "release-1.3.0-20250505" }
 base58 = "~2.1.1"
 pyjwt = "~2.10.0"
 uuid_utils = "^0.10.0"
 
 [tool.poetry.group.endorser.dependencies]
-aries-cloudcontroller = "==1.3.0rc1.post20250417"
+aries-cloudcontroller = { git = "https://github.com/didx-xyz/aries-cloudcontroller-python.git", branch = "release-1.3.0-20250505" }
 dependency-injector = "^4.46.0"
 nats-py = { extras = ["nkeys"], version = "^2.10.0" }
 tenacity = "^9.1.0"


### PR DESCRIPTION
I'm busy regenerating the cloudcontroller with Cheqd endpoints, and noticed the group-id plugin models should be updated

plugin changes: https://github.com/didx-xyz/acapy-wallet-groups-plugin/pull/80
cloudcontroller changes: https://github.com/didx-xyz/aries-cloudcontroller-python/pull/246
___
Includes model renames / refactoring for Create/Update tenant requests. (Note: does not impact API spec, because these cloudcontroller models are used internally, and not in client-side request bodies -- the openapi changes are for `cheqd` being added to supported DID methods, from cloudcontroller update)