### PR TITLE
:sparkles: Add Valkey for distributed locking

### DIFF
--- a/app/tests/e2e/issuer/test_concurrent_issuance_revocation.py
+++ b/app/tests/e2e/issuer/test_concurrent_issuance_revocation.py
@@ -5,6 +5,7 @@ import pytest
 from app.routes.issuer import router as issuer_router
 from app.routes.revocation import router as revocation_router
 from app.tests.util.connections import FaberAliceConnect
+from app.tests.util.regression_testing import TestMode
 from app.tests.util.webhooks import check_webhook_state
 from shared import RichAsyncClient
 from shared.models.credential_exchange import CredentialExchange
@@ -40,6 +41,10 @@ async def check_unique_cred_rev_ids(
 
 
 @pytest.mark.anyio
+@pytest.mark.skipif(
+    TestMode.regression_run in TestMode.fixture_params,
+    reason="Do not test multi-issuance and revocation in regression mode",
+)
 async def test_concurrent_issuance_sequential_revocation(
     faber_anoncreds_client: RichAsyncClient,
     alice_member_client: RichAsyncClient,

--- a/dockerfiles/agents/Dockerfile
+++ b/dockerfiles/agents/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/didx-xyz/acapy-agent:py3.12-test-lock@sha256:107aa31b8fc2b6787a3fa60d2d24597effd28b609c14c264f1471da665974973
+FROM ghcr.io/didx-xyz/acapy-agent:py3.12-test-1.3.0-20250609@sha256:707bd89816bdf2e01338904100e576e6adec07378ba84b3f107b42eef2c575b0
 
 USER root
 

--- a/dockerfiles/agents/Dockerfile
+++ b/dockerfiles/agents/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/didx-xyz/acapy-agent:py3.12-test-lock
+FROM ghcr.io/didx-xyz/acapy-agent:py3.12-test-lock@sha256:2bcdd83bd05c5129ffd4de16d4c7b5576334ffd3c8f7eeaff292f949f7dc12af
 
 USER root
 

--- a/dockerfiles/agents/Dockerfile
+++ b/dockerfiles/agents/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/didx-xyz/acapy-agent:py3.12-1.3.0-20250526@sha256:6d02573554820d3114ea3a74a863386cd9f536583bc77188623d3d10fab38d8a
+FROM ghcr.io/didx-xyz/acapy-agent:py3.12-test-lock
 
 USER root
 

--- a/dockerfiles/agents/Dockerfile
+++ b/dockerfiles/agents/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/didx-xyz/acapy-agent:py3.12-test-1.3.0-20250609@sha256:707bd89816bdf2e01338904100e576e6adec07378ba84b3f107b42eef2c575b0
+FROM ghcr.io/didx-xyz/acapy-agent:py3.12-test-1.3.0-20250609@sha256:72706a4a0cee5573c7a5051402330485fbc52d545773e1091bc93092960b3b15
 
 USER root
 

--- a/dockerfiles/agents/Dockerfile
+++ b/dockerfiles/agents/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/didx-xyz/acapy-agent:py3.12-test-lock@sha256:2bcdd83bd05c5129ffd4de16d4c7b5576334ffd3c8f7eeaff292f949f7dc12af
+FROM ghcr.io/didx-xyz/acapy-agent:py3.12-test-lock@sha256:107aa31b8fc2b6787a3fa60d2d24597effd28b609c14c264f1471da665974973
 
 USER root
 

--- a/helm/acapy-cloud.yaml.gotmpl
+++ b/helm/acapy-cloud.yaml.gotmpl
@@ -170,7 +170,7 @@ releases:
       app: valkey
     namespace: {{ .Values.namespace }}
     chart: oci://registry-1.docker.io/bitnamicharts/valkey
-    version: 3.0.9
+    version: 3.0.11
     values:
       - ./acapy-cloud/conf/valkey.yaml
       - primary:

--- a/helm/acapy-cloud.yaml.gotmpl
+++ b/helm/acapy-cloud.yaml.gotmpl
@@ -164,13 +164,29 @@ releases:
           podLabels:
             tags.datadoghq.com/env: acapy-cloud-{{ .Environment.Name }}
 
+  # https://github.com/bitnami/charts/tree/main/bitnami/valkey
+  - name: valkey
+    labels:
+      app: valkey
+    namespace: {{ .Values.namespace }}
+    chart: oci://registry-1.docker.io/bitnamicharts/valkey
+    version: 3.0.9
+    values:
+      - ./acapy-cloud/conf/valkey.yaml
+      - primary:
+          podLabels:
+            tags.datadoghq.com/env: acapy-cloud-{{ .Environment.Name }}
+        replica:
+          podLabels:
+            tags.datadoghq.com/env: acapy-cloud-{{ .Environment.Name }}
+
   # https://github.com/bitnami/charts/tree/main/bitnami/postgresql-ha
   - name: postgres
     labels:
       app: postgres
     namespace: {{ .Values.namespace }}
     chart: oci://registry-1.docker.io/bitnamicharts/postgresql-ha
-    version: 16.0.10
+    version: 16.0.11
     values:
       - ./acapy-cloud/conf/postgres.yaml
       - postgresql:
@@ -245,7 +261,7 @@ releases:
     installed: {{ .Values.minio.enabled }}
     namespace: {{ .Values.namespace }}
     chart: oci://registry-1.docker.io/bitnamicharts/minio
-    version: 17.0.2
+    version: 17.0.3
     labels:
       app: minio
     values:

--- a/helm/acapy-cloud/conf/dev/governance-agent.yaml
+++ b/helm/acapy-cloud/conf/dev/governance-agent.yaml
@@ -194,6 +194,10 @@ secretData:
   WALLET_DB_PORT: 5432
   WALLET_DB_USER: governance
 
+  # Sensitive because it _could_ contain credentials
+  # Format: redis[s]://user:password@host:port
+  VALKEY_URL: redis://valkey-primary:6379
+
 env:
   # NATS related
   NATS_CREDS_FILE: "" # NATS in Local dev has no auth

--- a/helm/acapy-cloud/conf/dev/mediator.yaml
+++ b/helm/acapy-cloud/conf/dev/mediator.yaml
@@ -129,26 +129,6 @@ initContainers:
           secretKeyRef:
             name: '{{ include "acapy-cloud.fullname" . }}-env'
             key: WALLET_DB_PORT
-  - name: wait-governance-agent
-    image: curlimages/curl
-    command:
-      - sh
-      - -c
-      - |
-        until curl -s http://governance-agent:3021 -o /dev/null; do
-          echo "waiting for governance-agent to be healthy"
-          sleep 2
-        done
-  - name: wait-multitenant-agent
-    image: curlimages/curl
-    command:
-      - sh
-      - -c
-      - |
-        until curl -s http://multitenant-agent:3021 -o /dev/null; do
-          echo "waiting for multitenant-agent to be healthy"
-          sleep 2
-        done
 
 podSecurityContext:
   fsGroup: 1001

--- a/helm/acapy-cloud/conf/dev/multitenant-agent.yaml
+++ b/helm/acapy-cloud/conf/dev/multitenant-agent.yaml
@@ -205,6 +205,10 @@ secretData:
   WALLET_DB_PORT: 5432
   WALLET_DB_USER: multitenant
 
+  # Sensitive because it _could_ contain credentials
+  # Format: redis[s]://user:password@host:port
+  VALKEY_URL: redis://valkey-primary:6379
+
 env:
   ACAPY_LABEL: Multitenant
   # NATS related

--- a/helm/acapy-cloud/conf/dev/public-web.yaml
+++ b/helm/acapy-cloud/conf/dev/public-web.yaml
@@ -86,7 +86,7 @@ initContainers:
       - -c
       - |
         until curl -s {{ .Values.env.TRUST_REGISTRY_URL }} -o /dev/null; do
-          echo "waiting for governance-agent to be healthy"
+          echo "waiting for trust-registry to be healthy"
           sleep 2
         done
 

--- a/helm/acapy-cloud/conf/dev/public-web.yaml
+++ b/helm/acapy-cloud/conf/dev/public-web.yaml
@@ -79,24 +79,14 @@ readinessProbe:
 #     memory: 256Mi
 
 initContainers:
-  - name: wait-governance-agent
+  - name: wait-trust-registry
     image: curlimages/curl
     command:
       - sh
       - -c
       - |
-        until curl -s http://governance-agent:3021 -o /dev/null; do
+        until curl -s {{ .Values.env.TRUST_REGISTRY_URL }} -o /dev/null; do
           echo "waiting for governance-agent to be healthy"
-          sleep 2
-        done
-  - name: wait-multitenant-agent
-    image: curlimages/curl
-    command:
-      - sh
-      - -c
-      - |
-        until curl -s http://multitenant-agent:3021 -o /dev/null; do
-          echo "waiting for multitenant-agent to be healthy"
           sleep 2
         done
 

--- a/helm/acapy-cloud/conf/local/governance-agent.yaml
+++ b/helm/acapy-cloud/conf/local/governance-agent.yaml
@@ -182,6 +182,10 @@ secretData:
   WALLET_DB_PORT: 5432
   WALLET_DB_USER: governance
 
+  # Sensitive because it _could_ contain credentials
+  # Format: redis[s]://user:password@host:port
+  VALKEY_URL: redis://valkey-primary:6379
+
 env:
   ACAPY_LOG_LEVEL: info
   # NATS related

--- a/helm/acapy-cloud/conf/local/mediator.yaml
+++ b/helm/acapy-cloud/conf/local/mediator.yaml
@@ -120,26 +120,6 @@ initContainers:
           secretKeyRef:
             name: '{{ include "acapy-cloud.fullname" . }}-env'
             key: WALLET_DB_PORT
-  - name: wait-governance-agent
-    image: curlimages/curl
-    command:
-      - sh
-      - -c
-      - |
-        until curl -s http://governance-agent:3021 -o /dev/null; do
-          echo "waiting for governance-agent to be healthy"
-          sleep 2
-        done
-  - name: wait-multitenant-agent
-    image: curlimages/curl
-    command:
-      - sh
-      - -c
-      - |
-        until curl -s http://multitenant-agent:3021 -o /dev/null; do
-          echo "waiting for multitenant-agent to be healthy"
-          sleep 2
-        done
 
 podSecurityContext:
   fsGroup: 1001

--- a/helm/acapy-cloud/conf/local/multitenant-agent.yaml
+++ b/helm/acapy-cloud/conf/local/multitenant-agent.yaml
@@ -194,6 +194,10 @@ secretData:
   WALLET_DB_PORT: 5432
   WALLET_DB_USER: multitenant
 
+  # Sensitive because it _could_ contain credentials
+  # Format: redis[s]://user:password@host:port
+  VALKEY_URL: redis://valkey-primary:6379
+
 env:
   ACAPY_LOG_LEVEL: info
   # NATS related

--- a/helm/acapy-cloud/conf/local/public-web.yaml
+++ b/helm/acapy-cloud/conf/local/public-web.yaml
@@ -76,7 +76,7 @@ initContainers:
       - -c
       - |
         until curl -s {{ .Values.env.TRUST_REGISTRY_URL }} -o /dev/null; do
-          echo "waiting for governance-agent to be healthy"
+          echo "waiting for trust-registry to be healthy"
           sleep 2
         done
 

--- a/helm/acapy-cloud/conf/local/public-web.yaml
+++ b/helm/acapy-cloud/conf/local/public-web.yaml
@@ -69,24 +69,14 @@ readinessProbe:
 #     memory: 256Mi
 
 initContainers:
-  - name: wait-governance-agent
+  - name: wait-trust-registry
     image: curlimages/curl
     command:
       - sh
       - -c
       - |
-        until curl -s http://governance-agent:3021 -o /dev/null; do
+        until curl -s {{ .Values.env.TRUST_REGISTRY_URL }} -o /dev/null; do
           echo "waiting for governance-agent to be healthy"
-          sleep 2
-        done
-  - name: wait-multitenant-agent
-    image: curlimages/curl
-    command:
-      - sh
-      - -c
-      - |
-        until curl -s http://multitenant-agent:3021 -o /dev/null; do
-          echo "waiting for multitenant-agent to be healthy"
           sleep 2
         done
 

--- a/helm/acapy-cloud/conf/valkey.yaml
+++ b/helm/acapy-cloud/conf/valkey.yaml
@@ -7,7 +7,7 @@ primary:
   replicaCount: 1
   resourcesPreset: nano
   persistence:
-    enabled: true
+    enabled: false
     size: 1Gi
   persistentVolumeClaimRetentionPolicy:
     enabled: true

--- a/helm/acapy-cloud/conf/valkey.yaml
+++ b/helm/acapy-cloud/conf/valkey.yaml
@@ -1,0 +1,28 @@
+# https://github.com/bitnami/charts/tree/main/bitnami/valkey
+fullnameOverride: valkey
+architecture: replication
+auth:
+  enabled: false
+primary:
+  replicaCount: 1
+  resourcesPreset: nano
+  persistence:
+    enabled: true
+    size: 1Gi
+  persistentVolumeClaimRetentionPolicy:
+    enabled: true
+    whenDeleted: Delete
+  podLabels:
+    sidecar.istio.io/inject: "false"
+replica:
+  replicaCount: 0
+  resourcesPreset: nano
+  persistence:
+    enabled: true
+    size: 1Gi
+  persistentVolumeClaimRetentionPolicy:
+    enabled: true
+    whenDeleted: Delete
+  podLabels:
+    sidecar.istio.io/inject: "false"
+  podManagementPolicy: Parallel

--- a/helm/acapy-cloud/conf/valkey.yaml
+++ b/helm/acapy-cloud/conf/valkey.yaml
@@ -18,7 +18,7 @@ replica:
   replicaCount: 0
   resourcesPreset: nano
   persistence:
-    enabled: true
+    enabled: false
     size: 1Gi
   persistentVolumeClaimRetentionPolicy:
     enabled: true

--- a/helm/acapy-cloud/templates/deployment.yaml
+++ b/helm/acapy-cloud/templates/deployment.yaml
@@ -121,6 +121,13 @@ spec:
           {{- include "common.tplvalues.render" (dict "value" . "context" $) | nindent 10 }}
           {{- end }}
         {{- end }}
+        {{- range $k,$_ := .Values.secretData }}
+        - name: {{ $k }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "acapy-cloud.fullname" $ }}-env
+              key: {{ $k }}
+        {{- end }}
         {{- if .Values.livenessProbe }}
         livenessProbe:
           {{- include "common.tplvalues.render" (dict "value" .Values.livenessProbe "context" $) | nindent 10 }}
@@ -136,10 +143,6 @@ spec:
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
         envFrom:
-        {{- if .Values.secretData }}
-          - secretRef:
-              name: {{ include "acapy-cloud.fullname" . }}-env
-        {{- end }}
         {{- range .Values.extraSecretNamesForEnvFrom }}
           - secretRef:
               name: {{ . }}

--- a/helm/nats/Chart.lock
+++ b/helm/nats/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 2.31.1
 - name: nats
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 9.0.18
-digest: sha256:3c7a9ebec2e436086d013d1d511cc9b43395833ee21657ee0d3891a45078bcb8
-generated: "2025-05-27T17:22:21.462497+02:00"
+  version: 9.0.19
+digest: sha256:4bf8d0f5833100934766960de937c0555cad45e62d6af40034b99365d2e6a067
+generated: "2025-06-06T16:28:14.441875+02:00"

--- a/tilt/acapy-cloud/Tiltfile
+++ b/tilt/acapy-cloud/Tiltfile
@@ -498,10 +498,6 @@ def setup_cheqd_localnet(namespace, ingress_domain):
             },
             "flags": [
                 "--set",
-                "ingressDomain=" + ingress_domain,
-                "--set",
-                "replicaCount=1",
-                "--set",
                 "secrets.validatorMnemonic=" + cheqd_validator_mnemonic,
             ],
             "labels": ["11-cheqd"],

