### PR TITLE
:rocket: :construction_worker: Re-implement k6 tests in CI/CD pipeline

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -157,10 +157,10 @@ jobs:
       helmfile-version: ${{ needs.export-versions.outputs.HELMFILE_VERSION }}
       image-version: ${{ needs.docker.outputs.image_version }}
       namespace: acapy-cloud-dev
-      regression-tests: ${{ github.event.inputs.regression-tests || 'true' }}
-      reset-deployments: ${{ github.event.inputs.reset-deployments || 'false' }}
-      run-k6: ${{ github.event.inputs.run-k6 || 'true' }}
-      run-tests: ${{ github.event.inputs.run-tests || 'true' }}
+      regression-tests: ${{ github.event.inputs.regression-tests || true }}
+      reset-deployments: ${{ github.event.inputs.reset-deployments || false }}
+      run-k6: ${{ github.event.inputs.run-k6 || true }}
+      run-tests: ${{ github.event.inputs.run-tests || true }}
     secrets:
       tailscale-authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
 

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -157,10 +157,10 @@ jobs:
       helmfile-version: ${{ needs.export-versions.outputs.HELMFILE_VERSION }}
       image-version: ${{ needs.docker.outputs.image_version }}
       namespace: acapy-cloud-dev
-      regression-tests: ${{ inputs.regression-tests || true }}
-      reset-deployments: ${{ inputs.reset-deployments || false }}
-      run-k6: ${{ inputs.run-k6 || true }}
-      run-tests: ${{ inputs.run-tests || true }}
+      regression-tests: ${{ github.event.inputs.regression-tests || 'true' }}
+      reset-deployments: ${{ github.event.inputs.reset-deployments || 'false' }}
+      run-k6: ${{ github.event.inputs.run-k6 || 'true' }}
+      run-tests: ${{ github.event.inputs.run-tests || 'true' }}
     secrets:
       tailscale-authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
 

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -157,10 +157,10 @@ jobs:
       helmfile-version: ${{ needs.export-versions.outputs.HELMFILE_VERSION }}
       image-version: ${{ needs.docker.outputs.image_version }}
       namespace: acapy-cloud-dev
-      regression-tests: 'false'
+      regression-tests: ${{ github.event.inputs.regression-tests || 'true' }}
       reset-deployments: ${{ github.event.inputs.reset-deployments || 'false' }}
-      run-k6: 'true'
-      run-tests: 'false'
+      run-k6: ${{ github.event.inputs.run-k6 || 'true' }}
+      run-tests: ${{ github.event.inputs.run-tests || 'true' }}
     secrets:
       tailscale-authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
 

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -157,10 +157,10 @@ jobs:
       helmfile-version: ${{ needs.export-versions.outputs.HELMFILE_VERSION }}
       image-version: ${{ needs.docker.outputs.image_version }}
       namespace: acapy-cloud-dev
-      regression-tests: ${{ github.event.inputs.regression-tests || 'true' }}
+      regression-tests: 'false'
       reset-deployments: ${{ github.event.inputs.reset-deployments || 'false' }}
-      run-k6: ${{ github.event.inputs.run-k6 || 'true' }}
-      run-tests: ${{ github.event.inputs.run-tests || 'true' }}
+      run-k6: 'true'
+      run-tests: 'false'
     secrets:
       tailscale-authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
 

--- a/.github/workflows/deploy-test-eks.yml
+++ b/.github/workflows/deploy-test-eks.yml
@@ -118,6 +118,9 @@ jobs:
       - name: Debug
         run: |
           echo "Debugging: ${{ toJson(github) }}"
+      - name: Debug
+        run: |
+          echo "Debugging: ${{ toJson(inputs) }}"
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/deploy-test-eks.yml
+++ b/.github/workflows/deploy-test-eks.yml
@@ -115,12 +115,6 @@ jobs:
       id-token: write # Required to authenticate with AWS
 
     steps:
-      - name: Debug
-        run: |
-          echo "Debugging: ${{ toJson(github) }}"
-      - name: Debug
-        run: |
-          echo "Debugging: ${{ toJson(inputs) }}"
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/deploy-test-eks.yml
+++ b/.github/workflows/deploy-test-eks.yml
@@ -492,7 +492,7 @@ jobs:
 
       - name: Run k6 tests
         run: |
