### PR TITLE
✅ Reduce error logs from tests

### DIFF
--- a/app/tests/e2e/issuer/test_anoncreds_credentials.py
+++ b/app/tests/e2e/issuer/test_anoncreds_credentials.py
@@ -132,6 +132,22 @@ async def test_send_credential_and_request(
         check_webhook_state(
             client=alice_member_client,
             topic="credentials",
+            state="request-sent",
+            filter_map={
+                "thread_id": thread_id,
+            },
+        ),
+        check_webhook_state(
+            client=faber_anoncreds_client,
+            topic="credentials",
+            state="request-received",
+            filter_map={
+                "thread_id": thread_id,
+            },
+        ),
+        check_webhook_state(
+            client=alice_member_client,
+            topic="credentials",
             state="done",
             filter_map={
                 "thread_id": thread_id,

--- a/app/tests/e2e/issuer/test_anoncreds_credentials.py
+++ b/app/tests/e2e/issuer/test_anoncreds_credentials.py
@@ -132,7 +132,7 @@ async def test_send_credential_and_request(
         check_webhook_state(
             client=alice_member_client,
             topic="credentials",
-            state="request-sent",
+            state="done",
             filter_map={
                 "thread_id": thread_id,
             },
@@ -140,7 +140,7 @@ async def test_send_credential_and_request(
         check_webhook_state(
             client=faber_anoncreds_client,
             topic="credentials",
-            state="request-received",
+            state="done",
             filter_map={
                 "thread_id": thread_id,
             },

--- a/app/tests/e2e/test_messaging.py
+++ b/app/tests/e2e/test_messaging.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 
 from app.models.messaging import Message, TrustPingMsg
@@ -23,6 +25,7 @@ async def test_send_trust_ping(
 
     assert response.status_code == 200
     assert "thread_id" in response_data
+    time.sleep(1)  # Wait for ping to be sent before deleting wallet
 
 
 @pytest.mark.anyio

--- a/app/tests/e2e/test_messaging.py
+++ b/app/tests/e2e/test_messaging.py
@@ -5,6 +5,7 @@ import pytest
 from app.models.messaging import Message, TrustPingMsg
 from app.routes.messaging import router
 from app.tests.util.connections import BobAliceConnect
+from app.tests.util.webhooks import check_webhook_state
 from shared import RichAsyncClient
 
 MESSAGING_BASE_PATH = router.prefix
@@ -30,7 +31,9 @@ async def test_send_trust_ping(
 
 @pytest.mark.anyio
 async def test_send_message(
-    bob_and_alice_connection: BobAliceConnect, alice_member_client: RichAsyncClient
+    bob_and_alice_connection: BobAliceConnect,
+    alice_member_client: RichAsyncClient,
+    bob_member_client: RichAsyncClient,
 ):
     message = Message(
         connection_id=bob_and_alice_connection.alice_connection_id, content="Asdf"
@@ -39,5 +42,15 @@ async def test_send_message(
     response = await alice_member_client.post(
         MESSAGING_BASE_PATH + "/send-message", json=message.model_dump()
     )
-
     assert response.status_code == 200
+
+    event = await check_webhook_state(
+        client=bob_member_client,
+        topic="basic-message",
+        state="received",
+        filter_map={
+            "connection_id": bob_and_alice_connection.bob_connection_id,
+        },
+    )
+    assert event is not None
+    assert event["content"] == "Asdf"

--- a/dockerfiles/agents/poetry.lock
+++ b/dockerfiles/agents/poetry.lock
@@ -1387,8 +1387,11 @@ files = [
     {file = "lxml-5.4.0-cp36-cp36m-win_amd64.whl", hash = "sha256:7ce1a171ec325192c6a636b64c94418e71a1964f56d002cc28122fceff0b6121"},
     {file = "lxml-5.4.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:795f61bcaf8770e1b37eec24edf9771b307df3af74d1d6f27d812e15a9ff3872"},
     {file = "lxml-5.4.0-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:29f451a4b614a7b5b6c2e043d7b64a15bd8304d7e767055e8ab68387a8cacf4e"},
+    {file = "lxml-5.4.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:891f7f991a68d20c75cb13c5c9142b2a3f9eb161f1f12a9489c82172d1f133c0"},
     {file = "lxml-5.4.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4aa412a82e460571fad592d0f93ce9935a20090029ba08eca05c614f99b0cc92"},
+    {file = "lxml-5.4.0-cp37-cp37m-manylinux_2_28_aarch64.whl", hash = "sha256:ac7ba71f9561cd7d7b55e1ea5511543c0282e2b6450f122672a2694621d63b7e"},
     {file = "lxml-5.4.0-cp37-cp37m-manylinux_2_28_x86_64.whl", hash = "sha256:c5d32f5284012deaccd37da1e2cd42f081feaa76981f0eaa474351b68df813c5"},
+    {file = "lxml-5.4.0-cp37-cp37m-musllinux_1_2_aarch64.whl", hash = "sha256:ce31158630a6ac85bddd6b830cffd46085ff90498b397bd0a259f59d27a12188"},
     {file = "lxml-5.4.0-cp37-cp37m-musllinux_1_2_x86_64.whl", hash = "sha256:31e63621e073e04697c1b2d23fcb89991790eef370ec37ce4d5d469f40924ed6"},
     {file = "lxml-5.4.0-cp37-cp37m-win32.whl", hash = "sha256:be2ba4c3c5b7900246a8f866580700ef0d538f2ca32535e991027bdaba944063"},
     {file = "lxml-5.4.0-cp37-cp37m-win_amd64.whl", hash = "sha256:09846782b1ef650b321484ad429217f5154da4d6e786636c38e434fa32e94e49"},
@@ -1733,8 +1736,8 @@ aca-py = ["acapy-agent-didx (==1.3.0.post20250526)"]
 [package.source]
 type = "git"
 url = "https://github.com/didx-xyz/aries-acapy-plugins"
-reference = "1.3.0-20250526"
-resolved_reference = "b21a81487fa7dd1c6809140c55ccf671c44ce23f"
+reference = "1b009670f"
+resolved_reference = "1b009670f7f753976a4773215be28ab4d76690a7"
 subdirectory = "nats_events"
 
 [[package]]
@@ -2947,4 +2950,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "~3.12.8"
-content-hash = "e69db9193da96c0af964ecc037bc618ba5883d443d5859044dde493d2bf3e2a1"
+content-hash = "8be42f241bffad1cde456c6908ab40a8a8ea2ac91ecb06c122161536ce1fb828"

--- a/dockerfiles/agents/pyproject.toml
+++ b/dockerfiles/agents/pyproject.toml
@@ -15,7 +15,7 @@ protobuf = "~=5.29.3"
 
 # ACA-Py Plugins
 acapy-wallet-groups-plugin = "==1.3.0.post20250526"
-nats-events = { git = "https://github.com/didx-xyz/aries-acapy-plugins", tag = "1.3.0-20250526", subdirectory = "nats_events" }
+nats-events = { git = "https://github.com/didx-xyz/aries-acapy-plugins", rev = "1b009670f", subdirectory = "nats_events" }
 cheqd = { git = "https://github.com/didx-xyz/aries-acapy-plugins", branch = "debug-cheqd", subdirectory = "cheqd" }
 
 [build-system]

--- a/resources/connect-processors/cloud/pipelines/cloud-events.yaml
+++ b/resources/connect-processors/cloud/pipelines/cloud-events.yaml
@@ -1,16 +1,30 @@
 input:
-  label: acapy_events
-  nats_jetstream:
-    urls:
-      - ${NATS_URL:nats://nats:4222}
-    subject: ${CLOUD_EVENTS_CREATE_NATS_INPUT_SUBJECT_PREFIX:acapy.record-with-state}.${CLOUD_EVENTS_CREATE_NATS_INPUT_TOPIC:*}
-    stream: ${CLOUD_EVENTS_CREATE_NATS_INPUT_STREAM:"acapy_events"}
-    durable: ${CLOUD_EVENTS_CREATE_NATS_INPUT_CONSUMER_NAME:acapy-events-processor}
-    queue: ${CLOUD_EVENTS_CREATE_NATS_INPUT_QUEUE_GROUP:""}
-    bind: ${CLOUD_EVENTS_CREATE_NATS_INPUT_BIND:false}
-    deliver: ${CLOUD_EVENTS_CREATE_NATS_INPUT_DELIVER:"all"}
-    auth:
-      user_credentials_file: ${NATS_AUTH_CREDENTIALS_FILE:""}
+  broker:
+    inputs:
+      - label: acapy_events
+        nats_jetstream:
+          urls:
+            - ${NATS_URL:nats://nats:4222}
+          subject: ${CLOUD_EVENTS_CREATE_NATS_INPUT_SUBJECT_PREFIX:acapy.record-with-state}.${CLOUD_EVENTS_CREATE_NATS_INPUT_TOPIC:*}
+          stream: ${CLOUD_EVENTS_CREATE_NATS_INPUT_STREAM:"acapy_events"}
+          durable: ${CLOUD_EVENTS_CREATE_NATS_INPUT_CONSUMER_NAME:acapy-events-processor}
+          queue: ${CLOUD_EVENTS_CREATE_NATS_INPUT_QUEUE_GROUP:""}
+          bind: ${CLOUD_EVENTS_CREATE_NATS_INPUT_BIND:false}
+          deliver: ${CLOUD_EVENTS_CREATE_NATS_INPUT_DELIVER:"all"}
+          auth:
+            user_credentials_file: ${NATS_AUTH_CREDENTIALS_FILE:""}
+      - label: acapy_messages
+        nats_jetstream:
+          urls:
+            - ${NATS_URL:nats://nats:4222}
+          subject: ${CLOUD_EVENTS_CREATE_NATS_INPUT_SUBJECT_MESSAGE_PREFIX:acapy.basicmessage.received}
+          stream: ${CLOUD_EVENTS_CREATE_NATS_INPUT_STREAM:"acapy_events"}
+          durable: ${CLOUD_EVENTS_CREATE_NATS_INPUT_CONSUMER_NAME:acapy-message-processor}
+          queue: ${CLOUD_EVENTS_CREATE_NATS_INPUT_QUEUE_GROUP:""}
+          bind: ${CLOUD_EVENTS_CREATE_NATS_INPUT_BIND:false}
+          deliver: ${CLOUD_EVENTS_CREATE_NATS_INPUT_DELIVER:"all"}
+          auth:
+            user_credentials_file: ${NATS_AUTH_CREDENTIALS_FILE:""}
 
 pipeline:
   threads: ${CLOUD_EVENTS_CREATE_PIPELINE_THREADS:-1}

--- a/resources/connect-processors/cloud/pipelines/cloud-events.yaml
+++ b/resources/connect-processors/cloud/pipelines/cloud-events.yaml
@@ -28,7 +28,7 @@ pipeline:
         root.payload = $payload
 
         let topic_mapping = {
-            "basicmessages": "basic-messages",
+            "basicmessage": "basic-message",
             "connections": "connections",
             "endorse_transaction": "endorsements",
             "credential": "deleted_credential",


### PR DESCRIPTION
Rework some test to remove error logs related to agent trying to send messages/credentials to deleted wallets

example of error logs:
`Exceeded retry limit for verkey: 2yQj8ebpGap7S9SXvyXNZV3YkfENcxrAFSUBMtEWnzrq`
`parsed_msg does not contain @type: {'protected':...`
`Message parsing failed: Message does not contain '@type' parameter, sending problem report`