### PR TITLE
✅ K6 improvements to revocation

### DIFF
--- a/scripts/k6/libs/k6Functions.js
+++ b/scripts/k6/libs/k6Functions.js
@@ -8,6 +8,8 @@
  * and iteration tracking. All log messages are prefixed with [VU:x|Iter:y] for easy
  * identification during test execution.
  *
+ * During setup/teardown phases where VU/ITER are not available, only timestamp is shown.
+ *
  * Debug logging can be controlled via the DEBUG environment variable:
  * - Set DEBUG=true or DEBUG=1 to enable debug messages
  * - Debug messages are filtered out when DEBUG is not enabled
@@ -15,7 +17,8 @@
  * Usage:
  *   import { log } from './libs/k6Functions.js';
  *
- *   log.info('Test started');              // [VU:1|Iter:1] Test started
+ *   log.info('Test started');              // [VU:1|Iter:1] Test started (during test)
+ *   log.info('Setup complete');            // Setup complete (during setup/teardown)
  *   log.debug('Debug info', data);         // [VU:1|Iter:1] DEBUG: Debug info {data}
  *   log.error('Something failed');         // [VU:1|Iter:1] Something failed
  *   log.warn('Warning message');          // [VU:1|Iter:1] Warning message
@@ -28,9 +31,15 @@ const DEBUG_ENABLED = __ENV.DEBUG === 'true' || __ENV.DEBUG === '1';
 // Helper function to generate prefix with timestamp
 function getLogPrefix(includeLevel = false) {
   const timestamp = new Date().toISOString();
-  const vuInfo = `[VU:${__VU}|Iter:${__ITER}]`;
+
+  // Check if VU and ITER are available (they're undefined during setup/teardown)
+  let vuInfo = '';
+  if (typeof __VU !== 'undefined' && typeof __ITER !== 'undefined') {
+    vuInfo = `[VU:${__VU}|Iter:${__ITER}] `;
+  }
+
   const levelSuffix = includeLevel ? ' DEBUG:' : '';
-  return `${timestamp} ${vuInfo}${levelSuffix}`;
+  return `${timestamp} ${vuInfo}${levelSuffix}`.trim();
 }
 
 const log = {

--- a/scripts/k6/scenarios/bootstrap-issuer.js
+++ b/scripts/k6/scenarios/bootstrap-issuer.js
@@ -12,7 +12,7 @@ const numIssuers = __ENV.NUM_ISSUERS;
 const holderPrefix = __ENV.HOLDER_PREFIX;
 const outputPrefix = `${issuerPrefix}`;
 
-const filepath = `output/${outputPrefix}-create-issuers.json`;
+const filepath = `output/${outputPrefix}-create-issuers.jsonl`;
 export function setup() {
   file.writeString(filepath, "");
 }

--- a/scripts/k6/scenarios/create-creddef.js
+++ b/scripts/k6/scenarios/create-creddef.js
@@ -38,7 +38,7 @@ export const options = {
   },
 };
 
-const inputFilepath = `../output/${issuerPrefix}-create-issuers.json`;
+const inputFilepath = `../output/${issuerPrefix}-create-issuers.jsonl`;
 const data = open(inputFilepath, "r");
 
 export function setup() {

--- a/scripts/k6/scenarios/create-credentials.js
+++ b/scripts/k6/scenarios/create-credentials.js
@@ -47,10 +47,10 @@ export const options = {
   },
 };
 
-const inputFilepath = `../output/${outputPrefix}-create-invitation.json`;
+const inputFilepath = `../output/${outputPrefix}-create-invitation.jsonl`;
 const data = open(inputFilepath, "r");
-const outputFilepath = `output/${outputPrefix}-create-credentials.json`;
-const epochOutputFilepath = `output/${outputPrefix}-epoch-timestamps.json`;
+const outputFilepath = `output/${outputPrefix}-create-credentials.jsonl`;
+const epochOutputFilepath = `output/${outputPrefix}-epoch-timestamps.jsonl`;
 
 // Helper function to get the issuer index using pre-calculated assignments
 function getIssuerIndex(vu, iter) {

--- a/scripts/k6/scenarios/create-credentials.js
+++ b/scripts/k6/scenarios/create-credentials.js
@@ -172,6 +172,8 @@ export default function (data) {
   }, { perspective: "Holder" });
 
   const issuerData = JSON.stringify({
+    issuer_wallet_name: wallet.issuer_wallet_name,
+    issuer_wallet_id: wallet.issuer_wallet_id,
     credential_exchange_id: issuerCredentialExchangeId,
     issuer_access_token: wallet.issuer_access_token,
     issuer_credential_definition_id: wallet.issuer_credential_definition_id,

--- a/scripts/k6/scenarios/create-credentials.js
+++ b/scripts/k6/scenarios/create-credentials.js
@@ -125,7 +125,7 @@ export default function (data) {
     field: "thread_id",
     fieldId: threadId,
     state: "offer-received",
-    maxAttempts: 10,
+    // maxAttempts: 10,
     lookBack: 60,
     sseTag: "credential_offer_received",
   }, { perspective: "Holder" });
@@ -166,7 +166,7 @@ export default function (data) {
     field: "credential_exchange_id",
     fieldId: holderCredentialExchangeId,
     state: "done",
-    maxAttempts: 10,
+    // maxAttempts: 10,
     lookBack: 60,
     sseTag: "credential_received",
   }, { perspective: "Holder" });