-          docker run --rm \
+          docker run --rm --network=host \
             -v ${{ github.workspace }}/scripts/k6:/scripts \
             -e CLOUDAPI_URL="https://acapy-cloud.dev.didxtech.com" \
             -e GOVERNANCE_API_KEY="adminApiKey" \

--- a/.github/workflows/deploy-test-eks.yml
+++ b/.github/workflows/deploy-test-eks.yml
@@ -133,7 +133,7 @@ jobs:
           tailscale-authkey: ${{ secrets.tailscale-authkey || secrets.TAILSCALE_AUTHKEY }}
 
       - name: Helmfile Destroy
-        if: github.event.inputs.reset-deployments == 'true'
+        if: inputs.reset-deployments == 'true'
         # https://github.com/helmfile/helmfile-action
         uses: helmfile/helmfile-action@712000e3d4e28c72778ecc53857746082f555ef3 # v2.0.4
         with:
@@ -175,7 +175,7 @@ jobs:
               -f ${{ inputs.acapy-helmfile-path || './helm/acapy-cloud.yaml.gotmpl' }} \
               --state-values-set image.tag=${{ inputs.image-version }} \
               --state-values-set image.registry=ghcr.io/${{ github.repository_owner }} \
-              --state-values-set pgProxyEnabled=${{ github.event.inputs.reset-deployments == 'false' }} \
+              --state-values-set pgProxyEnabled=${{ inputs.reset-deployments == 'false' }} \
               --state-values-set namespace=${{ inputs.namespace || 'acapy-cloud-dev' }}
           helm-plugins: ${{ inputs.helm-plugins || 'https://github.com/databus23/helm-diff' }}
           helmfile-version: ${{ inputs.helmfile-version || env.HELMFILE_VERSION_DEFAULT }}
@@ -184,7 +184,7 @@ jobs:
   test-e2e:
     name: Tests / End-to-End
     needs: deploy
-    if: github.event.inputs.run-tests == 'true' || github.event.inputs.regression-tests == 'true'
+    if: inputs.run-tests == 'true' || inputs.regression-tests == 'true'
     runs-on: ubuntu-latest
 
     timeout-minutes: 30
@@ -213,7 +213,7 @@ jobs:
           tailscale-authkey: ${{ secrets.tailscale-authkey || secrets.TAILSCALE_AUTHKEY }}
 
       - name: Helmfile run regression tests
-        if: github.event.inputs.regression-tests == 'true'
+        if: inputs.regression-tests == 'true'
         id: pytest-regression
         # https://github.com/helmfile/helmfile-action
         uses: helmfile/helmfile-action@712000e3d4e28c72778ecc53857746082f555ef3 # v2.0.4
@@ -228,7 +228,7 @@ jobs:
               --state-values-set release=acapy-test-regression \
               --set fullnameOverride=acapy-test-regression \
               --set env.RUN_REGRESSION_TESTS=true \
-              --set env.FAIL_ON_RECREATING_FIXTURES=${{ github.event.inputs.reset-deployments == 'false' }} \
+              --set env.FAIL_ON_RECREATING_FIXTURES=${{ inputs.reset-deployments == 'false' }} \
               --state-values-set regressionEnabled=true \
               --state-values-set namespace=${{ inputs.namespace || 'acapy-cloud-dev' }}
           helm-plugins: ${{ inputs.helm-plugins || 'https://github.com/databus23/helm-diff' }}
@@ -236,7 +236,7 @@ jobs:
           helm-version: ${{ inputs.helm-version || env.HELM_VERSION_DEFAULT }}
 
       - name: Helmfile run pytest
-        if: github.event.inputs.run-tests == 'true'
+        if: inputs.run-tests == 'true'
         id: pytest
         # https://github.com/helmfile/helmfile-action
         uses: helmfile/helmfile-action@712000e3d4e28c72778ecc53857746082f555ef3 # v2.0.4
@@ -464,7 +464,7 @@ jobs:
   test-k6:
     name: Tests / K6
     needs: deploy
-    if: github.event.inputs.run-k6 == 'true'
+    if: inputs.run-k6 == 'true'
     runs-on: ubuntu-latest
 
     timeout-minutes: 30

--- a/.github/workflows/deploy-test-eks.yml
+++ b/.github/workflows/deploy-test-eks.yml
@@ -70,23 +70,23 @@ on:
       regression-tests:
         description: Run Regression Tests
         required: false
-        default: 'true'
-        type: string
+        default: true
+        type: boolean
       reset-deployments:
         description: Reset deployment - Clean start
         required: false
