### PR TITLE
👷 Fix PR number handling in OpenAPI GitHub workflow

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -129,7 +129,7 @@ jobs:
     uses: ./.github/workflows/update-openapi.yml
     with:
       image-version: ${{ needs.docker.outputs.image_version }}
-      pr-number: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
+      pr-number: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || 0 }}
     secrets:
       devops-app-id: ${{ secrets.DEVOPS_APP_ID }}
       devops-private-key: ${{ secrets.DEVOPS_PRIVATE_KEY }}

--- a/.github/workflows/update-openapi.yml
+++ b/.github/workflows/update-openapi.yml
@@ -11,6 +11,7 @@ on:
         description: Pull request number (if triggered by a PR)
         required: false
         type: number
+        default: 0
     secrets:
       devops-app-id:
         required: true
@@ -59,7 +60,7 @@ jobs:
         with:
           persist-credentials: true
           token: ${{ steps.devops_login.outputs.token }}
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event.repository.default_branch }}
 
       - name: Check if services are up
         run: |
@@ -127,7 +128,7 @@ jobs:
 
       - name: Comment on PR
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        if: inputs.pr-number != ''
+        if: inputs.pr-number != 0
         with:
           github-token: ${{ steps.devops_login.outputs.token }}
           script: |
@@ -254,7 +255,7 @@ jobs:
             }
 
       - name: Commit and open PR for OpenAPI spec changes
-        if: inputs.pr-number == '' && github.ref_name == github.event.repository.default_branch
+        if: inputs.pr-number == 0 && github.ref_name == github.event.repository.default_branch
         env:
           HEAD_BRANCH: devops/sync-openapi
           BASE_BRANCH: ${{ github.event.repository.default_branch }}


### PR DESCRIPTION
Replace empty string with 0 for default PR number value to ensure
consistent type handling in conditional statements. This addresses
issues with string vs numeric comparisons in workflow conditions.

Improve checkout reference to dynamically use PR head sha when in PR
context, falling back to repository default branch otherwise. This
ensures more reliable behavior across different workflow trigger
contexts.