--- a/scripts/k6/scenarios/create-holders.js
+++ b/scripts/k6/scenarios/create-holders.js
@@ -59,7 +59,7 @@ const wallets = new SharedArray("wallets", () => {
   return walletsArray;
 });
 
-const filepath = `output/${outputPrefix}-create-holders.json`;
+const filepath = `output/${outputPrefix}-create-holders.jsonl`;
 export function setup() {
   file.writeString(filepath, "");
 

--- a/scripts/k6/scenarios/create-invitations.js
+++ b/scripts/k6/scenarios/create-invitations.js
@@ -52,11 +52,11 @@ export const options = {
 };
 
 const testFunctionReqs = new Counter("test_function_reqs");     // successful completions
-const inputFilepath = `../output/${holderPrefix}-create-holders.json`;
-const inputFilepathIssuer = `../output/${issuerPrefix}-create-issuers.json`;
+const inputFilepath = `../output/${holderPrefix}-create-holders.jsonl`;
+const inputFilepathIssuer = `../output/${issuerPrefix}-create-issuers.jsonl`;
 const data = open(inputFilepath, "r");
 const dataIssuer = open(inputFilepathIssuer, "r");
-const outputFilepath = `output/${outputPrefix}-create-invitation.json`;
+const outputFilepath = `output/${outputPrefix}-create-invitation.jsonl`;
 
 export function setup() {
   const holders = data.trim().split("\n").map(JSON.parse);

--- a/scripts/k6/scenarios/create-issuers.js
+++ b/scripts/k6/scenarios/create-issuers.js
@@ -18,7 +18,7 @@ const iterations = Number.parseInt(__ENV.ITERATIONS, 10);
 const issuerPrefix = __ENV.ISSUER_PREFIX;
 const outputPrefix = `${issuerPrefix}`;
 // const holderPrefix = __ENV.HOLDER_PREFIX;
-const filepath = `output/${outputPrefix}-create-issuers.json`;
+const filepath = `output/${outputPrefix}-create-issuers.jsonl`;
 
 export const options = {
   scenarios: {

--- a/scripts/k6/scenarios/create-proof.js
+++ b/scripts/k6/scenarios/create-proof.js
@@ -48,10 +48,10 @@ export const options = {
 
 const testFunctionReqs = new Counter("test_function_reqs");
 
-const inputFilepath = `../output/${outputPrefix}-create-invitation.json`;
+const inputFilepath = `../output/${outputPrefix}-create-invitation.jsonl`;
 const data = open(inputFilepath, "r");
 // Add path to epoch timestamps file
-const epochInputFilepath = `../output/${outputPrefix}-epoch-timestamps.json`;
+const epochInputFilepath = `../output/${outputPrefix}-epoch-timestamps.jsonl`;
 // Read epoch data in init stage
 let epochData = null;
 try {

--- a/scripts/k6/scenarios/create-proof.js
+++ b/scripts/k6/scenarios/create-proof.js
@@ -41,7 +41,7 @@ export const options = {
   },
   tags: {
     test_run_id: "phased-issuance",
-    test_phase: "create-proofs",
+    test_phase: __ENV.IS_REVOKED === "true" ? "create-proofs-unverified" : "create-proofs-verified",
     version: `${version}`,
   },
 };
@@ -185,7 +185,7 @@ export default function (data) {
     field: "thread_id",
     fieldId: threadId,
     state: "done",
-    maxAttempts: 1,
+    // maxAttempts: 3,
     lookBack: 60,
     sseTag: "proof_done",
   }, { perspective: "Holder" });

--- a/scripts/k6/scenarios/create-schemas.js
+++ b/scripts/k6/scenarios/create-schemas.js
@@ -7,7 +7,7 @@ import file from "k6/x/file";
 import { getAuthHeaders } from "./auth.js";
 import { createSchema, getSchema, getWalletIndex } from "../libs/functions.js";
 
-const outputFilepath = "output/create-schemas.json";
+const outputFilepath = "output/create-schemas.jsonl";
 const vus = Number.parseInt(__ENV.VUS, 10);
 const iterations = Number.parseInt(__ENV.ITERATIONS, 10);
 const schemaPrefix = __ENV.SCHEMA_PREFIX;

--- a/scripts/k6/scenarios/delete-holders.js
+++ b/scripts/k6/scenarios/delete-holders.js
@@ -58,7 +58,7 @@ const wallets = new SharedArray("wallets", () => {
   return walletsArray;
 });
 
-const filepath = `output/${outputPrefix}-create-holders.json`;
+const filepath = `output/${outputPrefix}-create-holders.jsonl`;
 
 export function setup() {
   const { tenantAdminHeaders } = getAuthHeaders();

--- a/scripts/k6/scenarios/delete-issuers.js
+++ b/scripts/k6/scenarios/delete-issuers.js
@@ -56,7 +56,7 @@ const wallets = new SharedArray("wallets", () => {
   return walletsArray;
 });
 
-const filepath = `output/${outputPrefix}-create-issuers.json`;
+const filepath = `output/${outputPrefix}-create-issuers.jsonl`;
 
 export function setup() {
   const { tenantAdminHeaders } = getAuthHeaders();

--- a/scripts/k6/scenarios/publish-revoke.js
+++ b/scripts/k6/scenarios/publish-revoke.js
@@ -15,7 +15,7 @@ const holderPrefix = __ENV.HOLDER_PREFIX;
 const issuerPrefix = __ENV.ISSUER_PREFIX;
 const outputPrefix = `${issuerPrefix}-${holderPrefix}`;
 
-const inputFilepath = `../output/${outputPrefix}-create-credentials.json`;
+const inputFilepath = `../output/${outputPrefix}-create-credentials.jsonl`;
 const data = open(inputFilepath, "r");
 
 const vus = Number.parseInt(__ENV.VUS, 10);

--- a/scripts/k6/scenarios/publish-revoke.js
+++ b/scripts/k6/scenarios/publish-revoke.js
@@ -21,6 +21,8 @@ const iterations = Number.parseInt(__ENV.ITERATIONS, 10);
 const testFunctionReqs = new Counter("test_function_reqs");
 const sleepDuration = Number.parseInt(__ENV.SLEEP_DURATION, 0);
 
+const version = __ENV.VERSION;
+
 export const options = {
   scenarios: {
     default: {
@@ -42,6 +44,7 @@ export const options = {
   tags: {
     test_run_id: "phased-issuance",
     test_phase: "publish-revoke",
+    version: `${version}`,
   },
 };
 
@@ -57,6 +60,15 @@ export function setup() {
   ];
 
   for (const issuerToken of uniqueIssuers) {
+    // Find the tenant data for this issuer token to get wallet info
+    const issuerTenant = tenants.find(
+      (tenant) => tenant.issuer_access_token === issuerToken
+    );
+
+    console.log(
+      `Publishing revocation for issuer: ${issuerTenant.walletName} (ID: ${issuerTenant.walletId})`
+    );
+
     const publishRevocationResponse = publishRevocation(issuerToken);
     check(publishRevocationResponse, {
       "Revocation published successfully": (r) => {

--- a/scripts/k6/scenarios/publish-revoke.js
+++ b/scripts/k6/scenarios/publish-revoke.js
@@ -117,6 +117,6 @@ export default function (data) {
     },
   });
 
-  sleep(sleepDuration);
+  // sleep(sleepDuration);
   testFunctionReqs.add(1);
 }

--- a/scripts/k6/scenarios/revoke-credentials.js
+++ b/scripts/k6/scenarios/revoke-credentials.js
@@ -16,7 +16,7 @@ const holderPrefix = __ENV.HOLDER_PREFIX;
 const issuerPrefix = __ENV.ISSUER_PREFIX;
 const outputPrefix = `${issuerPrefix}-${holderPrefix}`;
 
-const inputFilepath = `../output/${outputPrefix}-create-credentials.json`;
+const inputFilepath = `../output/${outputPrefix}-create-credentials.jsonl`;
 const data = open(inputFilepath, "r");
 
 const vus = Number.parseInt(__ENV.VUS, 10);

--- a/scripts/k6/scenarios/revoke-credentials.js
+++ b/scripts/k6/scenarios/revoke-credentials.js
@@ -24,6 +24,8 @@ const iterations = Number.parseInt(__ENV.ITERATIONS, 10);
 const testFunctionReqs = new Counter("test_function_reqs");
 const sleepDuration = Number.parseInt(__ENV.SLEEP_DURATION, 0);
 
+const version = __ENV.VERSION;
+
 export const options = {
   scenarios: {
     default: {
@@ -45,6 +47,7 @@ export const options = {
   tags: {
     test_run_id: "phased-issuance",
     test_phase: "revoke-credentials",
+    version: `${version}`,
   },
 };
 


### PR DESCRIPTION
- Support k6 `setup()` and `teardown()` phases in custom logging function
- Retry publishing revocation
- Use JSON lines file extension: `.jsonl`
- Programatically set k6 `test_phase` tag when creating proofs 