-        default: 'false'
-        type: string
+        default: false
+        type: boolean
       run-k6:
         description: Run K6 Tests
         required: false
-        default: 'true'
-        type: string
+        default: true
+        type: boolean
       run-tests:
         description: Run End-to-End Tests
         required: false
-        default: 'true'
-        type: string
+        default: true
+        type: boolean
     secrets:
       tailscale-authkey:
         required: true
@@ -133,7 +133,7 @@ jobs:
           tailscale-authkey: ${{ secrets.tailscale-authkey || secrets.TAILSCALE_AUTHKEY }}
 
       - name: Helmfile Destroy
-        if: inputs.reset-deployments == 'true'
+        if: inputs.reset-deployments
         # https://github.com/helmfile/helmfile-action
         uses: helmfile/helmfile-action@712000e3d4e28c72778ecc53857746082f555ef3 # v2.0.4
         with:
@@ -175,7 +175,7 @@ jobs:
               -f ${{ inputs.acapy-helmfile-path || './helm/acapy-cloud.yaml.gotmpl' }} \
               --state-values-set image.tag=${{ inputs.image-version }} \
               --state-values-set image.registry=ghcr.io/${{ github.repository_owner }} \
-              --state-values-set pgProxyEnabled=${{ inputs.reset-deployments == 'false' }} \
+              --state-values-set pgProxyEnabled=${{ inputs.reset-deployments }} \
               --state-values-set namespace=${{ inputs.namespace || 'acapy-cloud-dev' }}
           helm-plugins: ${{ inputs.helm-plugins || 'https://github.com/databus23/helm-diff' }}
           helmfile-version: ${{ inputs.helmfile-version || env.HELMFILE_VERSION_DEFAULT }}
@@ -184,7 +184,7 @@ jobs:
   test-e2e:
     name: Tests / End-to-End
     needs: deploy
-    if: inputs.run-tests == 'true' || inputs.regression-tests == 'true'
+    if: inputs.run-tests || inputs.regression-tests
     runs-on: ubuntu-latest
 
     timeout-minutes: 30
@@ -213,7 +213,7 @@ jobs:
           tailscale-authkey: ${{ secrets.tailscale-authkey || secrets.TAILSCALE_AUTHKEY }}
 
       - name: Helmfile run regression tests
-        if: inputs.regression-tests == 'true'
+        if: inputs.regression-tests
         id: pytest-regression
         # https://github.com/helmfile/helmfile-action
         uses: helmfile/helmfile-action@712000e3d4e28c72778ecc53857746082f555ef3 # v2.0.4
@@ -228,7 +228,7 @@ jobs:
               --state-values-set release=acapy-test-regression \
               --set fullnameOverride=acapy-test-regression \
               --set env.RUN_REGRESSION_TESTS=true \
-              --set env.FAIL_ON_RECREATING_FIXTURES=${{ inputs.reset-deployments == 'false' }} \
+              --set env.FAIL_ON_RECREATING_FIXTURES=${{ inputs.reset-deployments }} \
               --state-values-set regressionEnabled=true \
               --state-values-set namespace=${{ inputs.namespace || 'acapy-cloud-dev' }}
           helm-plugins: ${{ inputs.helm-plugins || 'https://github.com/databus23/helm-diff' }}
@@ -236,7 +236,7 @@ jobs:
           helm-version: ${{ inputs.helm-version || env.HELM_VERSION_DEFAULT }}
 
       - name: Helmfile run pytest
-        if: inputs.run-tests == 'true'
+        if: inputs.run-tests
         id: pytest
         # https://github.com/helmfile/helmfile-action
         uses: helmfile/helmfile-action@712000e3d4e28c72778ecc53857746082f555ef3 # v2.0.4
@@ -464,7 +464,7 @@ jobs:
   test-k6:
     name: Tests / K6
     needs: deploy
-    if: inputs.run-k6 == 'true'
+    if: inputs.run-k6
     runs-on: ubuntu-latest
 
     timeout-minutes: 30

--- a/.github/workflows/deploy-test-eks.yml
+++ b/.github/workflows/deploy-test-eks.yml
@@ -178,7 +178,7 @@ jobs:
               -f ${{ inputs.acapy-helmfile-path || './helm/acapy-cloud.yaml.gotmpl' }} \
               --state-values-set image.tag=${{ inputs.image-version }} \
               --state-values-set image.registry=ghcr.io/${{ github.repository_owner }} \
