### PR TITLE
:construction_worker: Disable OpenAPI updates for Dependabot PRs

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -113,7 +113,7 @@ jobs:
     name: OpenAPI
     needs: docker
     uses: ./.github/workflows/update-openapi.yml
-    if: github.event_name == 'pull_request' || github.ref_name == github.event.repository.default_branch
+    if: (github.event_name == 'pull_request' && github.actor != 'dependabot[bot]') || github.ref_name == github.event.repository.default_branch
     with:
       image-version: ${{ needs.docker.outputs.image_version }}
     secrets:


### PR DESCRIPTION
Fixes the workflow issues in #1541 and #1543 