### PR TITLE
:recycle: Reorganize workflow inputs and update configs

### DIFF
--- a/.github/workflows/deploy-test-eks.yml
+++ b/.github/workflows/deploy-test-eks.yml
@@ -1,4 +1,4 @@
-name: Deploy and Test EKS
+name: Deploy / Test EKS
 
 on:
   workflow_dispatch:
@@ -10,11 +10,6 @@ on:
         type: string
       reset-deployments:
         description: Reset deployments - Clean start
-        required: false
-        default: false
-        type: boolean
-      skip-deploy:
-        description: Skip deployments
         required: false
         default: false
         type: boolean
@@ -32,6 +27,11 @@ on:
         description: Run Regression Tests
         required: false
         default: true
+        type: boolean
+      skip-deploy:
+        description: Skip deployments
+        required: false
+        default: false
         type: boolean
   workflow_call:
     inputs:
@@ -92,16 +92,16 @@ on:
         required: false
         default: true
         type: boolean
-      tailscale-tags:
-        description: Tailscale device tags to use
-        required: false
-        default: "tag:cloudapi-dev"
-        type: string
       skip-deploy:
         description: Skip deployments
         required: false
         default: false
         type: boolean
+      tailscale-tags:
+        description: Tailscale device tags to use
+        required: false
+        default: "tag:cloudapi-dev"
+        type: string
     secrets:
       tailscale-oauth-client-id:
         required: true

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -77,7 +77,7 @@ jobs:
             type=gha,scope=build-${{ matrix.image }}-${{ matrix.arch }}
             type=registry,ref=ghcr.io/${{ github.repository_owner }}/acapy-cloud/${{ matrix.image }}:latest
           cache-to: |
-            type=gha,mode=max,scope=build-${{ matrix.image }}-${{ matrix.arch }}
+            type=gha,mode=min,scope=build-${{ matrix.image }}-${{ matrix.arch }}
           platforms: linux/${{ matrix.arch }}
 
   push:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,4 +1,4 @@
-name: Lint/Format
+name: Lint / Format
 
 on:
   workflow_call:
@@ -19,7 +19,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Overwrite .mise.toml # It's not needed in this workflow
+      - name: Overwrite .mise.toml # The full `mise.toml` isn't needed for this workflow
         run: |
           cat <<EOF > .mise.toml
           [tools]

--- a/.github/workflows/mdbook-deploy.yml
+++ b/.github/workflows/mdbook-deploy.yml
@@ -1,4 +1,4 @@
-name: mdbook deploy
+name: MDBook Deploy
 
 on:
   push:
@@ -14,8 +14,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     permissions:
-      contents: write  # To push a branch
-      pages: write  # To push to a GitHub Pages site
+      contents: write # To push a branch
+      pages: write # To push to a GitHub Pages site
       id-token: write # To update the deployment status
 
     steps:

--- a/helm/acapy-cloud/conf/dev/driver-did-cheqd.yaml
+++ b/helm/acapy-cloud/conf/dev/driver-did-cheqd.yaml
@@ -29,7 +29,7 @@ startupProbe:
 secretData:
   # FEE_PAYER_TESTNET_MNEMONIC: "" # Cheqd did-registrar uses testnet faucet by default
   # FEE_PAYER_MAINNET_MNEMONIC: "..."
-  # Use the same Testnet Mnemonic as the Localnet Cheqd node
+  # Use the same Mnemonic as the Localnet Cheqd node
   FEE_PAYER_TESTNET_MNEMONIC: betray purity grief spatial rude select loud reason wolf harvest session awesome
 
 env:

--- a/helm/acapy-cloud/conf/local/driver-did-cheqd.yaml
+++ b/helm/acapy-cloud/conf/local/driver-did-cheqd.yaml
@@ -9,8 +9,7 @@ image:
   registry: ghcr.io
   name: cheqd/did-registrar
   pullPolicy: Always
-  tag: develop
-  digest: sha256:52221271f250ef162a1b83576fc0dff63e96d1d7897e8d0106eebec925f0519f
+  tag: 2.6.0-1-g6979b43
 
 service:
   appProtocol: http
@@ -30,7 +29,7 @@ startupProbe:
 secretData:
   FEE_PAYER_TESTNET_MNEMONIC: "" # Cheqd did-registrar uses testnet faucet by default
   # FEE_PAYER_MAINNET_MNEMONIC: "..."
-  # Use the same Testnet Mnemonic as the Localnet Cheqd node
+  # Use the same Mnemonic as the Localnet Cheqd node
   FEE_PAYER_TESTNET_MNEMONIC: betray purity grief spatial rude select loud reason wolf harvest session awesome
 
 env:

--- a/helm/acapy-cloud/templates/istio-peerauth.yaml
+++ b/helm/acapy-cloud/templates/istio-peerauth.yaml
@@ -1,7 +1,7 @@
 {{- with .Values.istio.peerAuth }}
 {{- if .enabled }}
 # https://istio.io/latest/docs/reference/config/security/peer_authentication/
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: {{ include "acapy-cloud.fullname" $ }}