-              --state-values-set pgProxyEnabled=${{ inputs.reset-deployments }} \
+              --state-values-set pgProxyEnabled=${{ inputs.reset-deployments == false }} \
               --state-values-set namespace=${{ inputs.namespace || 'acapy-cloud-dev' }}
           helm-plugins: ${{ inputs.helm-plugins || 'https://github.com/databus23/helm-diff' }}
           helmfile-version: ${{ inputs.helmfile-version || env.HELMFILE_VERSION_DEFAULT }}
@@ -231,7 +231,7 @@ jobs:
               --state-values-set release=acapy-test-regression \
               --set fullnameOverride=acapy-test-regression \
               --set env.RUN_REGRESSION_TESTS=true \
-              --set env.FAIL_ON_RECREATING_FIXTURES=${{ inputs.reset-deployments }} \
+              --set env.FAIL_ON_RECREATING_FIXTURES=${{ inputs.reset-deployments == false }} \
               --state-values-set regressionEnabled=true \
               --state-values-set namespace=${{ inputs.namespace || 'acapy-cloud-dev' }}
           helm-plugins: ${{ inputs.helm-plugins || 'https://github.com/databus23/helm-diff' }}

--- a/.github/workflows/deploy-test-eks.yml
+++ b/.github/workflows/deploy-test-eks.yml
@@ -115,6 +115,9 @@ jobs:
       id-token: write # Required to authenticate with AWS
 
     steps:
+      - name: Debug
+        run: |
+          echo "Debugging: ${{ toJson(github) }}"
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/deploy-test-eks.yml
+++ b/.github/workflows/deploy-test-eks.yml
@@ -487,5 +487,24 @@ jobs:
           cluster-name: cloudapi-dev
           tailscale-authkey: ${{ secrets.tailscale-authkey || secrets.TAILSCALE_AUTHKEY }}
 
-      - name: Soon™
-        run: echo "Soon™"
+      - name: Prepare output directory
+        run: mkdir -p ${{ github.workspace }}/scripts/k6/output && chmod 777 ${{ github.workspace }}/scripts/k6/output
+
+      - name: Run k6 tests
+        run: |
+          docker run --rm \
+            -v ${{ github.workspace }}/scripts/k6:/scripts \
+            -e CLIENT_ID=${{ secrets.CLIENT_ID }} \
+            -e GOVERNANCE_CLIENT_ID=${{ secrets.GOVERNANCE_CLIENT_ID }} \
+            -e CLIENT_SECRET=${{ secrets.CLIENT_SECRET }} \
+            -e GOVERNANCE_CLIENT_SECRET=${{ secrets.GOVERNANCE_CLIENT_SECRET }} \
+            -e CLOUDAPI_URL=${{ secrets.CLOUDAPI_URL }} \
+            -e OAUTH_ENDPOINT=${{ secrets.OAUTH_ENDPOINT }} \
+            -e GOVERNANCE_OAUTH_ENDPOINT=${{ secrets.GOVERNANCE_OAUTH_ENDPOINT }} \
+            --workdir /scripts \
+            --entrypoint /bin/sh \
+            ghcr.io/${{ github.repository_owner }}/acapy-cloud/xk6:${VERSION} \
+            /scripts/run_tests.sh
+        shell: bash
+        env:
+          VERSION: ${{ inputs.image-version }}

--- a/.github/workflows/deploy-test-eks.yml
+++ b/.github/workflows/deploy-test-eks.yml
@@ -494,13 +494,9 @@ jobs:
         run: |
           docker run --rm \
             -v ${{ github.workspace }}/scripts/k6:/scripts \
-            -e CLIENT_ID=${{ secrets.CLIENT_ID }} \
-            -e GOVERNANCE_CLIENT_ID=${{ secrets.GOVERNANCE_CLIENT_ID }} \
-            -e CLIENT_SECRET=${{ secrets.CLIENT_SECRET }} \
-            -e GOVERNANCE_CLIENT_SECRET=${{ secrets.GOVERNANCE_CLIENT_SECRET }} \
             -e CLOUDAPI_URL=${{ secrets.CLOUDAPI_URL }} \
