### PR TITLE
:boom: Drop Indy credential type

### DIFF
--- a/app/services/issuer/acapy_issuer.py
+++ b/app/services/issuer/acapy_issuer.py
@@ -16,7 +16,7 @@ class Issuer(ABC):
         cls, controller: AcaPyClient, credential: CredentialWithConnection
     ) -> CredentialExchange:
         """
-        Create and send indy credential using Issue Credential protocol. Automating the entire flow.
+        Create and send credential using Issue Credential protocol. Automating the entire flow.
 
         Parameters:
         -----------

--- a/app/tests/models/test_issuer.py
+++ b/app/tests/models/test_issuer.py
@@ -4,14 +4,13 @@ from aries_cloudcontroller import Credential, LDProofVCDetail, LDProofVCOptions
 from app.models.issuer import (
     AnonCredsCredential,
     CredentialBase,
-    CredentialType,
 )
 from shared.exceptions.cloudapi_value_error import CloudApiValueError
 
 
 def test_credential_base_model():
-    CredentialBase(  # valid ld_proof
-        type=CredentialType.LD_PROOF,
+    # valid ld_proof
+    CredentialBase(
         ld_credential_detail=LDProofVCDetail(
             credential=Credential(
                 context=[],
@@ -24,8 +23,8 @@ def test_credential_base_model():
         ),
     )
 
-    CredentialBase(  # valid anoncreds
-        type=CredentialType.ANONCREDS,
+    # valid anoncreds
+    CredentialBase(
         anoncreds_credential_detail=AnonCredsCredential(
             issuer_did="WgWxqztrNooG92RXvxSTWv",
             credential_definition_id="WgWxqztrNooG92RXvxSTWv:3:CL:20:tag",
@@ -33,16 +32,32 @@ def test_credential_base_model():
         ),
     )
 
+    # both details are None
     with pytest.raises(CloudApiValueError) as exc:
-        CredentialBase(type=CredentialType.LD_PROOF, ld_credential_detail=None)
+        CredentialBase(ld_credential_detail=None, anoncreds_credential_detail=None)
     assert exc.value.detail == (
-        "ld_credential_detail must be populated if `ld_proof` "
-        "credential type is selected"
+        "One of anoncreds_credential_detail or ld_credential_detail must be populated"
     )
 
+    # both details are populated
     with pytest.raises(CloudApiValueError) as exc:
-        CredentialBase(type=CredentialType.ANONCREDS, anoncreds_credential_detail=None)
+        CredentialBase(
+            ld_credential_detail=LDProofVCDetail(
+                credential=Credential(
+                    context=[],
+                    credentialSubject={},
+                    issuanceDate="2024-04-18",
+                    issuer="abc",
+                    type=[],
+                ),
+                options=LDProofVCOptions(proofType="Ed25519Signature2018"),
+            ),
+            anoncreds_credential_detail=AnonCredsCredential(
+                issuer_did="WgWxqztrNooG92RXvxSTWv",
+                credential_definition_id="WgWxqztrNooG92RXvxSTWv:3:CL:20:tag",
+                attributes={},
+            ),
+        )
     assert exc.value.detail == (
-        "anoncreds_credential_detail must be populated if `anoncreds` "
-        "credential type is selected"
+        "Only one of anoncreds_credential_detail or ld_credential_detail must be populated"
     )

--- a/app/tests/routes/issuer/test_request_credential.py
+++ b/app/tests/routes/issuer/test_request_credential.py
@@ -14,7 +14,7 @@ from app.services.issuer.acapy_issuer_v2 import IssuerV2
 
 
 @pytest.mark.anyio
-@pytest.mark.parametrize("record_type", ["indy", "ld_proof", "bad"])
+@pytest.mark.parametrize("record_type", ["anoncreds", "ld_proof", "bad"])
 @pytest.mark.parametrize("save_exchange_record", [None, True, False])
 async def test_request_credential_success(record_type, save_exchange_record):
     mock_aries_controller = AsyncMock()
@@ -44,7 +44,7 @@ async def test_request_credential_success(record_type, save_exchange_record):
 
         if record_type == "bad":
             with pytest.raises(
-                HTTPException, match="Could not resolve record type"
+                HTTPException, match="Unsupported credential type: bad"
             ) as exc:
                 await request_credential(
                     credential_exchange_id="v2-test_id", auth="mocked_auth"
@@ -85,7 +85,7 @@ async def test_request_credential_fail_acapy_error(
     issuer.request_credential = IssuerV2.request_credential
 
     record = Mock()
-    record.type = "indy"
+    record.type = "anoncreds"
     issuer.get_record = AsyncMock(return_value=record)
 
     mock_aries_controller.issue_credential_v2_0.send_request = AsyncMock(
@@ -125,7 +125,7 @@ async def test_request_credential_fail_bad_record():
     issuer.request_credential = IssuerV2.request_credential
 
     record = Mock()
-    record.type = "indy"
+    record.type = "anoncreds"
     record.credential_definition_id = None
     issuer.get_record = AsyncMock(return_value=record)
 

--- a/app/tests/services/issuer/test_acapy_issuer_v2.py
+++ b/app/tests/services/issuer/test_acapy_issuer_v2.py
@@ -3,20 +3,15 @@ from aries_cloudcontroller import (
     AcaPyClient,
     V20CredAttrSpec,
     V20CredExRecord,
+    V20CredExRecordAnonCreds,
     V20CredExRecordByFormat,
     V20CredExRecordDetail,
-    V20CredExRecordIndy,
     V20CredExRecordListResult,
     V20CredPreview,
 )
 
 from app.exceptions.cloudapi_exception import CloudApiException
-from app.models.issuer import (
-    AnonCredsCredential,
-    CredentialType,
-    CredentialWithConnection,
-    IndyCredential,
-)
+from app.models.issuer import AnonCredsCredential, CredentialWithConnection
 from app.services.issuer.acapy_issuer_v2 import IssuerV2
 from app.tests.routes.issuer.test_create_offer import ld_cred
 
@@ -41,14 +36,14 @@ v2_credential_exchange_records = [
             cred_ex_id="db9d7025-b276-4c32-ae38-fbad41864112",
             by_format=V20CredExRecordByFormat(
                 cred_offer={
-                    "indy": {
+                    "anoncreds": {
                         "cred_def_id": cred_def_id_1,
                         "schema_id": schema_id_1,
                     }
                 }
             ),
         ),
-        indy=V20CredExRecordIndy(
+        anoncreds=V20CredExRecordAnonCreds(
             created_at="2021-09-15 14:41:47Z",
             updated_at="2021-09-15 14:49:47Z",
             cred_ex_id="db9d7025-b276-4c32-ae38-fbad41864112",
@@ -67,14 +62,14 @@ v2_credential_exchange_records = [
             cred_ex_id="db9d7025-b276-4c32-ae38-fbad41864133",
             by_format=V20CredExRecordByFormat(
                 cred_offer={
-                    "indy": {
+                    "anoncreds": {
                         "cred_def_id": cred_def_id_2,
                         "schema_id": schema_id_2,
                     }
                 }
             ),
         ),
-        indy=V20CredExRecordIndy(
+        anoncreds=V20CredExRecordAnonCreds(
             created_at="2021-09-15 14:41:47Z",
             updated_at="2021-09-15 14:49:47Z",
             cred_ex_id="db9d7025-b276-4c32-ae38-fbad41864112",
@@ -190,7 +185,7 @@ async def test_delete_credential_exchange(
 async def test_send_credential(mock_agent_controller: AcaPyClient):
     credential = CredentialWithConnection(
         connection_id=v2_record.cred_ex_record.connection_id,
-        indy_credential_detail=IndyCredential(
+        anoncreds_credential_detail=AnonCredsCredential(
             credential_definition_id=cred_def_id_1,
             attributes={
                 attr.name: attr.value
@@ -285,28 +280,8 @@ async def test_request_credential(mock_agent_controller: AcaPyClient):
 
 
 @pytest.mark.anyio
-async def test_create_offer_indy(mock_agent_controller: AcaPyClient):
-    credential = CredentialWithConnection(
-        type=CredentialType.INDY,
-        indy_credential_detail=IndyCredential(
-            credential_definition_id="WgWxqztrNooG92RXvxSTWv:3:CL:20:tag",
-            attributes={"name": "Alice", "age": "30"},
-        ),
-        connection_id="abc",
-    )
-
-    mock_agent_controller.issue_credential_v2_0.create_offer.return_value = (
-        v2_record.cred_ex_record
-    )
-    result = await IssuerV2.create_offer(mock_agent_controller, credential)
-
-    assert result.credential_exchange_id == f"v2-{v2_record.cred_ex_record.cred_ex_id}"
-
-
-@pytest.mark.anyio
 async def test_create_offer_ld_proof(mock_agent_controller: AcaPyClient):
     credential = CredentialWithConnection(
-        type=CredentialType.LD_PROOF,
         ld_credential_detail=ld_cred,
         connection_id="abc",
     )
@@ -322,7 +297,6 @@ async def test_create_offer_ld_proof(mock_agent_controller: AcaPyClient):
 @pytest.mark.anyio
 async def test_create_offer_anoncreds(mock_agent_controller: AcaPyClient):
     credential = CredentialWithConnection(
-        type=CredentialType.ANONCREDS,
         anoncreds_credential_detail=AnonCredsCredential(
             credential_definition_id="WgWxqztrNooG92RXvxSTWv:3:CL:20:tag",
             issuer_did="WgWxqztrNooG92RXvxSTWv",

--- a/app/tests/services/issuer/test_acapy_issuer_v2.py
+++ b/app/tests/services/issuer/test_acapy_issuer_v2.py
@@ -187,6 +187,7 @@ async def test_send_credential(mock_agent_controller: AcaPyClient):
         connection_id=v2_record.cred_ex_record.connection_id,
         anoncreds_credential_detail=AnonCredsCredential(
             credential_definition_id=cred_def_id_1,
+            issuer_did="did:sov:WgWxqztrNooG92RXvxSTWv",
             attributes={
                 attr.name: attr.value
                 for attr in v2_record.cred_ex_record.cred_preview.attributes
@@ -214,19 +215,6 @@ async def test_send_credential(mock_agent_controller: AcaPyClient):
         attr.name: attr.value
         for attr in v2_record.cred_ex_record.cred_preview.attributes
     }
-
-
-@pytest.mark.anyio
-async def test_send_credential_unsupported_cred_type(
-    mock_agent_controller: AcaPyClient,
-):
-    credential = CredentialWithConnection(type="jwt", connection_id="abc")
-
-    with pytest.raises(CloudApiException) as exc:
-        await IssuerV2.send_credential(mock_agent_controller, credential)
-
-    assert exc.value.detail == "Unsupported credential type: jwt"
-    assert exc.value.status_code == 501
 
 
 @pytest.mark.anyio
@@ -312,16 +300,3 @@ async def test_create_offer_anoncreds(mock_agent_controller: AcaPyClient):
     result = await IssuerV2.create_offer(mock_agent_controller, credential)
 
     assert result.credential_exchange_id == f"v2-{v2_record.cred_ex_record.cred_ex_id}"
-
-
-@pytest.mark.anyio
-async def test_create_offer_unsupported_credential_type(
-    mock_agent_controller: AcaPyClient,
-):
-    credential = CredentialWithConnection(type="jwt", connection_id="abc")
-
-    with pytest.raises(CloudApiException) as exc:
-        await IssuerV2.create_offer(mock_agent_controller, credential)
-
-    assert exc.value.detail == "Unsupported credential type: jwt"
-    assert exc.value.status_code == 501

--- a/app/tests/services/issuer/test_issuer.py
+++ b/app/tests/services/issuer/test_issuer.py
@@ -8,7 +8,7 @@ from pytest_mock import MockerFixture
 import app.routes.issuer as test_module
 from app.dependencies.auth import AcaPyAuth
 from app.exceptions import CloudApiException
-from app.models.issuer import CredentialBase, IndyCredential
+from app.models.issuer import AnonCredsCredential, CredentialBase
 from app.services.issuer.acapy_issuer_v2 import IssuerV2
 from shared.models.credential_exchange import CredentialExchange
 from shared.util.mock_agent_controller import MockContextManagedController
@@ -49,7 +49,7 @@ async def test_send_credential(
 
         credential = test_module.SendCredential(
             connection_id="conn_id",
-            indy_credential_detail=IndyCredential(
+            anoncreds_credential_detail=AnonCredsCredential(
                 credential_definition_id=cred_def_id,
                 attributes={"name": "John", "age": "23"},
             ),
@@ -231,7 +231,7 @@ async def test_request_credential(
 
     v2_record.credential_definition_id = "WgWxqztrNooG92RXvxSTWv:other:parts"
     v2_record.schema_id = "schema_id2"
-    v2_record.type = "indy"
+    v2_record.type = "anoncreds"
 
     ld_record.type = "ld_proof"
     ld_record.did = did
@@ -274,8 +274,7 @@ async def test_request_credential_x_no_schema_cred_def(mock_tenant_auth: AcaPyAu
 
     v2_record.credential_definition_id = None
     v2_record.schema_id = None
-    v2_record.type = "indy"
-
+    v2_record.type = "anoncreds"
     IssuerV2.get_record = AsyncMock(return_value=v2_record)
 
     with pytest.raises(
@@ -327,7 +326,6 @@ async def test_create_offer(
             return_value=mock_context_managed_controller(mock_agent_controller),
         )
         v2_credential = MagicMock(spec=CredentialBase)
-        v2_credential.type = "Indy"
 
         v2_record = MagicMock(spec=CredentialExchange)
         IssuerV2.create_offer = AsyncMock(return_value=v2_record)

--- a/app/tests/test_util_wallet_type_checks.py
+++ b/app/tests/test_util_wallet_type_checks.py
@@ -4,9 +4,7 @@ import pytest
 from aries_cloudcontroller import AcaPyClient
 
 from app.exceptions import CloudApiException
-from app.models.issuer import CredentialType
 from app.util.wallet_type_checks import (
-    assert_wallet_type_for_credential,
     get_wallet_type,
 )
 
@@ -111,21 +109,3 @@ async def test_get_wallet_type_invalid_wallet_type():
                 await get_wallet_type(aries_controller, logger)
             assert exc.value.status_code == 401
             assert exc.value.detail == "Invalid wallet type."
-
-
-def test_assert_wallet_type_for_credential():
-    # Test valid combinations
-    assert_wallet_type_for_credential("askar-anoncreds", CredentialType.ANONCREDS)
-    assert_wallet_type_for_credential("askar", CredentialType.INDY)
-
-    # Test invalid combinations
-    with pytest.raises(CloudApiException) as exc:
-        assert_wallet_type_for_credential("askar", CredentialType.ANONCREDS)
-    assert (
-        "AnonCreds credentials can only be issued by an askar-anoncreds wallet"
-        in str(exc.value)
-    )
-
-    with pytest.raises(CloudApiException) as exc:
-        assert_wallet_type_for_credential("askar-anoncreds", CredentialType.INDY)
-    assert "Indy credentials can only be issued by an askar wallet" in str(exc.value)

--- a/app/util/valid_issuer.py
+++ b/app/util/valid_issuer.py
@@ -4,10 +4,8 @@ from typing import Tuple
 from aries_cloudcontroller import AcaPyClient
 
 from app.exceptions import CloudApiException
-from app.models.issuer import CredentialType
 from app.services.acapy_wallet import assert_public_did
 from app.util.wallet_type_checks import (
-    assert_wallet_type_for_credential,
     get_wallet_type,
 )
 
@@ -27,9 +25,9 @@ async def assert_issuer_public_did(
 
 
 async def assert_public_did_and_wallet_type(
-    aries_controller: AcaPyClient, credential_type: CredentialType, bound_logger: Logger
+    aries_controller: AcaPyClient,
+    bound_logger: Logger,
 ) -> Tuple[str, str]:
     public_did = await assert_issuer_public_did(aries_controller, bound_logger)
     wallet_type = await get_wallet_type(aries_controller, bound_logger)
-    assert_wallet_type_for_credential(wallet_type, credential_type)
     return public_did, wallet_type

--- a/app/util/valid_issuer.py
+++ b/app/util/valid_issuer.py
@@ -25,8 +25,7 @@ async def assert_issuer_public_did(
 
 
 async def assert_public_did_and_wallet_type(
-    aries_controller: AcaPyClient,
-    bound_logger: Logger,
+    aries_controller: AcaPyClient, bound_logger: Logger
 ) -> Tuple[str, str]:
     public_did = await assert_issuer_public_did(aries_controller, bound_logger)
     wallet_type = await get_wallet_type(aries_controller, bound_logger)

--- a/app/util/wallet_type_checks.py
+++ b/app/util/wallet_type_checks.py
@@ -5,7 +5,6 @@ from aries_cloudcontroller import AcaPyClient
 
 from app.dependencies.acapy_clients import get_tenant_admin_controller
 from app.exceptions import CloudApiException, handle_acapy_call
-from app.models.issuer import CredentialType
 from app.util.tenants import get_wallet_id_from_b64encoded_jwt
 
 
@@ -38,17 +37,3 @@ async def get_wallet_type(
             raise CloudApiException(status_code=401, detail="Invalid wallet type.")
 
         return wallet_type
-
-
-def assert_wallet_type_for_credential(
-    wallet_type: Literal["askar", "askar-anoncreds"], credential_type: CredentialType
-) -> None:
-    if credential_type == CredentialType.ANONCREDS and wallet_type != "askar-anoncreds":
-        raise CloudApiException(
-            "AnonCreds credentials can only be issued by an askar-anoncreds wallet",
-            400,
-        )
-    if credential_type == CredentialType.INDY and wallet_type == "askar-anoncreds":
-        raise CloudApiException(
-            "Indy credentials can only be issued by an askar wallet", 400
-        )

--- a/dockerfiles/agents/Dockerfile
+++ b/dockerfiles/agents/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/didx-xyz/acapy-agent:py3.12-1.3.0-20250505@sha256:941c04facd7219904cec6eb3b0f3f6012528bad6fae7a91c0b73bc869a3fba87
+FROM ghcr.io/didx-xyz/acapy-agent:py3.12-test-1.3.0-20250507
 
 USER root
 

--- a/dockerfiles/agents/Dockerfile
+++ b/dockerfiles/agents/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/didx-xyz/acapy-agent:py3.12-test-1.3.0-20250507
+FROM ghcr.io/didx-xyz/acapy-agent:py3.12-1.3.0-20250505@sha256:941c04facd7219904cec6eb3b0f3f6012528bad6fae7a91c0b73bc869a3fba87
 
 USER root
 

--- a/docs/openapi/tenant-admin-openapi.json
+++ b/docs/openapi/tenant-admin-openapi.json
@@ -17,7 +17,7 @@
           "admin: tenants"
         ],
         "summary": "Create New Tenant",
-        "description": "Create a New Tenant\n---\n\nUse this endpoint to create a new Tenant, which is the same as creating a new Wallet.\n\nNB: To work with AnonCreds, the `askar-anoncreds` wallet type is required. i.e. To issue, verify, or\nhold AnonCreds, the issuer, verifier, or holder, requires the anoncreds wallet type.\n\nIndy credentials are compatible with `askar-anoncreds` wallets for holders or verifiers:\ni.e. an anoncreds wallet can hold or verify Indy credentials.\n\nHowever, issuers are restricted: an issuer with `askar` wallet type can only issue Indy credentials,\nand an issuer with `askar-anoncreds` wallet type can only issue AnonCreds.\n\nThe `wallet_label` is a required field that allows you to assign an alias to the Tenant.\nThis label is used as the default alias in connections (i.e. the other party will see this name in their records).\n\nIf roles (issuer and/or verifier) are specified, the Tenant will be onboarded with these roles and added to the\ntrust registry. An issuer or a verifier is referred to as an 'actor' in the trust registry, and the `wallet_label`\nwill be used as the name for this actor.\n\nIf no roles are provided, then the created wallet represents a regular tenant\n(also referred to as a 'user', 'wallet', 'holder', or 'prover', depending on the context).\n\nThe `wallet_label` does not have to be unique for regular tenants, but it may not match the name of an existing\nactor in the trust registry, and will be blocked. Conversely, an issuer or verifier may not use a label that is\nalready in use by another tenant, and will also be blocked.\n\nThe `wallet_name` is an optional field that allows you to assign an additional identifier to the wallet, and is\nuseful with `get_tenants` to fetch Wallets by name. Wallet names must be unique.\n\nThe `image_url` is an optional field for assigning an image to the Wallet. For actors, this will also be added to\nthe trust registry.\n\n`extra_settings` is an optional field intended for advanced users, which allows configuring wallet behaviour.\n\nRequest body:\n---\n    body: CreateTenantRequest\n        wallet_label: str\n            A required alias for the Tenant.\n        wallet_name: Optional[str]\n            An optional wallet name.\n        roles: Optional[List[str]]\n            A list of roles to assign to the Tenant.\n        image_url: Optional[str]\n            An optional image URL for the Tenant.\n        wallet_type: Optional[Literal[\"askar\", \"askar-anoncreds\"]]\n            The type of wallet to create. 'askar' or 'askar-anoncreds' are supported, with 'askar' as the default.\n        extra_settings: Optional[dict]\n            Optional per-tenant settings to configure wallet behaviour for advanced users.\n\nResponse body:\n---\n    CreateTenantResponse\n        wallet_id: str\n        wallet_label: str\n        wallet_name: str\n        created_at: str\n        image_url: Optional[str]\n        group_id: Optional[str]\n        updated_at: str\n        access_token: str",
+        "description": "Create a New Tenant\n---\n\nUse this endpoint to create a new Tenant, which is the same as creating a new Wallet.\n\nNB: To work with AnonCreds, the `askar-anoncreds` wallet type is required. i.e. To issue, verify, or\nhold AnonCreds, the issuer, verifier, or holder, requires the anoncreds wallet type.\n\nIndy credentials are compatible with `askar-anoncreds` wallets for holders or verifiers:\ni.e. an anoncreds wallet can hold or verify Indy credentials.\n\nHowever, issuers are restricted: an issuer with `askar` wallet type can only issue Indy credentials,\nand an issuer with `askar-anoncreds` wallet type can only issue AnonCreds.\n\nThe `wallet_label` is a required field that allows you to assign an alias to the Tenant.\nThis label is used as the default alias in connections (i.e. the other party will see this name in their records).\n\nIf roles (issuer and/or verifier) are specified, the Tenant will be onboarded with these roles and added to the\ntrust registry. An issuer or a verifier is referred to as an 'actor' in the trust registry, and the `wallet_label`\nwill be used as the name for this actor.\n\nIf no roles are provided, then the created wallet represents a regular tenant\n(also referred to as a 'user', 'wallet', 'holder', or 'prover', depending on the context).\n\nThe `wallet_label` does not have to be unique for regular tenants, but it may not match the name of an existing\nactor in the trust registry, and will be blocked. Conversely, an issuer or verifier may not use a label that is\nalready in use by another tenant, and will also be blocked.\n\nThe `wallet_name` is an optional field that allows you to assign an additional identifier to the wallet, and is\nuseful with `get_tenants` to fetch Wallets by name. Wallet names must be unique.\n\nThe `image_url` is an optional field for assigning an image to the Wallet. For actors, this will also be added to\nthe trust registry.\n\n`extra_settings` is an optional field intended for advanced users, which allows configuring wallet behaviour.\n\nRequest body:\n---\n    body: CreateTenantRequest\n        wallet_label: str\n            A required alias for the Tenant.\n        wallet_name: Optional[str]\n            An optional wallet name.\n        roles: Optional[List[str]]\n            A list of roles to assign to the Tenant.\n        image_url: Optional[str]\n            An optional image URL for the Tenant.\n        wallet_type: Optional[Literal[\"askar\", \"askar-anoncreds\"]]\n            The type of wallet to create. Can be 'askar' or 'askar-anoncreds', with 'askar-anoncreds' as default.\n        extra_settings: Optional[dict]\n            Optional per-tenant settings to configure wallet behaviour for advanced users.\n\nResponse body:\n---\n    CreateTenantResponse\n        wallet_id: str\n        wallet_label: str\n        wallet_name: str\n        created_at: str\n        image_url: Optional[str]\n        group_id: Optional[str]\n        updated_at: str\n        access_token: str",
         "operationId": "create_tenant_v1_tenants_post",
         "security": [
           {
@@ -312,53 +312,6 @@
       }
     },
     "/v1/tenants/{wallet_id}/access-token": {
-      "get": {
-        "tags": [
-          "admin: tenants"
-        ],
-        "summary": "(Deprecated) Rotate and Get New Access Token for Wallet",
-        "description": "(Deprecated) Rotate and get access token for Wallet\n---\n\nCalling this endpoint will invalidate the previous access token for the Wallet, and return a new one.\n\nRequest Parameters:\n---\n    wallet_id: str\n        The Wallet ID of the tenant for which the access token will be rotated.\n\nResponse Body:\n---\n    TenantAuth\n        access_token: str\n            The new access token for the Wallet.",
-        "operationId": "get_wallet_auth_token_v1_tenants__wallet_id__access_token_get",
-        "deprecated": true,
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "wallet_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Wallet Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TenantAuth"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
       "post": {
         "tags": [
           "admin: tenants"

--- a/docs/openapi/tenant-admin-openapi.yaml
+++ b/docs/openapi/tenant-admin-openapi.yaml
@@ -20,7 +20,7 @@ paths:
       tags:
         - 'admin: tenants'
       summary: Create New Tenant
-      description: "Create a New Tenant\n---\n\nUse this endpoint to create a new Tenant, which is the same as creating a new Wallet.\n\nNB: To work with AnonCreds, the `askar-anoncreds` wallet type is required. i.e. To issue, verify, or\nhold AnonCreds, the issuer, verifier, or holder, requires the anoncreds wallet type.\n\nIndy credentials are compatible with `askar-anoncreds` wallets for holders or verifiers:\ni.e. an anoncreds wallet can hold or verify Indy credentials.\n\nHowever, issuers are restricted: an issuer with `askar` wallet type can only issue Indy credentials,\nand an issuer with `askar-anoncreds` wallet type can only issue AnonCreds.\n\nThe `wallet_label` is a required field that allows you to assign an alias to the Tenant.\nThis label is used as the default alias in connections (i.e. the other party will see this name in their records).\n\nIf roles (issuer and/or verifier) are specified, the Tenant will be onboarded with these roles and added to the\ntrust registry. An issuer or a verifier is referred to as an 'actor' in the trust registry, and the `wallet_label`\nwill be used as the name for this actor.\n\nIf no roles are provided, then the created wallet represents a regular tenant\n(also referred to as a 'user', 'wallet', 'holder', or 'prover', depending on the context).\n\nThe `wallet_label` does not have to be unique for regular tenants, but it may not match the name of an existing\nactor in the trust registry, and will be blocked. Conversely, an issuer or verifier may not use a label that is\nalready in use by another tenant, and will also be blocked.\n\nThe `wallet_name` is an optional field that allows you to assign an additional identifier to the wallet, and is\nuseful with `get_tenants` to fetch Wallets by name. Wallet names must be unique.\n\nThe `image_url` is an optional field for assigning an image to the Wallet. For actors, this will also be added to\nthe trust registry.\n\n`extra_settings` is an optional field intended for advanced users, which allows configuring wallet behaviour.\n\nRequest body:\n---\n    body: CreateTenantRequest\n        wallet_label: str\n            A required alias for the Tenant.\n        wallet_name: Optional[str]\n            An optional wallet name.\n        roles: Optional[List[str]]\n            A list of roles to assign to the Tenant.\n        image_url: Optional[str]\n            An optional image URL for the Tenant.\n        wallet_type: Optional[Literal[\"askar\", \"askar-anoncreds\"]]\n            The type of wallet to create. 'askar' or 'askar-anoncreds' are supported, with 'askar' as the default.\n        extra_settings: Optional[dict]\n            Optional per-tenant settings to configure wallet behaviour for advanced users.\n\nResponse body:\n---\n    CreateTenantResponse\n        wallet_id: str\n        wallet_label: str\n        wallet_name: str\n        created_at: str\n        image_url: Optional[str]\n        group_id: Optional[str]\n        updated_at: str\n        access_token: str"
+      description: "Create a New Tenant\n---\n\nUse this endpoint to create a new Tenant, which is the same as creating a new Wallet.\n\nNB: To work with AnonCreds, the `askar-anoncreds` wallet type is required. i.e. To issue, verify, or\nhold AnonCreds, the issuer, verifier, or holder, requires the anoncreds wallet type.\n\nIndy credentials are compatible with `askar-anoncreds` wallets for holders or verifiers:\ni.e. an anoncreds wallet can hold or verify Indy credentials.\n\nHowever, issuers are restricted: an issuer with `askar` wallet type can only issue Indy credentials,\nand an issuer with `askar-anoncreds` wallet type can only issue AnonCreds.\n\nThe `wallet_label` is a required field that allows you to assign an alias to the Tenant.\nThis label is used as the default alias in connections (i.e. the other party will see this name in their records).\n\nIf roles (issuer and/or verifier) are specified, the Tenant will be onboarded with these roles and added to the\ntrust registry. An issuer or a verifier is referred to as an 'actor' in the trust registry, and the `wallet_label`\nwill be used as the name for this actor.\n\nIf no roles are provided, then the created wallet represents a regular tenant\n(also referred to as a 'user', 'wallet', 'holder', or 'prover', depending on the context).\n\nThe `wallet_label` does not have to be unique for regular tenants, but it may not match the name of an existing\nactor in the trust registry, and will be blocked. Conversely, an issuer or verifier may not use a label that is\nalready in use by another tenant, and will also be blocked.\n\nThe `wallet_name` is an optional field that allows you to assign an additional identifier to the wallet, and is\nuseful with `get_tenants` to fetch Wallets by name. Wallet names must be unique.\n\nThe `image_url` is an optional field for assigning an image to the Wallet. For actors, this will also be added to\nthe trust registry.\n\n`extra_settings` is an optional field intended for advanced users, which allows configuring wallet behaviour.\n\nRequest body:\n---\n    body: CreateTenantRequest\n        wallet_label: str\n            A required alias for the Tenant.\n        wallet_name: Optional[str]\n            An optional wallet name.\n        roles: Optional[List[str]]\n            A list of roles to assign to the Tenant.\n        image_url: Optional[str]\n            An optional image URL for the Tenant.\n        wallet_type: Optional[Literal[\"askar\", \"askar-anoncreds\"]]\n            The type of wallet to create. Can be 'askar' or 'askar-anoncreds', with 'askar-anoncreds' as default.\n        extra_settings: Optional[dict]\n            Optional per-tenant settings to configure wallet behaviour for advanced users.\n\nResponse body:\n---\n    CreateTenantResponse\n        wallet_id: str\n        wallet_label: str\n        wallet_name: str\n        created_at: str\n        image_url: Optional[str]\n        group_id: Optional[str]\n        updated_at: str\n        access_token: str"
       operationId: create_tenant_v1_tenants_post
       security:
         - APIKeyHeader: []
@@ -198,35 +198,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
   /v1/tenants/{wallet_id}/access-token:
-    get:
-      tags:
-        - 'admin: tenants'
-      summary: (Deprecated) Rotate and Get New Access Token for Wallet
-      description: "(Deprecated) Rotate and get access token for Wallet\n---\n\nCalling this endpoint will invalidate the previous access token for the Wallet, and return a new one.\n\nRequest Parameters:\n---\n    wallet_id: str\n        The Wallet ID of the tenant for which the access token will be rotated.\n\nResponse Body:\n---\n    TenantAuth\n        access_token: str\n            The new access token for the Wallet."
-      operationId: get_wallet_auth_token_v1_tenants__wallet_id__access_token_get
-      deprecated: true
-      security:
-        - APIKeyHeader: []
-      parameters:
-        - name: wallet_id
-          in: path
-          required: true
-          schema:
-            type: string
-            title: Wallet Id
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TenantAuth'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
     post:
       tags:
         - 'admin: tenants'

--- a/docs/openapi/tenant-openapi.json
+++ b/docs/openapi/tenant-openapi.json
@@ -1153,7 +1153,7 @@
           "issuer"
         ],
         "summary": "Send Holder a Credential",
-        "description": "Create and send a credential, automating the issuer-side flow\n---\nNB: Only a tenant with the issuer role can send credentials.\nTo send Indy credentials, the issuer requires an \"askar\" wallet type.\nTo send AnonCreds, the \"askar-anoncreds\" wallet type is required.\n\nWhen sending a credential, the credential type must be one of `indy`, `anoncreds` or `ld_proof`.\n```json\n{\n    \"type\": \"indy\", \"anoncreds\" or \"ld_proof\",\n    \"indy_credential_detail\": {...}, <-- Required if type is indy\n    \"anoncreds_credential_detail\": {...}, <-- Required if type is anoncreds\n    \"ld_credential_detail\": {...}, <-- Required if type is ld_proof\n    \"save_exchange_record\": true, <-- Whether the credential exchange record should be saved on completion.\n    \"connection_id\": \"string\", <-- The issuer's reference to the connection they want to submit the credential to.\n}\n```\nSetting the `save_exchange_record` field to True will save the exchange record after the credential is accepted.\nThe default behaviour is to only save exchange records while they are in pending state.\n\nFor a detailed technical specification of the credential issuing process, refer to the [Aries Issue Credential v2\nRFC](https://github.com/hyperledger/aries-rfcs/blob/main/features/0453-issue-credential-v2/README.md).\n\nRequest Body:\n---\n    credential: SendCredential\n        The payload for sending a credential\n\nReturns:\n---\n    CredentialExchange\n        A record of this credential exchange",
+        "description": "Create and send a credential, automating the issuer-side flow\n---\nNB: Only a tenant with the issuer role can send credentials.\n\nWhen sending a credential, the credential type must be one of `anoncreds` or `ld_proof`.\n```json\n{\n    \"anoncreds_credential_detail\": {...},\n    \"ld_credential_detail\": {...},\n    \"save_exchange_record\": true, <-- Whether the credential exchange record should be saved on completion.\n    \"connection_id\": \"string\", <-- The issuer's reference to the connection they want to submit the credential to.\n}\n```\nSetting the `save_exchange_record` field to True will save the exchange record after the credential is accepted.\nThe default behaviour is to only save exchange records while they are in pending state.\n\nFor a detailed technical specification of the credential issuing process, refer to the [Aries Issue Credential v2\nRFC](https://github.com/hyperledger/aries-rfcs/blob/main/features/0453-issue-credential-v2/README.md).\n\nRequest Body:\n---\n    credential: SendCredential\n        The payload for sending a credential\n\nReturns:\n---\n    CredentialExchange\n        A record of this credential exchange",
         "operationId": "send_credential_v1_issuer_credentials_post",
         "security": [
           {
@@ -1377,7 +1377,7 @@
           "issuer"
         ],
         "summary": "Create a Credential Offer (not bound to a connection)",
-        "description": "Create a credential offer, not bound to any connection\n---\nNB: Only a tenant with the issuer role can send credentials.\nTo send Indy credentials, the issuer requires an \"askar\" wallet type.\nTo send AnonCreds, the \"askar-anoncreds\" wallet type is required.\n\nThis endpoint takes the same body as the send credential endpoint, but without a connection id. This\nmeans the credential will not be sent, but it will do the initial step of creating a credential exchange record,\nwhich the issuer can then use in the out of band (OOB) protocol.\n\nThe OOB protocol allows credentials to be sent over alternative channels, such as email or QR code, where a\nconnection does not yet exist between holder and issuer.\n\nThe credential type must be one of indy, anoncreds or ld_proof.\n```json\n{\n    \"type\": \"indy\", \"anoncreds\" or \"ld_proof\",\n    \"indy_credential_detail\": {...}, <-- Required if type is indy\n    \"anoncreds_credential_detail\": {...}, <-- Required if type is anoncreds\n    \"ld_credential_detail\": {...}, <-- Required if type is ld_proof\n    \"save_exchange_record\": true, <-- Whether the credential exchange record should be saved on completion.\n}\n```\nFor a detailed technical specification of the credential issuing process, refer to the [Aries Issue Credential v2\nRFC](https://github.com/hyperledger/aries-rfcs/blob/main/features/0453-issue-credential-v2/README.md).\n\nRequest Body:\n---\n    credential: CreateOffer\n        The payload for creating a credential offer\n\nReturns:\n---\n    CredentialExchange\n        A record of this credential exchange",
+        "description": "Create a credential offer, not bound to any connection\n---\nNB: Only a tenant with the issuer role can send credentials.\n\nThis endpoint takes the same body as the send credential endpoint, but without a connection id. This\nmeans the credential will not be sent, but it will do the initial step of creating a credential exchange record,\nwhich the issuer can then use in the out of band (OOB) protocol.\n\nThe OOB protocol allows credentials to be sent over alternative channels, such as email or QR code, where a\nconnection does not yet exist between holder and issuer.\n\nThe credential type must be one of `anoncreds` or `ld_proof`.\n```json\n{\n    \"anoncreds_credential_detail\": {...},\n    \"ld_credential_detail\": {...},\n    \"save_exchange_record\": true, <-- Whether the credential exchange record should be saved on completion.\n}\n```\nFor a detailed technical specification of the credential issuing process, refer to the [Aries Issue Credential v2\nRFC](https://github.com/hyperledger/aries-rfcs/blob/main/features/0453-issue-credential-v2/README.md).\n\nRequest Body:\n---\n    credential: CreateOffer\n        The payload for creating a credential offer\n\nReturns:\n---\n    CredentialExchange\n        A record of this credential exchange",
         "operationId": "create_offer_v1_issuer_credentials_create_offer_post",
         "requestBody": {
           "content": {
@@ -1490,9 +1490,8 @@
           "issuer"
         ],
         "summary": "Store a Received Credential in Wallet",
-        "description": "NB: Deprecated because credentials are automatically stored in wallet after they are accepted\n---\n\nStore a credential\n---\nStore a credential by providing the credential exchange id.\nThe credential exchange id is the id of the credential exchange record, not the credential itself.\n\nThe holder only needs to call this endpoint if the holder receives a credential out of band\n\nThe holder can store the credential in their wallet after receiving it from the issuer.\n\nParameters:\n---\n    credential_exchange_id: str\n        credential exchange record identifier\n\nReturns:\n---\n    CredentialExchange\n        An updated record of this credential exchange",
+        "description": "Store a received credential in wallet\n---\nStore a received credential in wallet by providing the credential exchange id.\n\n`credential_exchange_id` is the id of the exchange record, not the credential itself.\n\nThe holder only needs to call this endpoint if the holder receives a credential out of band, since, typically,\ncredentials are automatically stored in wallet after they are accepted.\n\nThe holder can store the credential in their wallet after receiving it from the issuer.\n\nParameters:\n---\n    credential_exchange_id: str\n        credential exchange record identifier\n\nReturns:\n---\n    CredentialExchange\n        An updated record of this credential exchange",
         "operationId": "store_credential_v1_issuer_credentials__credential_exchange_id__store_post",
-        "deprecated": true,
         "security": [
           {
             "APIKeyHeader": []
@@ -3358,7 +3357,7 @@
           "wallet"
         ],
         "summary": "Create Local DID",
-        "description": "Create Local DID\n---\n\nThis endpoint allows you to create a new DID in the wallet.\nThe `method` parameter is optional and can be set to\n'sov', 'key', 'web', 'did:peer:2', or 'did:peer:4'.\n\nThe `options` field is deprecated and has been flattened, such that `did` and\n`key_type` are now top-level fields. The `options` field will still\ntake precedence over the top-level fields if it is present.\n\nRequest Body:\n---\n    DIDCreate (Optional):\n        method (str, optional): Method for the requested DID.\n        options (DIDCreateOptions, optional): Deprecated.\n        seed (str, optional): Optional seed for DID.\n        key_type (str, optional): Key type for the DID.\n        did (str, optional): Specific DID value.\n\nResponse:\n---\n    Returns the created DID object.",
+        "description": "Create Local DID\n---\n\nThis endpoint allows you to create a new DID in the wallet.\nThe `method` parameter is optional and can be set to\n'sov', 'key', 'web', 'did:peer:2', or 'did:peer:4'.\n\nRequest Body:\n---\n    DIDCreate (Optional):\n        method (str, optional): Method for the requested DID.\n        seed (str, optional): Optional seed for DID.\n        key_type (str, optional): Key type for the DID.\n        did (str, optional): Specific DID value.\n\nResponse:\n---\n    Returns the created DID object.",
         "operationId": "create_did_v1_wallet_dids_post",
         "requestBody": {
           "content": {
@@ -5413,20 +5412,6 @@
             "title": "Save Exchange Record",
             "description": "Controls exchange record retention after exchange is complete. None uses wallet default (typically to delete), true forces save, false forces delete."
           },
-          "type": {
-            "$ref": "#/components/schemas/CredentialType",
-            "default": "indy"
-          },
-          "indy_credential_detail": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/IndyCredential"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "ld_credential_detail": {
             "anyOf": [
               {
@@ -5978,11 +5963,6 @@
             ],
             "title": "Credential Definition Id"
           },
-          "credential_id": {
-            "type": "string",
-            "title": "Credential Id",
-            "deprecated": true
-          },
           "credential_exchange_id": {
             "type": "string",
             "title": "Credential Exchange Id"
@@ -6067,7 +6047,7 @@
           "type": {
             "type": "string",
             "title": "Type",
-            "default": "indy"
+            "default": "anoncreds"
           },
           "updated_at": {
             "type": "string",
@@ -6077,7 +6057,6 @@
         "type": "object",
         "required": [
           "created_at",
-          "credential_id",
           "credential_exchange_id",
           "role",
           "updated_at"
@@ -6150,16 +6129,6 @@
         ],
         "title": "CredentialStatusOptions",
         "description": "CredentialStatusOptions"
-      },
-      "CredentialType": {
-        "type": "string",
-        "enum": [
-          "indy",
-          "jwt",
-          "ld_proof",
-          "anoncreds"
-        ],
-        "title": "CredentialType"
       },
       "DID": {
         "properties": {
@@ -6255,24 +6224,6 @@
               "did:peer:4"
             ]
           },
-          "options": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/DIDCreateOptions"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "(Deprecated) Define a key type and/or a DID depending on the chosen DID method.",
-            "deprecated": true,
-            "examples": [
-              {
-                "did": "did:peer:2...",
-                "key_type": "ed25519"
-              }
-            ]
-          },
           "seed": {
             "anyOf": [
               {
@@ -6316,35 +6267,7 @@
           }
         },
         "type": "object",
-        "title": "DIDCreate",
-        "description": "Extends the AcapyDIDCreate model with smart defaults and a simplified interface.\nHandles deprecated `options` field from client requests by populating `key_type` and `did`.\nDownstream processes should use the appropriate `options` structure based on the model's fields."
-      },
-      "DIDCreateOptions": {
-        "properties": {
-          "did": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Did",
-            "description": "Specify final value of the did (including did:<method>: prefix)if the method supports or requires so."
-          },
-          "key_type": {
-            "type": "string",
-            "title": "Key Type",
-            "description": "Key type to use for the DID keypair. Validated with the chosen DID method's supported key types."
-          }
-        },
-        "type": "object",
-        "required": [
-          "key_type"
-        ],
-        "title": "DIDCreateOptions",
-        "description": "DIDCreateOptions"
+        "title": "DIDCreate"
       },
       "DIDEndpoint": {
         "properties": {
@@ -6885,12 +6808,6 @@
             "title": "Cred Rev Id",
             "description": "Credential revocation identifier"
           },
-          "credential_id": {
-            "type": "string",
-            "title": "Credential Id",
-            "description": "(deprecated - renamed to credential_id) Credential identifier",
-            "deprecated": true
-          },
           "rev_reg_id": {
             "anyOf": [
               {
@@ -6923,31 +6840,9 @@
         },
         "type": "object",
         "required": [
-          "credential_id",
           "referent"
         ],
         "title": "IndyCredInfo"
-      },
-      "IndyCredential": {
-        "properties": {
-          "credential_definition_id": {
-            "type": "string",
-            "title": "Credential Definition Id"
-          },
-          "attributes": {
-            "additionalProperties": {
-              "type": "string"
-            },
-            "type": "object",
-            "title": "Attributes"
-          }
-        },
-        "type": "object",
-        "required": [
-          "credential_definition_id",
-          "attributes"
-        ],
-        "title": "IndyCredential"
       },
       "IndyEQProof": {
         "properties": {
@@ -10060,20 +9955,6 @@
             "title": "Save Exchange Record",
             "description": "Controls exchange record retention after exchange is complete. None uses wallet default (typically to delete), true forces save, false forces delete."
           },
-          "type": {
-            "$ref": "#/components/schemas/CredentialType",
-            "default": "indy"
-          },
-          "indy_credential_detail": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/IndyCredential"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "ld_credential_detail": {
             "anyOf": [
               {
@@ -10529,12 +10410,6 @@
             ],
             "title": "Proof Types"
           },
-          "credential_id": {
-            "type": "string",
-            "title": "Credential Id",
-            "description": "(deprecated - renamed to credential_id) Credential identifier",
-            "deprecated": true
-          },
           "schema_ids": {
             "anyOf": [
               {
@@ -10571,7 +10446,6 @@
         },
         "type": "object",
         "required": [
-          "credential_id",
           "record_id"
         ],
         "title": "VCRecord"

--- a/docs/openapi/tenant-openapi.yaml
+++ b/docs/openapi/tenant-openapi.yaml
@@ -673,7 +673,7 @@ paths:
       tags:
         - issuer
       summary: Send Holder a Credential
-      description: "Create and send a credential, automating the issuer-side flow\n---\nNB: Only a tenant with the issuer role can send credentials.\nTo send Indy credentials, the issuer requires an \"askar\" wallet type.\nTo send AnonCreds, the \"askar-anoncreds\" wallet type is required.\n\nWhen sending a credential, the credential type must be one of `indy`, `anoncreds` or `ld_proof`.\n```json\n{\n    \"type\": \"indy\", \"anoncreds\" or \"ld_proof\",\n    \"indy_credential_detail\": {...}, <-- Required if type is indy\n    \"anoncreds_credential_detail\": {...}, <-- Required if type is anoncreds\n    \"ld_credential_detail\": {...}, <-- Required if type is ld_proof\n    \"save_exchange_record\": true, <-- Whether the credential exchange record should be saved on completion.\n    \"connection_id\": \"string\", <-- The issuer's reference to the connection they want to submit the credential to.\n}\n```\nSetting the `save_exchange_record` field to True will save the exchange record after the credential is accepted.\nThe default behaviour is to only save exchange records while they are in pending state.\n\nFor a detailed technical specification of the credential issuing process, refer to the [Aries Issue Credential v2\nRFC](https://github.com/hyperledger/aries-rfcs/blob/main/features/0453-issue-credential-v2/README.md).\n\nRequest Body:\n---\n    credential: SendCredential\n        The payload for sending a credential\n\nReturns:\n---\n    CredentialExchange\n        A record of this credential exchange"
+      description: "Create and send a credential, automating the issuer-side flow\n---\nNB: Only a tenant with the issuer role can send credentials.\n\nWhen sending a credential, the credential type must be one of `anoncreds` or `ld_proof`.\n```json\n{\n    \"anoncreds_credential_detail\": {...},\n    \"ld_credential_detail\": {...},\n    \"save_exchange_record\": true, <-- Whether the credential exchange record should be saved on completion.\n    \"connection_id\": \"string\", <-- The issuer's reference to the connection they want to submit the credential to.\n}\n```\nSetting the `save_exchange_record` field to True will save the exchange record after the credential is accepted.\nThe default behaviour is to only save exchange records while they are in pending state.\n\nFor a detailed technical specification of the credential issuing process, refer to the [Aries Issue Credential v2\nRFC](https://github.com/hyperledger/aries-rfcs/blob/main/features/0453-issue-credential-v2/README.md).\n\nRequest Body:\n---\n    credential: SendCredential\n        The payload for sending a credential\n\nReturns:\n---\n    CredentialExchange\n        A record of this credential exchange"
       operationId: send_credential_v1_issuer_credentials_post
       security:
         - APIKeyHeader: []
@@ -809,7 +809,7 @@ paths:
       tags:
         - issuer
       summary: Create a Credential Offer (not bound to a connection)
-      description: "Create a credential offer, not bound to any connection\n---\nNB: Only a tenant with the issuer role can send credentials.\nTo send Indy credentials, the issuer requires an \"askar\" wallet type.\nTo send AnonCreds, the \"askar-anoncreds\" wallet type is required.\n\nThis endpoint takes the same body as the send credential endpoint, but without a connection id. This\nmeans the credential will not be sent, but it will do the initial step of creating a credential exchange record,\nwhich the issuer can then use in the out of band (OOB) protocol.\n\nThe OOB protocol allows credentials to be sent over alternative channels, such as email or QR code, where a\nconnection does not yet exist between holder and issuer.\n\nThe credential type must be one of indy, anoncreds or ld_proof.\n```json\n{\n    \"type\": \"indy\", \"anoncreds\" or \"ld_proof\",\n    \"indy_credential_detail\": {...}, <-- Required if type is indy\n    \"anoncreds_credential_detail\": {...}, <-- Required if type is anoncreds\n    \"ld_credential_detail\": {...}, <-- Required if type is ld_proof\n    \"save_exchange_record\": true, <-- Whether the credential exchange record should be saved on completion.\n}\n```\nFor a detailed technical specification of the credential issuing process, refer to the [Aries Issue Credential v2\nRFC](https://github.com/hyperledger/aries-rfcs/blob/main/features/0453-issue-credential-v2/README.md).\n\nRequest Body:\n---\n    credential: CreateOffer\n        The payload for creating a credential offer\n\nReturns:\n---\n    CredentialExchange\n        A record of this credential exchange"
+      description: "Create a credential offer, not bound to any connection\n---\nNB: Only a tenant with the issuer role can send credentials.\n\nThis endpoint takes the same body as the send credential endpoint, but without a connection id. This\nmeans the credential will not be sent, but it will do the initial step of creating a credential exchange record,\nwhich the issuer can then use in the out of band (OOB) protocol.\n\nThe OOB protocol allows credentials to be sent over alternative channels, such as email or QR code, where a\nconnection does not yet exist between holder and issuer.\n\nThe credential type must be one of `anoncreds` or `ld_proof`.\n```json\n{\n    \"anoncreds_credential_detail\": {...},\n    \"ld_credential_detail\": {...},\n    \"save_exchange_record\": true, <-- Whether the credential exchange record should be saved on completion.\n}\n```\nFor a detailed technical specification of the credential issuing process, refer to the [Aries Issue Credential v2\nRFC](https://github.com/hyperledger/aries-rfcs/blob/main/features/0453-issue-credential-v2/README.md).\n\nRequest Body:\n---\n    credential: CreateOffer\n        The payload for creating a credential offer\n\nReturns:\n---\n    CredentialExchange\n        A record of this credential exchange"
       operationId: create_offer_v1_issuer_credentials_create_offer_post
       requestBody:
         content:
@@ -876,9 +876,8 @@ paths:
       tags:
         - issuer
       summary: Store a Received Credential in Wallet
-      description: "NB: Deprecated because credentials are automatically stored in wallet after they are accepted\n---\n\nStore a credential\n---\nStore a credential by providing the credential exchange id.\nThe credential exchange id is the id of the credential exchange record, not the credential itself.\n\nThe holder only needs to call this endpoint if the holder receives a credential out of band\n\nThe holder can store the credential in their wallet after receiving it from the issuer.\n\nParameters:\n---\n    credential_exchange_id: str\n        credential exchange record identifier\n\nReturns:\n---\n    CredentialExchange\n        An updated record of this credential exchange"
+      description: "Store a received credential in wallet\n---\nStore a received credential in wallet by providing the credential exchange id.\n\n`credential_exchange_id` is the id of the exchange record, not the credential itself.\n\nThe holder only needs to call this endpoint if the holder receives a credential out of band, since, typically,\ncredentials are automatically stored in wallet after they are accepted.\n\nThe holder can store the credential in their wallet after receiving it from the issuer.\n\nParameters:\n---\n    credential_exchange_id: str\n        credential exchange record identifier\n\nReturns:\n---\n    CredentialExchange\n        An updated record of this credential exchange"
       operationId: store_credential_v1_issuer_credentials__credential_exchange_id__store_post
-      deprecated: true
       security:
         - APIKeyHeader: []
       parameters:
@@ -1983,7 +1982,7 @@ paths:
       tags:
         - wallet
       summary: Create Local DID
-      description: "Create Local DID\n---\n\nThis endpoint allows you to create a new DID in the wallet.\nThe `method` parameter is optional and can be set to\n'sov', 'key', 'web', 'did:peer:2', or 'did:peer:4'.\n\nThe `options` field is deprecated and has been flattened, such that `did` and\n`key_type` are now top-level fields. The `options` field will still\ntake precedence over the top-level fields if it is present.\n\nRequest Body:\n---\n    DIDCreate (Optional):\n        method (str, optional): Method for the requested DID.\n        options (DIDCreateOptions, optional): Deprecated.\n        seed (str, optional): Optional seed for DID.\n        key_type (str, optional): Key type for the DID.\n        did (str, optional): Specific DID value.\n\nResponse:\n---\n    Returns the created DID object."
+      description: "Create Local DID\n---\n\nThis endpoint allows you to create a new DID in the wallet.\nThe `method` parameter is optional and can be set to\n'sov', 'key', 'web', 'did:peer:2', or 'did:peer:4'.\n\nRequest Body:\n---\n    DIDCreate (Optional):\n        method (str, optional): Method for the requested DID.\n        seed (str, optional): Optional seed for DID.\n        key_type (str, optional): Key type for the DID.\n        did (str, optional): Specific DID value.\n\nResponse:\n---\n    Returns the created DID object."
       operationId: create_did_v1_wallet_dids_post
       requestBody:
         content:
@@ -3157,13 +3156,6 @@ components:
             - type: 'null'
           title: Save Exchange Record
           description: Controls exchange record retention after exchange is complete. None uses wallet default (typically to delete), true forces save, false forces delete.
-        type:
-          $ref: '#/components/schemas/CredentialType'
-          default: indy
-        indy_credential_detail:
-          anyOf:
-            - $ref: '#/components/schemas/IndyCredential'
-            - type: 'null'
         ld_credential_detail:
           anyOf:
             - $ref: '#/components/schemas/LDProofVCDetail'
@@ -3474,10 +3466,6 @@ components:
             - type: string
             - type: 'null'
           title: Credential Definition Id
-        credential_id:
-          type: string
-          title: Credential Id
-          deprecated: true
         credential_exchange_id:
           type: string
           title: Credential Exchange Id
@@ -3528,14 +3516,13 @@ components:
         type:
           type: string
           title: Type
-          default: indy
+          default: anoncreds
         updated_at:
           type: string
           title: Updated At
       type: object
       required:
         - created_at
-        - credential_id
         - credential_exchange_id
         - role
         - updated_at
@@ -3588,14 +3575,6 @@ components:
         - type
       title: CredentialStatusOptions
       description: CredentialStatusOptions
-    CredentialType:
-      type: string
-      enum:
-        - indy
-        - jwt
-        - ld_proof
-        - anoncreds
-      title: CredentialType
     DID:
       properties:
         did:
@@ -3666,15 +3645,6 @@ components:
             - web
             - did:peer:2
             - did:peer:4
-        options:
-          anyOf:
-            - $ref: '#/components/schemas/DIDCreateOptions'
-            - type: 'null'
-          description: (Deprecated) Define a key type and/or a DID depending on the chosen DID method.
-          deprecated: true
-          examples:
-            - did: did:peer:2...
-              key_type: ed25519
         seed:
           anyOf:
             - type: string
@@ -3699,28 +3669,6 @@ components:
           description: Specify the final value of DID (including `did:<method>:` prefix) if the method supports it.
       type: object
       title: DIDCreate
-      description: 'Extends the AcapyDIDCreate model with smart defaults and a simplified interface.
-
-        Handles deprecated `options` field from client requests by populating `key_type` and `did`.
-
-        Downstream processes should use the appropriate `options` structure based on the model''s fields.'
-    DIDCreateOptions:
-      properties:
-        did:
-          anyOf:
-            - type: string
-            - type: 'null'
-          title: Did
-          description: 'Specify final value of the did (including did:<method>: prefix)if the method supports or requires so.'
-        key_type:
-          type: string
-          title: Key Type
-          description: Key type to use for the DID keypair. Validated with the chosen DID method's supported key types.
-      type: object
-      required:
-        - key_type
-      title: DIDCreateOptions
-      description: DIDCreateOptions
     DIDEndpoint:
       properties:
         did:
@@ -4004,11 +3952,6 @@ components:
             - type: 'null'
           title: Cred Rev Id
           description: Credential revocation identifier
-        credential_id:
-          type: string
-          title: Credential Id
-          description: (deprecated - renamed to credential_id) Credential identifier
-          deprecated: true
         rev_reg_id:
           anyOf:
             - type: string
@@ -4027,24 +3970,8 @@ components:
           description: Credential identifier
       type: object
       required:
-        - credential_id
         - referent
       title: IndyCredInfo
-    IndyCredential:
-      properties:
-        credential_definition_id:
-          type: string
-          title: Credential Definition Id
-        attributes:
-          additionalProperties:
-            type: string
-          type: object
-          title: Attributes
-      type: object
-      required:
-        - credential_definition_id
-        - attributes
-      title: IndyCredential
     IndyEQProof:
       properties:
         a_prime:
@@ -5805,13 +5732,6 @@ components:
             - type: 'null'
           title: Save Exchange Record
           description: Controls exchange record retention after exchange is complete. None uses wallet default (typically to delete), true forces save, false forces delete.
-        type:
-          $ref: '#/components/schemas/CredentialType'
-          default: indy
-        indy_credential_detail:
-          anyOf:
-            - $ref: '#/components/schemas/IndyCredential'
-            - type: 'null'
         ld_credential_detail:
           anyOf:
             - $ref: '#/components/schemas/LDProofVCDetail'
@@ -6060,11 +5980,6 @@ components:
               type: array
             - type: 'null'
           title: Proof Types
-        credential_id:
-          type: string
-          title: Credential Id
-          description: (deprecated - renamed to credential_id) Credential identifier
-          deprecated: true
         schema_ids:
           anyOf:
             - items:
@@ -6085,7 +6000,6 @@ components:
           description: Credential identifier
       type: object
       required:
-        - credential_id
         - record_id
       title: VCRecord
     VCRecordList:

--- a/poetry.lock
+++ b/poetry.lock
@@ -217,14 +217,16 @@ test = ["anyio[trio]", "blockbuster (>=1.5.23)", "coverage[toml] (>=7)", "except
 trio = ["trio (>=0.26.1)"]
 
 [[package]]
-name = "aries_cloudcontroller"
+name = "aries-cloudcontroller"
 version = "1.3.0.post20250507"
 description = "A simple python client for controlling an ACA-Py agent"
 optional = false
 python-versions = ">=3.9"
 groups = ["app", "endorser"]
-files = []
-develop = false
+files = [
+    {file = "aries_cloudcontroller-1.3.0.post20250507-py3-none-any.whl", hash = "sha256:d682a346f1010e3307d70d97b1ee8c8f274f5f4e5906357c9ff91e25435fbd34"},
+    {file = "aries_cloudcontroller-1.3.0.post20250507.tar.gz", hash = "sha256:d0957ac306047d67f940dead0a777c7ad8a39fa5cee31bc86edd1d4237347fb0"},
+]
 
 [package.dependencies]
 aiohttp = ">=3.9.4,<4.0"
@@ -234,12 +236,6 @@ pydantic = ">=2.6,<3.0"
 python-dateutil = ">=2"
 typing-extensions = ">=4,<5.0"
 urllib3 = ">=2.1,<3"
-
-[package.source]
-type = "git"
-url = "https://github.com/didx-xyz/aries-cloudcontroller-python.git"
-reference = "release-1.3.0-20250507"
-resolved_reference = "978db934ccbfa4948209770f3d4650ef7c5c9093"
 
 [[package]]
 name = "astroid"
@@ -2541,4 +2537,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "~3.12.10"
-content-hash = "3cdcfd37b7af782850062a1b4627ee231f62180343db81591afefa82a79d82c0"
+content-hash = "80b9be55a480e51bd5a048eb8b461c23434c4c0822995c40c9ca1e441ac30226"

--- a/poetry.lock
+++ b/poetry.lock
@@ -217,16 +217,14 @@ test = ["anyio[trio]", "blockbuster (>=1.5.23)", "coverage[toml] (>=7)", "except
 trio = ["trio (>=0.26.1)"]
 
 [[package]]
-name = "aries-cloudcontroller"
-version = "1.3.0.post20250506"
+name = "aries_cloudcontroller"
+version = "1.3.0.post20250507"
 description = "A simple python client for controlling an ACA-Py agent"
 optional = false
 python-versions = ">=3.9"
 groups = ["app", "endorser"]
-files = [
-    {file = "aries_cloudcontroller-1.3.0.post20250506-py3-none-any.whl", hash = "sha256:cedbd3051a00d7da1d10fded510464b4d5b362b48679fba1b68756fcf21ff875"},
-    {file = "aries_cloudcontroller-1.3.0.post20250506.tar.gz", hash = "sha256:a3e308b062667fc8c88c5ec82f4bc3225414d5d6cb52696ef9c848e32f72ce63"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 aiohttp = ">=3.9.4,<4.0"
@@ -236,6 +234,12 @@ pydantic = ">=2.6,<3.0"
 python-dateutil = ">=2"
 typing-extensions = ">=4,<5.0"
 urllib3 = ">=2.1,<3"
+
+[package.source]
+type = "git"
+url = "https://github.com/didx-xyz/aries-cloudcontroller-python.git"
+reference = "release-1.3.0-20250507"
+resolved_reference = "63594a495638d03235fc8eeed7938c8012307352"
 
 [[package]]
 name = "astroid"
@@ -1632,7 +1636,6 @@ files = [
     {file = "psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:bb89f0a835bcfc1d42ccd5f41f04870c1b936d8507c6df12b7737febc40f0909"},
     {file = "psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f0c2d907a1e102526dd2986df638343388b94c33860ff3bbe1384130828714b1"},
     {file = "psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f8157bed2f51db683f31306aa497311b560f2265998122abe1dce6428bd86567"},
-    {file = "psycopg2_binary-2.9.10-cp313-cp313-win_amd64.whl", hash = "sha256:27422aa5f11fbcd9b18da48373eb67081243662f9b46e6fd07c3eb46e4535142"},
     {file = "psycopg2_binary-2.9.10-cp38-cp38-macosx_12_0_x86_64.whl", hash = "sha256:eb09aa7f9cecb45027683bb55aebaaf45a0df8bf6de68801a6afdc7947bb09d4"},
     {file = "psycopg2_binary-2.9.10-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b73d6d7f0ccdad7bc43e6d34273f70d587ef62f824d7261c4ae9b8b1b6af90e8"},
     {file = "psycopg2_binary-2.9.10-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ce5ab4bf46a211a8e924d307c1b1fcda82368586a19d0a24f8ae166f5c784864"},
@@ -2538,4 +2541,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "~3.12.10"
-content-hash = "7c6088755e64651d03b67b6d57cf04c35cdd2ca2869c74ea695ef8024e942dda"
+content-hash = "3cdcfd37b7af782850062a1b4627ee231f62180343db81591afefa82a79d82c0"

--- a/poetry.lock
+++ b/poetry.lock
@@ -239,7 +239,7 @@ urllib3 = ">=2.1,<3"
 type = "git"
 url = "https://github.com/didx-xyz/aries-cloudcontroller-python.git"
 reference = "release-1.3.0-20250507"
-resolved_reference = "63594a495638d03235fc8eeed7938c8012307352"
+resolved_reference = "978db934ccbfa4948209770f3d4650ef7c5c9093"
 
 [[package]]
 name = "astroid"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,13 +27,13 @@ uvloop = "^0.21.0"
 [tool.poetry.group.app.dependencies]
 aiohttp = "~3.11.7"
 aiocache = "~0.12.0"
-aries-cloudcontroller = { git = "https://github.com/didx-xyz/aries-cloudcontroller-python.git", branch = "release-1.3.0-20250507" }
+aries-cloudcontroller = "==1.3.0.post20250507"
 base58 = "~2.1.1"
 pyjwt = "~2.10.0"
 uuid_utils = "^0.10.0"
 
 [tool.poetry.group.endorser.dependencies]
-aries-cloudcontroller = { git = "https://github.com/didx-xyz/aries-cloudcontroller-python.git", branch = "release-1.3.0-20250507" }
+aries-cloudcontroller = "==1.3.0.post20250507"
 dependency-injector = "^4.46.0"
 nats-py = { extras = ["nkeys"], version = "^2.10.0" }
 tenacity = "^9.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,13 +27,13 @@ uvloop = "^0.21.0"
 [tool.poetry.group.app.dependencies]
 aiohttp = "~3.11.7"
 aiocache = "~0.12.0"
-aries-cloudcontroller = "==1.3.0.post20250506"
+aries-cloudcontroller = { git = "https://github.com/didx-xyz/aries-cloudcontroller-python.git", branch = "release-1.3.0-20250507" }
 base58 = "~2.1.1"
 pyjwt = "~2.10.0"
 uuid_utils = "^0.10.0"
 
 [tool.poetry.group.endorser.dependencies]
-aries-cloudcontroller = "==1.3.0.post20250506"
+aries-cloudcontroller = { git = "https://github.com/didx-xyz/aries-cloudcontroller-python.git", branch = "release-1.3.0-20250507" }
 dependency-injector = "^4.46.0"
 nats-py = { extras = ["nkeys"], version = "^2.10.0" }
 tenacity = "^9.1.0"

--- a/shared/models/credential_exchange.py
+++ b/shared/models/credential_exchange.py
@@ -42,7 +42,7 @@ class CredentialExchange(BaseModel):
     state: Optional[State] = None
     # Thread id can be None in connectionless exchanges
     thread_id: Optional[str] = None
-    type: str = "indy"
+    type: str = "anoncreds"  # TODO: should come from the record
     updated_at: str
 
 
@@ -69,7 +69,9 @@ def credential_record_to_model_v2(record: V20CredExRecord) -> CredentialExchange
         thread_id=record.thread_id,
         updated_at=record.updated_at,
         type=(
-            list(record.by_format.cred_offer.keys())[0] if record.by_format else "indy"
+            list(record.by_format.cred_offer.keys())[0]
+            if record.by_format
+            else "anoncreds"
         ),
     )
 

--- a/shared/models/credential_exchange.py
+++ b/shared/models/credential_exchange.py
@@ -56,7 +56,8 @@ def credential_record_to_model_v2(record: V20CredExRecord) -> CredentialExchange
     )
 
     issuer_did = None
-    if record.by_format:  # Attempt to retrieve issuer did from record
+    # Attempt to retrieve issuer did from record, which is different for anoncreds vs ld_proof
+    if record.by_format and record.by_format.cred_proposal:
         cred_proposal = record.by_format.cred_proposal.get(credential_type, {})
 
         if credential_type == "anoncreds":
@@ -66,7 +67,7 @@ def credential_record_to_model_v2(record: V20CredExRecord) -> CredentialExchange
             issuer_did = credential.get("issuer")
 
     if issuer_did and not issuer_did.startswith("did:"):
-        issuer_did = f"did:sov:{issuer_did}"  # anoncreds doesn't qualify did
+        issuer_did = f"did:sov:{issuer_did}"  # anoncreds provides unqualified did:sov
 
     return CredentialExchange(
         attributes=attributes,

--- a/shared/tests/models/test_credential_exchange.py
+++ b/shared/tests/models/test_credential_exchange.py
@@ -77,7 +77,7 @@ def test_credential_record_to_model_v2():
     assert model.state == "offer-sent"
     assert model.thread_id == "thread-id"
     assert model.updated_at == "2023-01-01T01:00:00Z"
-    assert model.type == "indy"
+    assert model.type == "anoncreds"
 
 
 def test_schema_cred_def_from_record():


### PR DESCRIPTION
Also removes "type" option from credentials -- just pass `anoncreds_credential_detail`, or `ld_credential_detail`.
(Relates to #1501)