--- a/helm/acapy-cloud/templates/istio-sidecar.yaml
+++ b/helm/acapy-cloud/templates/istio-sidecar.yaml
@@ -1,7 +1,7 @@
 {{- with .Values.istio.sidecar }}
 {{- if .enabled }}
 # https://istio.io/latest/docs/reference/config/networking/sidecar/
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: Sidecar
 metadata:
   name: {{ include "acapy-cloud.fullname" $ }}

--- a/helm/acapy-cloud/templates/istio-virtualservice.yaml
+++ b/helm/acapy-cloud/templates/istio-virtualservice.yaml
@@ -1,7 +1,7 @@
 {{- with .Values.istio.virtualService }}
 {{- if .enabled }}
 # https://istio.io/latest/docs/reference/config/networking/virtual-service/
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: {{ include "acapy-cloud.fullname" $ }}

--- a/tilt/acapy-cloud/Tiltfile
+++ b/tilt/acapy-cloud/Tiltfile
@@ -520,7 +520,7 @@ def setup_cloudapi(build_enabled, expose):
 
     releases = {
         "governance-agent": {
-            "depends": ["nats", "postgres", "did-registrar", "did-resolver", "minio"],
+            "depends": ["nats", "postgres", "did-registrar", "did-resolver"],
             "links": [
                 link(
                     "http://governance-agent.cloudapi." + ingress_domain,
@@ -540,7 +540,7 @@ def setup_cloudapi(build_enabled, expose):
             },
         },
         "governance-web": {
-            "depends": ["governance-agent", "multitenant-agent"],
+            "depends": ["governance-agent"],
             "links": [
                 link(
                     "http://cloudapi." + ingress_domain + "/governance",
@@ -570,7 +570,7 @@ def setup_cloudapi(build_enabled, expose):
             },
         },
         "multitenant-agent": {
-            "depends": ["nats", "postgres", "did-registrar", "did-resolver", "minio"],
+            "depends": ["nats", "postgres", "did-registrar", "did-resolver"],
             "links": [
                 link(
                     "http://multitenant-agent.cloudapi." + ingress_domain,
@@ -590,7 +590,7 @@ def setup_cloudapi(build_enabled, expose):
             },
         },
         "multitenant-web": {
-            "depends": ["governance-agent", "multitenant-agent"],
+            "depends": ["multitenant-agent"],
             "links": [
                 link(
                     "http://cloudapi." + ingress_domain + "/tenant-admin",
@@ -726,11 +726,7 @@ def setup_cloudapi(build_enabled, expose):
         },
         "mediator": {
             "enabled": False,
-            "depends": [
-                "postgres",
-                "governance-agent",
-                "multitenant-agent",
-            ],
+            "depends": ["postgres"],
             "links": [
                 link("http://mediator.cloudapi." + ingress_domain, "Mediator"),
             ],
@@ -763,7 +759,7 @@ def setup_cloudapi(build_enabled, expose):
         },
         "driver-did-cheqd": {
             # https://github.com/cheqd/did-registrar
-            "depends": ["cheqd", "did-resolver"],
+            "depends": ["did-resolver"],
             "flags": [
                 "--set",
                 "secretData.FEE_PAYER_TESTNET_MNEMONIC=" + cheqd_validator_mnemonic,

--- a/tilt/acapy-cloud/Tiltfile
+++ b/tilt/acapy-cloud/Tiltfile
@@ -396,6 +396,7 @@ def setup_cloudapi_service(
             + release_config.get("depends", []),
             deps=[base_values_file, values_file],
             port_forwards=release_config.get("port_forwards", []),
+            auto_init=release_config.get("auto_init", True),
         )
         k8s_resource(workload=release, links=release_config.get("links", []))
     else:
@@ -725,7 +726,7 @@ def setup_cloudapi(build_enabled, expose):
             },
         },
         "mediator": {
-            "enabled": False,
+            "auto_init": False,
             "depends": ["postgres"],
             "links": [
                 link("http://mediator.cloudapi." + ingress_domain, "Mediator"),


### PR DESCRIPTION
Reorganize GitHub workflow input parameters for better logical 
grouping and consistency. Update several configuration files to 
use current API versions and improve naming conventions.

Changes made:
* Reorder workflow inputs in `deploy-test-eks.yml` to be
alphabetical
* Update workflow names to use consistent format with forward 
 slashes (`Deploy / Test EKS`, `Lint / Format`, `MDBook Deploy`)
* Change Docker build cache mode from `max` to `min` for 
 faster caching
* Update Istio resource API versions from `v1beta1` to `v1`
* Update cheqd did-registrar image tag from `develop` to 
 `2.6.0-1-g6979b43` and remove digest
* Simplify mnemonic comments by removing "Testnet" references
* Improve comment clarity in `.mise.toml` overwrite step
* Clean up spacing in mdbook workflow permissions