-            -e OAUTH_ENDPOINT=${{ secrets.OAUTH_ENDPOINT }} \
-            -e GOVERNANCE_OAUTH_ENDPOINT=${{ secrets.GOVERNANCE_OAUTH_ENDPOINT }} \
+            -e GOVERNANCE_API_KEY=${{ secrets.GOVERNANCE_API_KEY }} \
+            -e TENANT_ADMIN_API_KEY=${{ secrets.TENANT_ADMIN_API_KEY }} \
             --workdir /scripts \
             --entrypoint /bin/sh \
             ghcr.io/${{ github.repository_owner }}/acapy-cloud/xk6:${VERSION} \

--- a/.github/workflows/deploy-test-eks.yml
+++ b/.github/workflows/deploy-test-eks.yml
@@ -70,23 +70,23 @@ on:
       regression-tests:
         description: Run Regression Tests
         required: false
-        default: true
-        type: boolean
+        default: 'true'
+        type: string
       reset-deployments:
         description: Reset deployment - Clean start
         required: false
-        default: false
-        type: boolean
+        default: 'false'
+        type: string
       run-k6:
         description: Run K6 Tests
         required: false
-        default: true
-        type: boolean
+        default: 'true'
+        type: string
       run-tests:
         description: Run End-to-End Tests
         required: false
-        default: true
-        type: boolean
+        default: 'true'
+        type: string
     secrets:
       tailscale-authkey:
         required: true
@@ -130,7 +130,7 @@ jobs:
           tailscale-authkey: ${{ secrets.tailscale-authkey || secrets.TAILSCALE_AUTHKEY }}
 
       - name: Helmfile Destroy
-        if: inputs.reset-deployments
+        if: github.event.inputs.reset-deployments == 'true'
         # https://github.com/helmfile/helmfile-action
         uses: helmfile/helmfile-action@712000e3d4e28c72778ecc53857746082f555ef3 # v2.0.4
         with:
@@ -172,7 +172,7 @@ jobs:
               -f ${{ inputs.acapy-helmfile-path || './helm/acapy-cloud.yaml.gotmpl' }} \
               --state-values-set image.tag=${{ inputs.image-version }} \
               --state-values-set image.registry=ghcr.io/${{ github.repository_owner }} \
-              --state-values-set pgProxyEnabled=${{ inputs.reset-deployments == false }} \
+              --state-values-set pgProxyEnabled=${{ github.event.inputs.reset-deployments == 'false' }} \
               --state-values-set namespace=${{ inputs.namespace || 'acapy-cloud-dev' }}
           helm-plugins: ${{ inputs.helm-plugins || 'https://github.com/databus23/helm-diff' }}
           helmfile-version: ${{ inputs.helmfile-version || env.HELMFILE_VERSION_DEFAULT }}
@@ -181,7 +181,7 @@ jobs:
   test-e2e:
     name: Tests / End-to-End
     needs: deploy
-    if: inputs.run-tests || inputs.regression-tests
+    if: github.event.inputs.run-tests == 'true' || github.event.inputs.regression-tests == 'true'
     runs-on: ubuntu-latest
 
     timeout-minutes: 30
@@ -210,7 +210,7 @@ jobs:
           tailscale-authkey: ${{ secrets.tailscale-authkey || secrets.TAILSCALE_AUTHKEY }}
 
       - name: Helmfile run regression tests
-        if: inputs.regression-tests
+        if: github.event.inputs.regression-tests == 'true'
         id: pytest-regression
         # https://github.com/helmfile/helmfile-action
         uses: helmfile/helmfile-action@712000e3d4e28c72778ecc53857746082f555ef3 # v2.0.4
@@ -225,7 +225,7 @@ jobs:
               --state-values-set release=acapy-test-regression \
               --set fullnameOverride=acapy-test-regression \
               --set env.RUN_REGRESSION_TESTS=true \
-              --set env.FAIL_ON_RECREATING_FIXTURES=${{ inputs.reset-deployments == false }} \
+              --set env.FAIL_ON_RECREATING_FIXTURES=${{ github.event.inputs.reset-deployments == 'false' }} \
               --state-values-set regressionEnabled=true \
               --state-values-set namespace=${{ inputs.namespace || 'acapy-cloud-dev' }}
           helm-plugins: ${{ inputs.helm-plugins || 'https://github.com/databus23/helm-diff' }}
@@ -233,7 +233,7 @@ jobs:
           helm-version: ${{ inputs.helm-version || env.HELM_VERSION_DEFAULT }}
 
       - name: Helmfile run pytest
-        if: inputs.run-tests
+        if: github.event.inputs.run-tests == 'true'
         id: pytest
         # https://github.com/helmfile/helmfile-action
         uses: helmfile/helmfile-action@712000e3d4e28c72778ecc53857746082f555ef3 # v2.0.4
