### PR TITLE
:construction_worker: Add Cheqd testnet mnemonic to CI/CD

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -156,6 +156,7 @@ jobs:
       mise-version: ${{ needs.prep.outputs.mise-version }}
     secrets:
       codacy-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+      cheqd-mnemonic: ${{ secrets.CHEQD_TESTNET_MNEMONIC }}
     concurrency:
       group: local-tests-${{ github.ref_name }}
       cancel-in-progress: true

--- a/.github/workflows/local-tests.yml
+++ b/.github/workflows/local-tests.yml
@@ -12,6 +12,8 @@ on:
     secrets:
       codacy-token:
         required: true
+      cheqd-mnemonic:
+        required: true
 
 permissions: {}
 
@@ -57,8 +59,9 @@ jobs:
         run: mise run tilt:ci
         shell: bash
         env:
-          REGISTRY: ghcr.io/${{ github.repository_owner }}
+          FEE_PAYER_TESTNET_MNEMONIC: ${{ secrets.cheqd-mnemonic }}
           IMAGE_TAG: ${{ inputs.image-version }}
+          REGISTRY: ghcr.io/${{ github.repository_owner }}
 
       - name: Test with pytest
         run: |

--- a/tilt/acapy-cloud/Tiltfile
+++ b/tilt/acapy-cloud/Tiltfile
@@ -597,7 +597,12 @@ def setup_cloudapi(build_enabled, expose):
                 link("http://tails.cloudapi." + ingress_domain, "Tails"),
             ]
         },
-        "driver-did-cheqd": {},
+        "driver-did-cheqd": {
+          "flags": [
+            "--set",
+            "secretData.FEE_PAYER_TESTNET_MNEMONIC=" + os.environ.get("FEE_PAYER_TESTNET_MNEMONIC", ""),
+          ]
+        },
         "did-registrar": {
             "depends": ["driver-did-cheqd"],
         },


### PR DESCRIPTION
Configure the GitHub Actions workflow to pass the Cheqd testnet mnemonic
secret to the `driver-did-cheqd` component. This allows the driver to
interact with the Cheqd testnet blockchain during CI/CD runs and local
tests.

* The mnemonic is used as a fee-payer account for testnet transactions
* Added as a required secret to both `cicd.yml` and `local-tests.yml` workflows
* Passed as `FEE_PAYER_TESTNET_MNEMONIC` environment variable to Tilt