### PR TITLE
:bug: :technologist: Fix Tilt Live Update

### DIFF
--- a/dockerfiles/app/Dockerfile
+++ b/dockerfiles/app/Dockerfile
@@ -13,8 +13,8 @@ RUN poetry config cache-dir "$POETRY_CACHE_DIR" && \
   poetry config virtualenvs.path "$POETRY_CACHE_DIR/virtualenvs" && \
   poetry install --only main,app
 
-COPY --chown=65534:65534 app /app
-COPY --chown=65534:65534 shared /shared
+COPY app /app
+COPY shared /shared
 
 EXPOSE 8000
 

--- a/dockerfiles/tails/Dockerfile
+++ b/dockerfiles/tails/Dockerfile
@@ -13,8 +13,8 @@ RUN poetry config cache-dir "$POETRY_CACHE_DIR" && \
   poetry config virtualenvs.path "$POETRY_CACHE_DIR/virtualenvs" && \
   poetry install --only main,tails
 
-COPY --chown=65534:65536 tails /tails
-COPY --chown=65534:65536 shared /shared
+COPY tails /tails
+COPY shared /shared
 
 EXPOSE 6543
 

--- a/dockerfiles/trustregistry/Dockerfile
+++ b/dockerfiles/trustregistry/Dockerfile
@@ -13,8 +13,8 @@ RUN poetry config cache-dir "$POETRY_CACHE_DIR" && \
   poetry config virtualenvs.path "$POETRY_CACHE_DIR/virtualenvs" && \
   poetry install --only main,trust-registry
 
-COPY --chown=65534:65534 trustregistry /trustregistry
-COPY --chown=65534:65534 shared /shared
+COPY trustregistry /trustregistry
+COPY shared /shared
 
 EXPOSE 8001
 

--- a/dockerfiles/waypoint/Dockerfile
+++ b/dockerfiles/waypoint/Dockerfile
@@ -13,8 +13,8 @@ RUN poetry config cache-dir "$POETRY_CACHE_DIR" && \
   poetry config virtualenvs.path "$POETRY_CACHE_DIR/virtualenvs" && \
   poetry install --only main,waypoint
 
-COPY --chown=65534:65534 waypoint /waypoint
-COPY --chown=65534:65534 shared /shared
+COPY waypoint /waypoint
+COPY shared /shared
 
 EXPOSE 3011
 

--- a/helm/acapy-cloud/conf/local/governance-web.yaml
+++ b/helm/acapy-cloud/conf/local/governance-web.yaml
@@ -108,8 +108,10 @@ env:
 podSecurityContext:
   fsGroup: 65534
 securityContext:
+  # Required for Tilt Live Reload
   readOnlyRootFilesystem: false
-  runAsUser: 65534
+  runAsNonRoot: false
+  runAsUser: 0
 
 extraVolumes:
   - name: logs

--- a/helm/acapy-cloud/conf/local/multitenant-web.yaml
+++ b/helm/acapy-cloud/conf/local/multitenant-web.yaml
@@ -110,8 +110,10 @@ env:
 podSecurityContext:
   fsGroup: 65534
 securityContext:
+  # Required for Tilt Live Reload
   readOnlyRootFilesystem: false
-  runAsUser: 65534
+  runAsNonRoot: false
+  runAsUser: 0
 
 extraVolumes:
   - name: logs

--- a/helm/acapy-cloud/conf/local/public-web.yaml
+++ b/helm/acapy-cloud/conf/local/public-web.yaml
@@ -119,8 +119,10 @@ env:
 podSecurityContext:
   fsGroup: 65534
 securityContext:
+  # Required for Tilt Live Reload
   readOnlyRootFilesystem: false
-  runAsUser: 65534
+  runAsNonRoot: false
+  runAsUser: 0
 
 extraVolumes:
   - name: logs

--- a/helm/acapy-cloud/conf/local/tails-server.yaml
+++ b/helm/acapy-cloud/conf/local/tails-server.yaml
@@ -75,8 +75,10 @@ extraVolumeMounts:
 podSecurityContext:
   fsGroup: 65534
 securityContext:
+  # Required for Tilt Live Reload
   readOnlyRootFilesystem: false
-  runAsUser: 65534
+  runAsNonRoot: false
+  runAsUser: 0
 
 # resources:
 #   requests:

--- a/helm/acapy-cloud/conf/local/tenant-web.yaml
+++ b/helm/acapy-cloud/conf/local/tenant-web.yaml
@@ -128,8 +128,10 @@ env:
 podSecurityContext:
   fsGroup: 65534
 securityContext:
+  # Required for Tilt Live Reload
   readOnlyRootFilesystem: false
-  runAsUser: 65534
+  runAsNonRoot: false
+  runAsUser: 0
 
 extraVolumes:
   - name: logs

--- a/helm/acapy-cloud/conf/local/trust-registry.yaml
+++ b/helm/acapy-cloud/conf/local/trust-registry.yaml
@@ -91,8 +91,10 @@ env:
 podSecurityContext:
   fsGroup: 65534
 securityContext:
+  # Required for Tilt Live Reload
   readOnlyRootFilesystem: false
-  runAsUser: 65534
+  runAsNonRoot: false
+  runAsUser: 0
 
 extraVolumes:
   - name: logs

--- a/helm/acapy-cloud/conf/local/waypoint.yaml
+++ b/helm/acapy-cloud/conf/local/waypoint.yaml
@@ -107,8 +107,10 @@ env:
 podSecurityContext:
   fsGroup: 65534
 securityContext:
+  # Required for Tilt Live Reload
   readOnlyRootFilesystem: false
-  runAsUser: 65534
+  runAsNonRoot: false
+  runAsUser: 0
 
 extraVolumes:
   - name: logs

--- a/tilt/acapy-cloud/Tiltfile
+++ b/tilt/acapy-cloud/Tiltfile
@@ -620,6 +620,7 @@ def setup_cloudapi(build_enabled, expose):
             ],
         },
         "tails-server": {
+            "depends": ["minio"],
             "links": [
                 link("http://tails-server.cloudapi." + ingress_domain, "Tails"),
                 link(

--- a/tilt/acapy-cloud/Tiltfile
+++ b/tilt/acapy-cloud/Tiltfile
@@ -347,6 +347,7 @@ def setup_cloudapi_service(
 
     # Setup CloudAPI Service
     if release_config.get("enabled", True):
+        base_values_file = chart + "/values.yaml"
         values_file = chart + "/conf/local/" + release + ".yaml"
         helm_resource(
             name=release,
@@ -372,7 +373,7 @@ def setup_cloudapi_service(
                 "istio",
             ]
             + release_config.get("depends", []),
-            deps=[values_file],
+            deps=[base_values_file, values_file],
             port_forwards=release_config.get("port_forwards", []),
         )
         k8s_resource(workload=release, links=release_config.get("links", []))


### PR DESCRIPTION
* Remove `--chown` flags from `COPY` commands in Dockerfiles
* Set `runAsUser: 0` and `runAsNonRoot: false` in local Helm configs

Tilt requires root privileges to modify files during live reload.
This configuration is isolated to local development environment
and does not affect production security posture.

* Tails depends on MinIO
* Resources depend on base values file

---

> [!NOTE]
> Turns out the below is a MacOS issue.

Fixes Tilt Live Update.
Modified files get copied into running containers and Uvicorn successfully
picks up the change and restarts, but Tilt fails with a `chown` which results
in an error.

I've opened a [feature request](https://github.com/tilt-dev/tilt/issues/6562) to add support for `--no-preserve` in live
updates to get around the `chown` issue.