@@ -461,7 +461,7 @@ jobs:
   test-k6:
     name: Tests / K6
     needs: deploy
-    if: inputs.run-k6
+    if: github.event.inputs.run-k6 == 'true'
     runs-on: ubuntu-latest
 
     timeout-minutes: 30

--- a/.github/workflows/deploy-test-eks.yml
+++ b/.github/workflows/deploy-test-eks.yml
@@ -494,9 +494,9 @@ jobs:
         run: |
           docker run --rm \
             -v ${{ github.workspace }}/scripts/k6:/scripts \
-            -e CLOUDAPI_URL=${{ secrets.CLOUDAPI_URL }} \
-            -e GOVERNANCE_API_KEY=${{ secrets.GOVERNANCE_API_KEY }} \
-            -e TENANT_ADMIN_API_KEY=${{ secrets.TENANT_ADMIN_API_KEY }} \
+            -e CLOUDAPI_URL="https://acapy-cloud.dev.didxtech.com" \
+            -e GOVERNANCE_API_KEY="adminApiKey" \
+            -e TENANT_ADMIN_API_KEY="adminApiKey" \
             --workdir /scripts \
             --entrypoint /bin/sh \
             ghcr.io/${{ github.repository_owner }}/acapy-cloud/xk6:${VERSION} \

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -80,7 +80,7 @@ jobs:
           push: false
           cache-from: |
             type=gha,scope=build-${{ matrix.image }}-${{ matrix.arch }}
-            type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:latest
+            type=registry,ref=ghcr.io/${{ github.repository_owner }}/acapy-cloud/${{ matrix.image }}:latest
           cache-to: |
             type=gha,mode=max,scope=build-${{ matrix.image }}-${{ matrix.arch }}
           platforms: linux/${{ matrix.arch }}
@@ -193,7 +193,7 @@ jobs:
           cache-from: |
             type=gha,scope=build-${{ matrix.image }}-arm64
             type=gha,scope=build-${{ matrix.image }}-amd64
-            type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:latest
+            type=registry,ref=ghcr.io/${{ github.repository_owner }}/acapy-cloud/${{ matrix.image }}:latest
           cache-to: |
             ${{ matrix.image == 'ledger-nodes' && 'type=gha,mode=max,scope=build-${{ matrix.image }}-amd64' || '' }}
           platforms: ${{ matrix.platforms }}

--- a/scripts/k6/.mise.toml
+++ b/scripts/k6/.mise.toml
@@ -1,2 +1,2 @@
 [tools]
-node = "22"
+node = "24"

--- a/scripts/k6/Dockerfile
+++ b/scripts/k6/Dockerfile
@@ -1,28 +1,29 @@
-FROM docker.io/golang:1.24@sha256:30baaea08c5d1e858329c50f29fe381e9b7d7bced11a0f5f1f69a1504cdfbf5e AS builder
+FROM docker.io/golang:1.24-alpine@sha256:ef18ee7117463ac1055f5a370ed18b8750f01589f13ea0b48642f5792b234044 AS builder
 
 WORKDIR /app
 
-RUN go install go.k6.io/xk6/cmd/xk6@v0.13.4
-RUN xk6 build v0.56.0 --output /app/xk6 \
-  --with github.com/avitalique/xk6-file@v1.4.2 \
-  --with github.com/phymbert/xk6-sse@v0.1.8 \
-  --with github.com/LeonAdato/xk6-output-statsd@latest
+RUN apk add --update --no-cache git
 
-FROM docker.io/alpine:3@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c
-RUN apk add --no-cache bash
+RUN go install go.k6.io/xk6/cmd/xk6@v0.19.2
+RUN xk6 build v1.0.0 --output /app/xk6 \
+  --with github.com/avitalique/xk6-file@v1.5.0 \
+  --with github.com/phymbert/xk6-sse@v0.1.9 \
+  --with github.com/LeonAdato/xk6-output-statsd@v0.2.1
+
+###
+
+FROM docker.io/alpine:3@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c AS k6
+
+RUN apk add --update --no-cache bash tini
 
 COPY --from=builder /app/xk6 /usr/local/bin/xk6
 
