### PR TITLE
:construction_worker: Refine OpenAPI workflow configuration

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -129,7 +129,6 @@ jobs:
     uses: ./.github/workflows/update-openapi.yml
     with:
       image-version: ${{ needs.docker.outputs.image_version }}
-      pr-number: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || 0 }}
     secrets:
       devops-app-id: ${{ secrets.DEVOPS_APP_ID }}
       devops-private-key: ${{ secrets.DEVOPS_PRIVATE_KEY }}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -127,6 +127,7 @@ jobs:
     name: OpenAPI
     needs: docker
     uses: ./.github/workflows/update-openapi.yml
+    if: github.event_name == 'pull_request' || github.ref_name == github.event.repository.default_branch
     with:
       image-version: ${{ needs.docker.outputs.image_version }}
     secrets:

--- a/.github/workflows/update-openapi.yml
+++ b/.github/workflows/update-openapi.yml
@@ -7,11 +7,6 @@ on:
         description: Image version to run
         required: true
         type: string
-      pr-number:
-        description: Pull request number (if triggered by a PR)
-        required: false
-        type: number
-        default: 0
     secrets:
       devops-app-id:
         required: true
@@ -103,7 +98,7 @@ jobs:
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         if: github.event_name == 'pull_request'
         env:
-          PR_NUMBER: ${{ inputs.pr-number }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         with:
           github-token: ${{ steps.devops_login.outputs.token }}
           script: |

--- a/.github/workflows/update-openapi.yml
+++ b/.github/workflows/update-openapi.yml
@@ -209,7 +209,7 @@ jobs:
 
           # Check if there are any changes
           if [[ -n "$(git status --porcelain ./docs/openapi)" ]]; then
-            echo "Changes detected in OpenAPI specs, preparing to commit and push"
+            echo "::warning:: OpenAPI specs have changed, committing and opening a PR to sync changes"
 
             # Commit and push changes
             git add ./docs/openapi/

--- a/.github/workflows/update-openapi.yml
+++ b/.github/workflows/update-openapi.yml
@@ -59,7 +59,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: ${{ github.event_name != 'pull_request' }}
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event.repository.default_branch }}
+          ref: ${{ github.event_name == 'pull_request' && github.ref || github.event.repository.default_branch }}
           token: ${{ steps.devops_login.outputs.token }}
 
       - name: Check if services are up
@@ -228,12 +228,13 @@ jobs:
             if [[ -n "${pr_exists}" ]]; then
               echo "Pull request #${pr_exists} already exists for syncing OpenAPI Spec"
             else
+              echo -e "This PR syncs the OpenAPI Spec with the latest code changes.\n\nPlease review and merge." > pr-body.txt
               gh pr create \
                 --repo ${REPO} \
                 --base ${BASE_BRANCH} \
                 --head ${HEAD_BRANCH} \
                 --title ":memo: Sync OpenAPI Spec" \
-                --body "This PR syncs the OpenAPI Spec with the latest code changes.\n\nPlease review and merge." \
+                --body-file pr-body.txt \
                 --label documentation
               echo "Pull request created for OpenAPI spec changes"
             fi

--- a/.github/workflows/update-openapi.yml
+++ b/.github/workflows/update-openapi.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           persist-credentials: ${{ github.event_name != 'pull_request' }}
           ref: ${{ github.event_name == 'pull_request' && github.ref || github.event.repository.default_branch }}
-          token: ${{ steps.devops_login.outputs.token }}
+          token: ${{ github.event_name == 'pull_request' && github.token || steps.devops_login.outputs.token }}
 
       - name: Check if services are up
         run: |

--- a/.github/workflows/update-openapi.yml
+++ b/.github/workflows/update-openapi.yml
@@ -54,7 +54,6 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: ${{ github.event_name != 'pull_request' }}
-          ref: ${{ github.event_name == 'pull_request' && github.ref || github.event.repository.default_branch }}
           token: ${{ github.event_name == 'pull_request' && github.token || steps.devops_login.outputs.token }}
 
       - name: Check if services are up
@@ -194,7 +193,7 @@ jobs:
             }
 
       - name: Commit and open PR for OpenAPI spec changes
-        if: github.event_name != 'pull_request' && github.ref_name == github.event.repository.default_branch
+        if: github.ref_name == github.event.repository.default_branch
         env:
           HEAD_BRANCH: devops/sync-openapi
           BASE_BRANCH: ${{ github.event.repository.default_branch }}


### PR DESCRIPTION
Streamline workflow by removing redundant PR number input parameter
and using GitHub context variables directly. Add condition to skip 
workflow on tag-based releases to prevent unnecessary runs.

Improve PR creation process with file-based body content for better 
multi-line handling. Use workflow warning command for better 
visibility of OpenAPI spec changes in logs.

Simplify checkout configuration by using appropriate tokens based 
on event context and removing unnecessary reference specifications.