--- a/tilt/acapy-cloud/Tiltfile
+++ b/tilt/acapy-cloud/Tiltfile
@@ -13,7 +13,7 @@ postgres_version = "16.0.11"
 # https://github.com/redpanda-data/helm-charts/tree/main/charts/connect
 redpanda_connect_version = "3.0.3"
 # https://github.com/bitnami/charts/tree/main/bitnami/valkey
-valkey_version = "3.0.9"
+valkey_version = "3.0.11"
 
 # Mnemonic for the Cheqd Localnet Validator
 # Will be used for Localnet as well as the Fee Payer for Cheqd DID Driver

--- a/tilt/acapy-cloud/Tiltfile
+++ b/tilt/acapy-cloud/Tiltfile
@@ -2,12 +2,18 @@ load("../utils/Tiltfile", "namespace_create_wrap", "generate_ingress_domain")
 load("ext://color", "color")
 load("ext://helm_resource", "helm_resource", "helm_repo")
 
-# https://github.com/bitnami/charts/tree/main/bitnami/postgresql-ha
-postgres_version = "16.0.10"
-# https://github.com/rowanruseler/helm-charts/tree/main/charts/pgadmin4
-pgadmin_version = "1.47.0"
 # https://github.com/cheqd/cheqd-node
 cheqd_noded_version = "v3.1.9"