-# Add Tini
-ENV TINI_VERSION=v0.19.0
-RUN apk add --no-cache tini
-
-COPY scripts /k6/scripts
-COPY scenarios /k6/scenarios
-COPY libs /k6/libs
-COPY env.sh /k6/env.sh
-
-ENTRYPOINT ["/bin/bash"]
+USER nobody
 WORKDIR /k6
 
-USER nobody
+COPY --chown=nobody:nodody scripts /k6/scripts
+COPY --chown=nobody:nodody scenarios /k6/scenarios
+COPY --chown=nobody:nodody libs /k6/libs
+COPY --chown=nobody:nodody env.sh /k6/env.sh
+
+ENTRYPOINT ["/bin/bash"]

--- a/scripts/k6/Dockerfile
+++ b/scripts/k6/Dockerfile
@@ -21,9 +21,9 @@ COPY --from=builder /app/xk6 /usr/local/bin/xk6
 USER nobody
 WORKDIR /k6
 
-COPY --chown=nobody:nodody scripts /k6/scripts
-COPY --chown=nobody:nodody scenarios /k6/scenarios
-COPY --chown=nobody:nodody libs /k6/libs
-COPY --chown=nobody:nodody env.sh /k6/env.sh
+COPY --chown=nobody:nobody scripts /k6/scripts
+COPY --chown=nobody:nobody scenarios /k6/scenarios
+COPY --chown=nobody:nobody libs /k6/libs
+COPY --chown=nobody:nobody env.sh /k6/env.sh
 
 ENTRYPOINT ["/bin/bash"]

--- a/scripts/k6/Dockerfile
+++ b/scripts/k6/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 RUN apk add --update --no-cache git
 
-RUN go install go.k6.io/xk6/cmd/xk6@v0.19.2
+RUN go install go.k6.io/xk6/cmd/xk6@v0.19.3
 RUN xk6 build v1.0.0 --output /app/xk6 \
   --with github.com/avitalique/xk6-file@v1.5.0 \
   --with github.com/phymbert/xk6-sse@v0.1.9 \

--- a/scripts/k6/env.sh
+++ b/scripts/k6/env.sh
@@ -7,11 +7,11 @@ fi
 export K6_STATSD_ENABLE_TAGS=true
 export K6_STATSD_PUSH_INTERVAL=5
 export SKIP_DELETE_ISSUERS=true
-export VUS=5
+export VUS=2
 export ITERATIONS=2
 export ISSUER_PREFIX=k6_issuer
 export HOLDER_PREFIX=k6_holder
 export SCHEMA_PREFIX=k6_schema
-export NUM_ISSUERS=2
+export NUM_ISSUERS=1
 export SCHEMA_NAME=k6_schema
 export SCHEMA_VERSION=1.0

--- a/scripts/k6/env.sh
+++ b/scripts/k6/env.sh
@@ -13,3 +13,5 @@ export ISSUER_PREFIX=k6_issuer
 export HOLDER_PREFIX=k6_holder
 export SCHEMA_PREFIX=k6_schema
 export NUM_ISSUERS=2
+export SCHEMA_NAME=k6_schema
+export SCHEMA_VERSION=1.0

--- a/scripts/k6/libs/functions.js
+++ b/scripts/k6/libs/functions.js
@@ -29,7 +29,6 @@ export function createTenant(headers, wallet) {
     image_url:
       "https://upload.wikimedia.org/wikipedia/commons/7/70/Example.png",
   });
