### PR TITLE
:bug: Fix Scalar missing root path on initial load

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -122,7 +122,7 @@ async def scalar_html():
     return get_scalar_api_reference(
         openapi_url=openapi_url,
         title=app.title,
-        servers=app.servers,
+        servers=[{"url": ROOT_PATH} if ROOT_PATH else {}],
     )
 
 


### PR DESCRIPTION
Resolve bug where Scalar UI defaulted to `/` root path causing
API endpoints to return 404 errors. Previously, users had to
manually refresh the page to trigger FastAPI to update
`app.servers` with the correct root path.

* Use `ROOT_PATH` directly in servers configuration
* Eliminate need for manual page refresh to fix API paths
* Ensure Scalar UI uses correct root path from initial load