### PR TITLE
:rewind: Revert Python 3.13 upgrade

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -25,7 +25,7 @@ jobs:
           [tools]
           "pipx:black" = "25.1"
           "pipx:isort" = "6.0"
-          python = "3.13"
+          python = "3.12"
           EOF
 
       - name: Set up Mise

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -57,7 +57,7 @@ jobs:
           cat <<EOF > .mise.toml
           [tools]
           poetry = "2.1"
-          python = "3.13"
+          python = "3.12"
 
           [settings]
           experimental = true

--- a/.mise.toml
+++ b/.mise.toml
@@ -8,7 +8,7 @@ kind = "0.27"
 kubectl = "1.32"
 poetry = "2.1"
 pre-commit = "4.2"
-python = "3.13"
+python = "3.12"
 tilt = "0.34"
 usage = "latest"
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -91,7 +91,7 @@ persistent=yes
 
 # Minimum Python version to use for version dependent checks. Will default to
 # the version used to run pylint.
-py-version=3.13
+py-version=3.12
 
 # Discover python modules and packages in the file system subtree.
 recursive=no

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # acapy-cloud
 
-![Python](https://img.shields.io/badge/python-3.13-blue.svg)
+![Python](https://img.shields.io/badge/python-3.12-blue.svg)
 [![Toolset: Mise](https://img.shields.io/badge/toolset-Mise-orange.svg?style=flat)](https://mise.jdx.dev/)
 [![Dev Experience: Tilt](https://img.shields.io/badge/devex-Tilt-blue.svg?style=flat)](https://tilt.dev)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/ceca5ac566f74a3a8bfb3095074117ad)](https://app.codacy.com/gh/didx-xyz/acapy-cloud/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)

--- a/dockerfiles/app/Dockerfile
+++ b/dockerfiles/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13.3-slim
+FROM python:3.12.10-slim
 
 WORKDIR /app
 

--- a/dockerfiles/endorser/Dockerfile
+++ b/dockerfiles/endorser/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13.3-slim
+FROM python:3.12.10-slim
 
 WORKDIR /endorser
 

--- a/dockerfiles/tests/Dockerfile
+++ b/dockerfiles/tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13.3-slim
+FROM python:3.12.10-slim
 
 # Copy the pyproject.toml and lock file
 COPY pyproject.toml cloudapi-tests/

--- a/dockerfiles/trustregistry/Dockerfile
+++ b/dockerfiles/trustregistry/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13.3-slim
+FROM python:3.12.10-slim
 
 WORKDIR /trustregistry
 

--- a/dockerfiles/waypoint/Dockerfile
+++ b/dockerfiles/waypoint/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13.3-slim
+FROM python:3.12.10-slim
 
 WORKDIR /waypoint
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -209,6 +209,7 @@ files = [
 [package.dependencies]
 idna = ">=2.8"
 sniffio = ">=1.1"
+typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
 
 [package.extras]
 doc = ["Sphinx (>=8.2,<9.0)", "packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx_rtd_theme"]
@@ -1631,6 +1632,7 @@ files = [
     {file = "psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:bb89f0a835bcfc1d42ccd5f41f04870c1b936d8507c6df12b7737febc40f0909"},
     {file = "psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f0c2d907a1e102526dd2986df638343388b94c33860ff3bbe1384130828714b1"},
     {file = "psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f8157bed2f51db683f31306aa497311b560f2265998122abe1dce6428bd86567"},
+    {file = "psycopg2_binary-2.9.10-cp313-cp313-win_amd64.whl", hash = "sha256:27422aa5f11fbcd9b18da48373eb67081243662f9b46e6fd07c3eb46e4535142"},
     {file = "psycopg2_binary-2.9.10-cp38-cp38-macosx_12_0_x86_64.whl", hash = "sha256:eb09aa7f9cecb45027683bb55aebaaf45a0df8bf6de68801a6afdc7947bb09d4"},
     {file = "psycopg2_binary-2.9.10-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b73d6d7f0ccdad7bc43e6d34273f70d587ef62f824d7261c4ae9b8b1b6af90e8"},
     {file = "psycopg2_binary-2.9.10-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ce5ab4bf46a211a8e924d307c1b1fcda82368586a19d0a24f8ae166f5c784864"},
@@ -2230,7 +2232,7 @@ version = "4.13.2"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "app", "endorser", "trust-registry"]
+groups = ["main", "app", "dev", "endorser", "trust-registry", "waypoint"]
 files = [
     {file = "typing_extensions-4.13.2-py3-none-any.whl", hash = "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c"},
     {file = "typing_extensions-4.13.2.tar.gz", hash = "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef"},
@@ -2535,5 +2537,5 @@ propcache = ">=0.2.1"
 
 [metadata]
 lock-version = "2.1"
-python-versions = "~3.13.3"
-content-hash = "a219ae1d76db6624f8bcf9370e1deb3eda9e82f0a6109ccf69d1a72a66807c7c"
+python-versions = "~3.12.10"
+content-hash = "7c6088755e64651d03b67b6d57cf04c35cdd2ca2869c74ea695ef8024e942dda"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 package-mode = false
 
 [tool.poetry.dependencies]
-python = "~3.13.3"
+python = "~3.12.10"
 
 fastapi = "~0.115.10"
 httpx = "~0.28.0"


### PR DESCRIPTION
There seems to be an issue with Uvicorn/FastAPI under load getting a SIGSEGV (segmentation fault) without any logs.

It's very inconsistent and happens after a while of throwing load at it (via k6)

@wdbasson

This is to test if reverting the Python 3.13 upgrade resolves the issue.