### PR TITLE
👷 🐛 Fix OpenAPI diff interpolation

### DIFF
--- a/.github/workflows/update-openapi.yml
+++ b/.github/workflows/update-openapi.yml
@@ -129,13 +129,19 @@ jobs:
       - name: Comment on PR
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         if: github.event_name == 'pull_request'
+        env:
+          TENANT_ADMIN_JSON_DIFF: ${{ steps.tenant-admin-json.outputs.diff }}
+          TENANT_ADMIN_YAML_DIFF: ${{ steps.tenant-admin-yaml.outputs.diff }}
+          TENANT_JSON_DIFF: ${{ steps.tenant-json.outputs.diff }}
+          TENANT_YAML_DIFF: ${{ steps.tenant-yaml.outputs.diff }}
+          PR_NUMBER: ${{ inputs.pr-number }}
         with:
           github-token: ${{ steps.devops_login.outputs.token }}
           script: |
-            const tenantAdminJsonDiff = `${{ steps.tenant-admin-json.outputs.diff }}`;
-            const tenantAdminYamlDiff = `${{ steps.tenant-admin-yaml.outputs.diff }}`;
-            const tenantJsonDiff = `${{ steps.tenant-json.outputs.diff }}`;
-            const tenantYamlDiff = `${{ steps.tenant-yaml.outputs.diff }}`;
+            const tenantAdminJsonDiff = process.env.TENANT_ADMIN_JSON_DIFF;
+            const tenantAdminYamlDiff = process.env.TENANT_ADMIN_YAML_DIFF;
+            const tenantJsonDiff = process.env.TENANT_JSON_DIFF;
+            const tenantYamlDiff = process.env.TENANT_YAML_DIFF;
 
             // Unique identifier for our comment
             const COMMENT_IDENTIFIER = "<!-- openapi-diff-check -->";
@@ -197,7 +203,7 @@ jobs:
             console.log('Added OpenAPI diff results to the step summary');
 
             // Check if PR number is provided
-            const prNumber = parseInt('${{ inputs.pr-number }}', 10);
+            const prNumber = parseInt(process.env.PR_NUMBER, 10);
             if (!prNumber) {
               console.log('PR number not provided, skipping PR comment creation');
               return;


### PR DESCRIPTION
Use `env` to get around JS and Github Actions variable interpolation shenanigans