+# https://github.com/bitnami/charts/tree/main/bitnami/minio
+minio_version = "17.0.3"
+# https://github.com/rowanruseler/helm-charts/tree/main/charts/pgadmin4
+pgadmin_version = "1.47.0"
+# https://github.com/bitnami/charts/tree/main/bitnami/postgresql-ha
+postgres_version = "16.0.11"
+# https://github.com/redpanda-data/helm-charts/tree/main/charts/connect
+redpanda_connect_version = "3.0.3"
+# https://github.com/bitnami/charts/tree/main/bitnami/valkey
+valkey_version = "3.0.9"
 
 # Mnemonic for the Cheqd Localnet Validator
 # Will be used for Localnet as well as the Fee Payer for Cheqd DID Driver
@@ -47,7 +53,35 @@ def setup_postgres(namespace):
             "--wait",
         ],
         labels=["04-dbs"],
-        resource_deps=["cloudapi-ns", "istio"],
+        resource_deps=["cloudapi-ns"],
+        deps=[values_file],
+    )
+
+
+def setup_valkey(namespace):
+    print(color.green("Installing Valkey..."))
+
+    values_file = "./helm/acapy-cloud/conf/valkey.yaml"
+
+    ## Setup Valkey
+    # https://github.com/bitnami/charts/tree/main/bitnami/valkey
+    helm_resource(
+        name="valkey",
+        chart="oci://registry-1.docker.io/bitnamicharts/valkey",
+        release_name="valkey",
+        namespace=namespace,
+        flags=[
+            "--values",
+            values_file,
+            "--version",
+            valkey_version,
+            "--wait",
+        ],
+        labels=["04-dbs"],
+        resource_deps=["cloudapi-ns"],
+        port_forwards=[
+            port_forward(6379, name="valkey"),
+        ],
         deps=[values_file],
     )
 
