### PR TITLE
:wrench: Replace MT Agent persistence with emptyDir volumes

### DIFF
--- a/helm/acapy-cloud/conf/dev/multitenant-agent.yaml
+++ b/helm/acapy-cloud/conf/dev/multitenant-agent.yaml
@@ -156,7 +156,7 @@ securityContext:
   runAsUser: 1001
 
 persistence:
-  enabled: true
+  enabled: false
   mountPath: /home/aries/.indy_client
   capacity: 10Gi
   storageClassName: gp3
@@ -166,6 +166,8 @@ extraVolumes:
   - name: acapy-agent
     emptyDir: {}
   - name: cache
+    emptyDir: {}
+  - name: indy-client
     emptyDir: {}
   - name: ledger
     emptyDir: {}
@@ -178,6 +180,8 @@ extraVolumeMounts:
     mountPath: /home/aries/.acapy_agent
   - name: cache
     mountPath: /home/aries/.cache
+  - name: indy-client
+    mountPath: /home/aries/.indy_client
   - name: ledger
     mountPath: /home/aries/ledger
   - name: log

--- a/helm/acapy-cloud/conf/local/multitenant-agent.yaml
+++ b/helm/acapy-cloud/conf/local/multitenant-agent.yaml
@@ -138,7 +138,7 @@ securityContext:
   readOnlyRootFilesystem: true
 
 persistence:
-  enabled: true
+  enabled: false
   mountPath: /home/aries/.indy_client
   capacity: 1Gi
   storageClassName: standard
@@ -148,6 +148,8 @@ extraVolumes:
   - name: acapy-agent
     emptyDir: {}
   - name: cache
+    emptyDir: {}
+  - name: indy-client
     emptyDir: {}
   - name: ledger
     emptyDir: {}
@@ -160,6 +162,8 @@ extraVolumeMounts:
     mountPath: /home/aries/.acapy_agent
   - name: cache
     mountPath: /home/aries/.cache
+  - name: indy-client
+    mountPath: /home/aries/.indy_client
   - name: ledger
     mountPath: /home/aries/ledger
   - name: log

--- a/tilt/acapy-cloud/Tiltfile
+++ b/tilt/acapy-cloud/Tiltfile
@@ -572,11 +572,20 @@ def setup_cloudapi(build_enabled, expose):
             ]
         },
         "driver-did-cheqd": {
-            "flags": [
-                "--set",
-                "secretData.FEE_PAYER_TESTNET_MNEMONIC="
-                + os.environ.get("FEE_PAYER_TESTNET_MNEMONIC", ""),
-            ]
+            "flags": (
+                [
+                    "--set",
+                    "secretData.FEE_PAYER_TESTNET_MNEMONIC="
+                    + os.environ.get("FEE_PAYER_TESTNET_MNEMONIC"),
+                ]
+                if os.environ.get("FEE_PAYER_TESTNET_MNEMONIC")
+                else []
+            )
+            + [
+                # Add custom flags here
+                # "--set", "someParameter=someValue",
+                # "--set", "anotherParameter=anotherValue",
+            ],
         },
         "did-registrar": {
             "depends": ["driver-did-cheqd"],


### PR DESCRIPTION
Disable persistence for the indy client directory and configure
explicit emptyDir volume mounts instead. This change affects both
dev and local environment configurations.

* Set `persistence.enabled` to false
* Add indy-client `emptyDir` volume to `extraVolumes`
* Mount indy-client volume to `/home/aries/.indy_client``path

Previously, multitenant agents required shared persistent storage
for revocation registry operations on the Indy blockchain, as any
replica could receive instructions to upload tails files. With the
migration to Cheqd blockchain, this shared storage requirement is
eliminated, allowing for ephemeral storage that resets on pod
restart.