-  console.log(`URL: ${url}`);
   const params = {
     headers: {
       "Content-Type": "application/json",

--- a/scripts/k6/libs/functions.js
+++ b/scripts/k6/libs/functions.js
@@ -29,7 +29,7 @@ export function createTenant(headers, wallet) {
     image_url:
       "https://upload.wikimedia.org/wikipedia/commons/7/70/Example.png",
   });
-
+  console.log(`URL: ${url}`);
   const params = {
     headers: {
       "Content-Type": "application/json",

--- a/scripts/k6/libs/functions.js
+++ b/scripts/k6/libs/functions.js
@@ -248,6 +248,7 @@ export function createDidExchangeRequest(holderAccessToken, issuerPublicDid) {
     const response = http.post(url, null, params);
     // console.log(`Request params: ${JSON.stringify(params, null, 2)}`);
     // console.log(`Holder Access tpoken: ${holderAccessToken}`);
+    // console.log(`Response: ${JSON.stringify(response, null, 2)}`);
     return response;
   } catch (error) {
     console.error(`Error creating invitation: ${error.message}`);
@@ -267,6 +268,7 @@ export function getIssuerConnectionId(issuerAccessToken, holderDid) {
     // console.log(`Request URL: ${url}`);
     const response = http.get(url, params);
     // console.log(`Request params: ${JSON.stringify(params, null, 2)}`);
+    // console.log(`Response: ${JSON.stringify(response, null, 2)}`);
     return response;
   } catch (error) {
     console.error(`Error creating invitation: ${error.message}`);

--- a/scripts/k6/libs/schemaUtils.js
+++ b/scripts/k6/libs/schemaUtils.js
@@ -16,7 +16,7 @@ export function createSchemaIfNotExists(
     console.log(
       `Schema: ${schemaName} version: ${schemaVersion} already exists`
     );
-    return getSchemaId(bearerToken, schemaName, schemaVersion);
+    return getSchemaId(governanceHeaders, schemaName, schemaVersion);
   }
   console.log(
     `Schema: ${schemaName} version: ${schemaVersion} does not exist - creating...`

--- a/scripts/k6/run_tests.sh
+++ b/scripts/k6/run_tests.sh
@@ -21,6 +21,7 @@ run_test() {
 
 # Single issuer, multiple holder tests
 export MULTI_ISSUERS=false
+xk6 run ./scenarios/bootstrap-issuer.js -e ITERATIONS=1 -e VUS=1
 run_test ./scenarios/create-holders.js
 run_test ./scenarios/create-invitations.js
 run_test ./scenarios/create-credentials.js

--- a/scripts/k6/scenarios/create-creddef.js
+++ b/scripts/k6/scenarios/create-creddef.js
@@ -2,7 +2,7 @@
 /* eslint-disable no-undefined, no-console, camelcase */
 
 import { check } from "k6";
-import { getAuthHeaders } from "./auth.js";
+import { getAuthHeaders } from '../libs/auth.js';
 import { createCredentialDefinition } from "../libs/functions.js";
 import { createSchemaIfNotExists } from "../libs/schemaUtils.js";
 
@@ -10,6 +10,7 @@ const vus = Number.parseInt(__ENV.VUS, 10);
 const iterations = Number.parseInt(__ENV.ITERATIONS, 10);
 const schemaName = __ENV.SCHEMA_NAME;
 const schemaVersion = __ENV.SCHEMA_VERSION;
+const issuerPrefix = __ENV.ISSUER_PREFIX;
 
 export const options = {
   scenarios: {
@@ -37,7 +38,7 @@ export const options = {
   },
 };
 
-const inputFilepath = "../output/create-issuers.json";
+const inputFilepath = `../output/${issuerPrefix}-create-issuers.json`;
 const data = open(inputFilepath, "r");
 
 export function setup() {

--- a/scripts/k6/scenarios/create-invitations.js
+++ b/scripts/k6/scenarios/create-invitations.js
@@ -148,8 +148,8 @@ export default function (data) {
       return true;
     },
   });
-  const { my_did: holderDid, connection_id: holderConnectionId } =
-    JSON.parse(createInvitationResponse.body);
+  const { my_did, connection_id: holderConnectionId } = JSON.parse(createInvitationResponse.body);
+  const holderDid = my_did.split(':').slice(0, 3).join(':');
 
   const waitForSSEEventResponse = genericPolling({
     accessToken: wallet.access_token,

--- a/scripts/k6/scenarios/delete-holders.js
+++ b/scripts/k6/scenarios/delete-holders.js
@@ -31,8 +31,8 @@ export const options = {
     // "http_req_duration{scenario:default}": ["max>=0"],
     // "http_reqs{scenario:default}": ["count >= 0"],
     // "iteration_duration{scenario:default}": ["max>=0"],
-    'test_function_reqs{my_custom_tag:specific_function}': ['count>=0'],
-    checks: ["rate==1"],
+    // 'test_function_reqs{my_custom_tag:specific_function}': ['count>=0'],
+    // checks: ["rate==1"],
   },
   tags: {
     test_run_id: "phased-issuance",


### PR DESCRIPTION
* Upgrade k6 from v0.56.0 to v1.0.0
* Update xk6 CLI from v0.13.4 to v0.19.3
* Update xk6 extensions to latest versions
* Switch Golang base image to Alpine for reduced size
* Update Node.js from 22 to 24
* Improve Docker configuration with proper permissions and staging

Reintroduce K6 testing as part of the CI/CD pipeline.
The implementation configures Docker to run k6 tests against the deployed
application.