@@ -250,7 +284,7 @@ def setup_redpanda_connect_cloud(namespace):
             "--set",
             "streams.streamsConfigMap=" + resource_name + "-pipelines",
             "--version",
-            "3.0.3",
+            redpanda_connect_version,
         ],
         labels=["03-streaming"],
         resource_deps=[
@@ -288,7 +322,7 @@ def setup_minio(namespace, ingress_domain):
             "--set",
             "ingress.hostname=minio-api." + ingress_domain,
             "--version",
-            "17.0.2",
+            minio_version,
             "--wait",
         ],
         labels=["04-dbs"],
@@ -511,17 +545,17 @@ def setup_cloudapi(build_enabled, expose):
     ingress_domain = generate_ingress_domain(expose)
     print(color.green("Ingress Domain: " + ingress_domain))
 
+    setup_cheqd_localnet(namespace, ingress_domain)
     setup_minio(namespace, ingress_domain)
     setup_nats(namespace)
     setup_pgadmin(namespace, ingress_domain)
     setup_postgres(namespace)
     setup_redpanda_connect_cloud(namespace)
-
-    setup_cheqd_localnet(namespace, ingress_domain)
+    setup_valkey(namespace)
 
     releases = {
         "governance-agent": {
-            "depends": ["nats", "postgres", "did-registrar", "did-resolver"],
+            "depends": ["nats", "postgres", "valkey", "did-registrar", "did-resolver"],
             "links": [
                 link(
                     "http://governance-agent.cloudapi." + ingress_domain,
@@ -571,7 +605,7 @@ def setup_cloudapi(build_enabled, expose):
             },
         },
         "multitenant-agent": {
-            "depends": ["nats", "postgres", "did-registrar", "did-resolver"],
+            "depends": ["nats", "postgres", "valkey", "did-registrar", "did-resolver"],
             "links": [
                 link(
                     "http://multitenant-agent.cloudapi." + ingress_domain,

--- a/tilt/metrics/Tiltfile
+++ b/tilt/metrics/Tiltfile
@@ -22,7 +22,7 @@ def setup_metrics_server():
             "--set",
             "extraArgs[1]=--kubelet-insecure-tls",
             "--version",
-            "7.4.5",
+            "7.4.6",
             "--wait",
         ],
         labels=["30-monitoring"],


### PR DESCRIPTION
* Add [Valkey](https://valkey.io) Helm release with replication architecture
* Configure Valkey with authentication disabled and 1Gi storage
* Update PostgreSQL HA chart from `16.0.10` to `16.0.11`
* Update MinIO chart from `17.0.2` to `17.0.3`
* Update metrics-server chart from `7.4.5` to `7.4.6`
* Remove redundant init containers waiting for agent services
* Replace hardcoded `governance-agent` checks with trust registry URL
* Add Valkey as dependency for `governance` and `multitenant` agents

This change introduces Valkey as a Redis-compatible in-memory data
store for distributed locking mechanisms. The configuration uses
standalone architecture without authentication for development
environments.

The init container cleanup removes dependencies on specific agent
services, making the deployment more modular and reducing coupling
between components. The `public-web` service now waits for the trust
registry URL instead of individual agent endpoints.

---

> [!NOTE]
_Ideally we'd be using NATS KV for distributed locking instead of Valkey,
but this is the expedient solution. We can migrate Valkey -> NATS KV later_