### PR TITLE
:construction_worker: 🔧 Refine credentials handling in OpenAPI workflow

### DIFF
--- a/.github/workflows/update-openapi.yml
+++ b/.github/workflows/update-openapi.yml
@@ -58,9 +58,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          persist-credentials: true
-          token: ${{ steps.devops_login.outputs.token }}
+          persist-credentials: ${{ github.event_name != 'pull_request' }}
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event.repository.default_branch }}
+          token: ${{ steps.devops_login.outputs.token }}
 
       - name: Check if services are up
         run: |
@@ -128,7 +128,7 @@ jobs:
 
       - name: Comment on PR
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        if: inputs.pr-number != 0
+        if: github.event_name == 'pull_request'
         with:
           github-token: ${{ steps.devops_login.outputs.token }}
           script: |
@@ -255,16 +255,13 @@ jobs:
             }
 
       - name: Commit and open PR for OpenAPI spec changes
-        if: inputs.pr-number == 0 && github.ref_name == github.event.repository.default_branch
+        if: github.event_name != 'pull_request' && github.ref_name == github.event.repository.default_branch
         env:
           HEAD_BRANCH: devops/sync-openapi
           BASE_BRANCH: ${{ github.event.repository.default_branch }}
           GITHUB_TOKEN: ${{ steps.devops_login.outputs.token }}
           REPO: ${{ github.repository }}
         run: |
-          git config --global user.name "DIDx DevOps"
-          git config --global user.email "devops@didx.co.za"
-
           # Ensure we are on the correct branch
           git checkout -b ${HEAD_BRANCH}
 


### PR DESCRIPTION
Make `persist-credentials` conditional based on event type instead of using
a static value. This prevents credential issues when running in PR
contexts while maintaining proper auth for default branch operations.

Change PR detection to use `github.event_name` directly instead of relying
on `inputs.pr-number`, which provides more reliable event-type detection.

Remove redundant git config commands as these are not needed with the
authentication flow.