### PR TITLE
:heavy_plus_sign: Add pytest-ruff

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -108,6 +108,7 @@
     "patchers",
     "pathspec",
     "paymentaddr",
+    "perflint",
     "pgadmin",
     "pgpool",
     "PIPESTATUS",

--- a/app/routes/admin/tenants.py
+++ b/app/routes/admin/tenants.py
@@ -59,7 +59,7 @@ group_id_query: str | None = Query(
 )
 
 
-@router.post("", response_model=CreateTenantResponse, summary="Create New Tenant")
+@router.post("", summary="Create New Tenant")
 async def create_tenant(
     body: CreateTenantRequest,
     admin_auth: AcaPyAuthVerified = Depends(acapy_auth_tenant_admin),
@@ -296,7 +296,6 @@ async def delete_tenant_by_id(
 
 @router.post(
     "/{wallet_id}/access-token",
-    response_model=TenantAuth,
     summary="Rotate and Get New Access Token for Wallet",
 )
 async def post_wallet_auth_token(
@@ -344,7 +343,7 @@ async def post_wallet_auth_token(
     return response
 
 
-@router.put("/{wallet_id}", response_model=Tenant, summary="Update Tenant by Wallet ID")
+@router.put("/{wallet_id}", summary="Update Tenant by Wallet ID")
 async def update_tenant(
     wallet_id: str,
     body: UpdateTenantRequest,
@@ -406,7 +405,7 @@ async def update_tenant(
     return response
 
 
-@router.get("/{wallet_id}", response_model=Tenant, summary="Get Tenant by Wallet ID")
+@router.get("/{wallet_id}", summary="Get Tenant by Wallet ID")
 async def get_tenant(
     wallet_id: str,
     group_id: str | None = group_id_query,
@@ -449,7 +448,7 @@ async def get_tenant(
     return response
 
 
-@router.get("", response_model=list[Tenant], summary="Fetch Tenants")
+@router.get("", summary="Fetch Tenants")
 async def get_tenants(
     wallet_name: str | None = None,
     group_id: str | None = group_id_query,

--- a/app/routes/connections.py
+++ b/app/routes/connections.py
@@ -29,7 +29,7 @@ logger = get_logger(__name__)
 router = APIRouter(prefix="/v1/connections", tags=["connections"])
 
 
-@router.get("", summary="Fetch Connection Records", response_model=list[Connection])
+@router.get("", summary="Fetch Connection Records")
 async def get_connections(  # pylint: disable=R0913,R0917
     limit: int | None = limit_query_parameter,
     offset: int | None = offset_query_parameter,
@@ -104,9 +104,7 @@ async def get_connections(  # pylint: disable=R0913,R0917
     return result
 
 
-@router.get(
-    "/{connection_id}", summary="Fetch a Connection Record", response_model=Connection
-)
+@router.get("/{connection_id}", summary="Fetch a Connection Record")
 async def get_connection_by_id(  # noqa: D417
     connection_id: str,
     auth: AcaPyAuth = Depends(acapy_auth_from_header),
@@ -199,7 +197,6 @@ async def delete_connection_by_id(  # noqa: D417
 @router.post(
     "/did-exchange/create-request",
     summary="Create a DID Exchange Request",
-    response_model=Connection,
 )
 async def create_did_exchange_request(  # noqa: D417
     their_public_did: str,
@@ -284,7 +281,6 @@ async def create_did_exchange_request(  # noqa: D417
 @router.post(
     "/did-exchange/accept-request",
     summary="Accept a DID Exchange Request",
-    response_model=Connection,
 )
 async def accept_did_exchange_request(  # noqa: D417
     connection_id: str,
@@ -326,7 +322,6 @@ async def accept_did_exchange_request(  # noqa: D417
 @router.post(
     "/did-exchange/reject",
     summary="Reject or Abandon a DID Exchange",
-    response_model=Connection,
 )
 async def reject_did_exchange(
     connection_id: str,
@@ -363,7 +358,6 @@ async def reject_did_exchange(
 @router.post(
     "/did-rotate",
     summary="Begin DID Rotation",
-    response_model=Rotate,
 )
 async def rotate_did(  # noqa: D417
     connection_id: str,
@@ -406,7 +400,6 @@ async def rotate_did(  # noqa: D417
 @router.post(
     "/did-rotate/hangup",
     summary="Hangup DID Rotation",
-    response_model=Hangup,
 )
 async def hangup_did_rotation(  # noqa: D417
     connection_id: str,

--- a/app/routes/definitions.py
+++ b/app/routes/definitions.py
@@ -34,7 +34,7 @@ router = APIRouter(
 )
 
 
-@router.post("/schemas", summary="Create a new Schema", response_model=CredentialSchema)
+@router.post("/schemas", summary="Create a new Schema")
 async def create_schema(
     schema: CreateSchema,
     auth: AcaPyAuthVerified = Depends(acapy_auth_verified),
@@ -97,7 +97,6 @@ async def create_schema(
 @router.get(
     "/schemas",
     summary="Get Created Schemas",
-    response_model=list[CredentialSchema],
 )
 async def get_schemas(
     schema_issuer_did: str | None = None,
@@ -172,7 +171,6 @@ async def get_schemas(
 @router.get(
     "/schemas/{schema_id:path}",
     summary="Get a Schema",
-    response_model=CredentialSchema,
 )
 async def get_schema(  # noqa: D417
     schema_id: str,
@@ -218,7 +216,6 @@ async def get_schema(  # noqa: D417
 @router.post(
     "/credentials",
     summary="Create a new Credential Definition",
-    response_model=CredentialDefinition,
 )
 async def create_credential_definition(
     credential_definition: CreateCredentialDefinition,
@@ -287,7 +284,6 @@ async def create_credential_definition(
 @router.get(
     "/credentials",
     summary="Get Created Credential Definitions",
-    response_model=list[CredentialDefinition],
 )
 async def get_credential_definitions(
     issuer_did: str | None = None,
@@ -356,7 +352,6 @@ async def get_credential_definitions(
 @router.get(
     "/credentials/{credential_definition_id:path}",
     summary="Get a Credential Definition",
-    response_model=CredentialDefinition,
 )
 async def get_credential_definition_by_id(  # noqa: D417
     credential_definition_id: str,

--- a/app/routes/issuer.py
+++ b/app/routes/issuer.py
@@ -26,7 +26,7 @@ logger = get_logger(__name__)
 router = APIRouter(prefix="/v1/issuer/credentials", tags=["issuer"])
 
 
-@router.post("", summary="Send Holder a Credential", response_model=CredentialExchange)
+@router.post("", summary="Send Holder a Credential")
 async def send_credential(
     credential: SendCredential,
     auth: AcaPyAuth = Depends(acapy_auth_from_header),
@@ -104,7 +104,6 @@ async def send_credential(
 @router.post(
     "/create-offer",
     summary="Create a Credential Offer (not bound to a connection)",
-    response_model=CredentialExchange,
 )
 async def create_offer(
     credential: CreateOffer,
@@ -181,7 +180,6 @@ async def create_offer(
 @router.post(
     "/{credential_exchange_id}/request",
     summary="Accept a Credential Offer",
-    response_model=CredentialExchange,
 )
 async def request_credential(  # noqa: D417
     credential_exchange_id: str,
@@ -254,7 +252,6 @@ async def request_credential(  # noqa: D417
 @router.post(
     "/{credential_exchange_id}/store",
     summary="Store a Received Credential in Wallet",
-    response_model=CredentialExchange,
 )
 async def store_credential(  # noqa: D417
     credential_exchange_id: str,
@@ -298,7 +295,6 @@ async def store_credential(  # noqa: D417
 @router.get(
     "",
     summary="Fetch Credential Exchange Records",
-    response_model=list[CredentialExchange],
 )
 async def get_credentials(
     limit: int | None = limit_query_parameter,
@@ -372,7 +368,6 @@ async def get_credentials(
 @router.get(
     "/{credential_exchange_id}",
     summary="Fetch a single Credential Exchange Record",
-    response_model=CredentialExchange,
 )
 async def get_credential(  # noqa: D417
     credential_exchange_id: str,

--- a/app/routes/messaging.py
+++ b/app/routes/messaging.py
@@ -52,9 +52,7 @@ async def send_messages(
     logger.debug("Successfully sent message.")
 
 
-@router.post(
-    "/trust-ping", summary="Send Trust Ping", response_model=PingRequestResponse
-)
+@router.post("/trust-ping", summary="Send Trust Ping")
 async def send_trust_ping(
     trustping_msg: TrustPingMsg,
     auth: AcaPyAuth = Depends(acapy_auth_from_header),

--- a/app/routes/oob.py
+++ b/app/routes/oob.py
@@ -17,7 +17,6 @@ router = APIRouter(prefix="/v1/oob", tags=["out-of-band"])
 @router.post(
     "/create-invitation",
     summary="Create OOB Invitation",
-    response_model=InvitationRecord,
 )
 async def create_oob_invitation(
     body: CreateOobInvitation | None = None,
@@ -97,9 +96,7 @@ async def create_oob_invitation(
     return invitation
 
 
-@router.post(
-    "/accept-invitation", summary="Accept OOB Invitation", response_model=OobRecord
-)
+@router.post("/accept-invitation", summary="Accept OOB Invitation")
 async def accept_oob_invitation(
     body: AcceptOobInvitation,
     auth: AcaPyAuth = Depends(acapy_auth_from_header),
@@ -142,9 +139,7 @@ async def accept_oob_invitation(
     return oob_record
 
 
-@router.post(
-    "/connect-public-did", summary="Connect with Public DID", response_model=Connection
-)
+@router.post("/connect-public-did", summary="Connect with Public DID")
 async def connect_to_public_did(
     body: ConnectToPublicDid,
     auth: AcaPyAuth = Depends(acapy_auth_from_header),

--- a/app/routes/revocation.py
+++ b/app/routes/revocation.py
@@ -72,7 +72,6 @@ async def revoke_credential(
 @router.get(
     "/revocation/record",
     summary="Fetch a Revocation Record",
-    response_model=IssuerCredRevRecord,
 )
 async def get_credential_revocation_record(  # noqa: D417
     credential_exchange_id: str | None = None,
@@ -226,7 +225,6 @@ async def publish_revocations(
 @router.post(
     "/clear-pending-revocations",
     summary="Clear Pending Revocations",
-    response_model=ClearPendingRevocationsResult,
 )
 async def clear_pending_revocations(
     clear_pending_request: ClearPendingRevocationsRequest,

--- a/app/routes/trust_registry.py
+++ b/app/routes/trust_registry.py
@@ -10,7 +10,7 @@ logger = get_logger(__name__)
 router = APIRouter(prefix="/v1/trust-registry", tags=["trust-registry"])
 
 
-@router.get("/schemas", response_model=list[Schema])
+@router.get("/schemas")
 async def get_schemas() -> list[Schema]:
     """Fetch the schemas from the trust registry.
 
@@ -26,7 +26,7 @@ async def get_schemas() -> list[Schema]:
     return schemas
 
 
-@router.get("/schemas/{schema_id:path}", response_model=Schema)
+@router.get("/schemas/{schema_id:path}")
 async def get_schema_by_id(schema_id: str) -> Schema:  # noqa: D417
     """Retrieve schema by id.
 
@@ -51,7 +51,7 @@ async def get_schema_by_id(schema_id: str) -> Schema:  # noqa: D417
         raise HTTPException(404, f"Schema with id: {schema_id} not found")
 
 
-@router.get("/actors", response_model=list[Actor])
+@router.get("/actors")
 async def get_actors(  # noqa: D417
     actor_did: str | None = None,
     actor_id: str | None = None,
@@ -119,7 +119,7 @@ async def get_actors(  # noqa: D417
         raise HTTPException(404, "Actor not found")
 
 
-@router.get("/actors/issuers", response_model=list[Actor])
+@router.get("/actors/issuers")
 async def get_issuers() -> list[Actor]:
     """Fetch the issuers from the trust registry.
 
@@ -135,7 +135,7 @@ async def get_issuers() -> list[Actor]:
     return issuers
 
 
-@router.get("/actors/verifiers", response_model=list[Actor])
+@router.get("/actors/verifiers")
 async def get_verifiers() -> list[Actor]:
     """Fetch the verifiers from the trust registry.
 

--- a/app/routes/verifier.py
+++ b/app/routes/verifier.py
@@ -31,7 +31,6 @@ router = APIRouter(prefix="/v1/verifier", tags=["verifier"])
 @router.post(
     "/send-request",
     summary="Send a Proof Request to a connection",
-    response_model=PresentationExchange,
 )
 async def send_proof_request(
     body: SendProofRequest,
@@ -97,7 +96,6 @@ async def send_proof_request(
 @router.post(
     "/create-request",
     summary="Create a Proof Request (not bound to a connection)",
-    response_model=PresentationExchange,
 )
 async def create_proof_request(
     body: CreateProofRequest,
@@ -160,7 +158,6 @@ async def create_proof_request(
 @router.post(
     "/accept-request",
     summary="Accept a Proof Request",
-    response_model=PresentationExchange,
 )
 async def accept_proof_request(
     body: AcceptProofRequest,
@@ -310,7 +307,6 @@ async def reject_proof_request(
 @router.get(
     "/proofs",
     summary="Get Presentation Exchange Records",
-    response_model=list[PresentationExchange],
 )
 async def get_proof_records(
     limit: int | None = limit_query_parameter,
@@ -376,7 +372,6 @@ async def get_proof_records(
 @router.get(
     "/proofs/{proof_id}",
     summary="Get a Presentation Exchange Record",
-    response_model=PresentationExchange,
 )
 async def get_proof_record(  # noqa: D417
     proof_id: str,
@@ -459,7 +454,6 @@ async def delete_proof(  # noqa: D417
 @router.get(
     "/proofs/{proof_id}/credentials",
     summary="Get Matching Credentials for a Proof",
-    response_model=list[CredPrecis],
 )
 async def get_credentials_by_proof_id(  # noqa: D417
     proof_id: str,

--- a/app/routes/wallet/credentials.py
+++ b/app/routes/wallet/credentials.py
@@ -19,7 +19,6 @@ router = APIRouter(prefix="/v1/wallet/credentials", tags=["wallet"])
 
 @router.get(
     "",
-    response_model=CredInfoList,
     summary="Fetch a list of credentials from the wallet",
 )
 async def list_credentials(
@@ -70,7 +69,6 @@ async def list_credentials(
 
 @router.get(
     "/{credential_id}",
-    response_model=CredInfo,
     summary="Fetch a credential by ID",
 )
 async def get_credential_record(  # noqa: D417
@@ -140,7 +138,6 @@ async def delete_credential(  # noqa: D417
 
 @router.get(
     "/{credential_id}/mime-types",
-    response_model=AttributeMimeTypesResult,
     summary="Retrieve attribute MIME types of a credential",
 )
 async def get_credential_mime_types(  # noqa: D417
@@ -180,7 +177,6 @@ async def get_credential_mime_types(  # noqa: D417
 
 @router.get(
     "/{credential_id}/revocation-status",
-    response_model=CredRevokedResult,
     summary="Get revocation status of a credential",
 )
 async def get_credential_revocation_status(  # noqa: D417
@@ -232,7 +228,6 @@ async def get_credential_revocation_status(  # noqa: D417
 
 @router.get(
     "/w3c",
-    response_model=VCRecordList,
     summary="Fetch a list of W3C credentials from the wallet",
 )
 async def list_w3c_credentials(
@@ -283,7 +278,6 @@ async def list_w3c_credentials(
 
 @router.get(
     "/w3c/{credential_id}",
-    response_model=VCRecord,
     summary="Fetch a W3C credential by ID",
 )
 async def get_w3c_credential(  # noqa: D417

--- a/app/routes/wallet/dids.py
+++ b/app/routes/wallet/dids.py
@@ -17,7 +17,7 @@ logger = get_logger(__name__)
 router = APIRouter(prefix="/v1/wallet/dids", tags=["wallet"])
 
 
-@router.post("", response_model=DID, summary="Create Local DID")
+@router.post("", summary="Create Local DID")
 async def create_did(
     did_create: DIDCreate | None = None,
     auth: AcaPyAuth = Depends(acapy_auth_from_header),
@@ -56,7 +56,7 @@ async def create_did(
     return result
 
 
-@router.get("", response_model=list[DID], summary="List DIDs")
+@router.get("", summary="List DIDs")
 async def list_dids(
     auth: AcaPyAuth = Depends(acapy_auth_from_header),
 ) -> list[DID]:
@@ -85,7 +85,7 @@ async def list_dids(
     return did_result.results
 
 
-@router.get("/public", response_model=DID, summary="Fetch Public DID")
+@router.get("/public", summary="Fetch Public DID")
 async def get_public_did(
     auth: AcaPyAuth = Depends(acapy_auth_from_header),
 ) -> DID:
@@ -114,7 +114,7 @@ async def get_public_did(
     return result.result
 
 
-@router.put("/public", response_model=DID, summary="Set Public DID")
+@router.put("/public", summary="Set Public DID")
 async def set_public_did(  # noqa: D417
     did: str,
     auth: AcaPyAuth = Depends(acapy_auth_from_header),
@@ -176,7 +176,7 @@ async def rotate_keypair(  # noqa: D417
     bound_logger.debug("Successfully rotated keypair.")
 
 
-@router.get("/{did}/endpoint", response_model=DIDEndpoint, summary="Get DID Endpoint")
+@router.get("/{did}/endpoint", summary="Get DID Endpoint")
 async def get_did_endpoint(  # noqa: D417
     did: str,
     auth: AcaPyAuth = Depends(acapy_auth_from_header),

--- a/app/routes/wallet/jws.py
+++ b/app/routes/wallet/jws.py
@@ -21,7 +21,6 @@ router = APIRouter(prefix="/v1/wallet/jws", tags=["wallet"])
 
 @router.post(
     "/sign",
-    response_model=JWSCreateResponse,
     summary="Sign JWS",
 )
 async def sign_jws(
@@ -117,7 +116,6 @@ async def sign_jws(
 
 @router.post(
     "/verify",
-    response_model=JWSVerifyResponse,
     summary="Verify JWS",
 )
 async def verify_jws(

--- a/app/routes/wallet/sd_jws.py
+++ b/app/routes/wallet/sd_jws.py
@@ -21,7 +21,6 @@ router = APIRouter(prefix="/v1/wallet/sd-jws", tags=["wallet"])
 
 @router.post(
     "/sign",
-    response_model=SDJWSCreateResponse,
     summary="Sign SD-JWS",
 )
 async def sign_sd_jws(
@@ -136,7 +135,6 @@ async def sign_sd_jws(
 
 @router.post(
     "/verify",
-    response_model=SDJWSVerifyResponse,
     summary="Verify SD-JWS",
 )
 async def verify_sd_jws(

--- a/app/tests/e2e/issuer/test_concurrent_issuance_revocation.py
+++ b/app/tests/e2e/issuer/test_concurrent_issuance_revocation.py
@@ -35,9 +35,7 @@ async def check_unique_cred_rev_ids(
                 f"Duplicate cred_rev_id found: {cred_rev_id} for credential {cred_ex_id}"
             )
 
-    print(f"Unique cred_rev_ids found: {len(seen)}")
     seen.sort()
-    print(f"Credential revocation IDs: {seen}")
 
 
 @pytest.mark.anyio

--- a/app/tests/e2e/test_messaging.py
+++ b/app/tests/e2e/test_messaging.py
@@ -1,4 +1,4 @@
-import time
+import asyncio
 
 import pytest
 
@@ -26,7 +26,7 @@ async def test_send_trust_ping(
 
     assert response.status_code == 200
     assert "thread_id" in response_data
-    time.sleep(1)  # Wait for ping to be sent before deleting wallet
+    await asyncio.sleep(1)  # Wait for ping to be sent before deleting wallet
 
 
 @pytest.mark.anyio

--- a/app/tests/e2e/verifier/anoncreds/test_many_revocations.py
+++ b/app/tests/e2e/verifier/anoncreds/test_many_revocations.py
@@ -28,7 +28,7 @@ async def test_revoke_many_credentials(
     alice_member_client: RichAsyncClient,
     acme_and_alice_connection: AcmeAliceConnect,
 ):
-    time.sleep(10)  # moment for revocation registry to update
+    await asyncio.sleep(10)  # moment for revocation registry to update
     # todo: remove sleep when issue resolved: https://github.com/openwallet-foundation/acapy/issues/3018
 
     # Do proof request

--- a/app/tests/services/event_handling/test_sse.py
+++ b/app/tests/services/event_handling/test_sse.py
@@ -170,17 +170,18 @@ async def test_sse_subscribe_event_with_field_and_state_success(
         return_value=configured_async_context_manager_mock,
     ) as mock_stream:
         # Execute the sse_subscribe_event_with_field_and_state and collect results
-        results = []
-        async for line in sse_subscribe_event_with_field_and_state(
-            request=mock_request,
-            group_id=group_id,
-            wallet_id=wallet_id,
-            topic=topic,
-            field=field,
-            field_id=field_id,
-            desired_state=state,
-        ):
-            results.append(line)
+        results = [
+            line
+            async for line in sse_subscribe_event_with_field_and_state(
+                request=mock_request,
+                group_id=group_id,
+                wallet_id=wallet_id,
+                topic=topic,
+                field=field,
+                field_id=field_id,
+                desired_state=state,
+            )
+        ]
 
         # Verify the collected lines
         assert results == lines_list

--- a/app/tests/util/sse_listener.py
+++ b/app/tests/util/sse_listener.py
@@ -34,7 +34,7 @@ class SseListener:
         field,
         field_id,
         desired_state,
-        timeout: int = DEFAULT_LISTENER_TIMEOUT,
+        timeout: int = DEFAULT_LISTENER_TIMEOUT,  # noqa: ASYNC109
         look_back: int = 15,
     ) -> dict[str, Any]:
         """Start listening for SSE events. When an event is received that matches the specified parameters."""

--- a/docs/openapi/tenant-admin-openapi.json
+++ b/docs/openapi/tenant-admin-openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "CloudAPI Multitenant Admin",
     "description": "\nWelcome to CloudAPI Multitenant Admin!\n\nFor detailed guidance on using the API, please visit our official documentation:\nhttps://www.didx.co.za/acapy-cloud/index.html\n",
-    "version": "5.0.0-rc4"
+    "version": "5.0.0-rc5"
   },
   "servers": [
     {

--- a/docs/openapi/tenant-admin-openapi.yaml
+++ b/docs/openapi/tenant-admin-openapi.yaml
@@ -11,7 +11,7 @@ info:
     https://www.didx.co.za/acapy-cloud/index.html
 
 '
-  version: 5.0.0-rc4
+  version: 5.0.0-rc5
 servers:
   - url: /tenant-admin
 paths:

--- a/docs/openapi/tenant-openapi.json
+++ b/docs/openapi/tenant-openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "CloudAPI Tenant",
     "description": "\nWelcome to CloudAPI Tenant!\n\nFor detailed guidance on using the API, please visit our official documentation:\nhttps://www.didx.co.za/acapy-cloud/index.html\n",
-    "version": "5.0.0-rc4"
+    "version": "5.0.0-rc5"
   },
   "servers": [
     {

--- a/docs/openapi/tenant-openapi.yaml
+++ b/docs/openapi/tenant-openapi.yaml
@@ -11,7 +11,7 @@ info:
     https://www.didx.co.za/acapy-cloud/index.html
 
 '
-  version: 5.0.0-rc4
+  version: 5.0.0-rc5
 servers:
   - url: /tenant
 paths:

--- a/poetry.lock
+++ b/poetry.lock
@@ -1848,6 +1848,22 @@ pytest = ">=6.2.5"
 dev = ["pre-commit", "pytest-asyncio", "tox"]
 
 [[package]]
+name = "pytest-ruff"
+version = "0.4.1"
+description = "pytest plugin to check ruff requirements."
+optional = false
+python-versions = "<4.0,>=3.8"
+groups = ["dev"]
+files = [
+    {file = "pytest_ruff-0.4.1-py3-none-any.whl", hash = "sha256:69acd5b2ba68d65998c730b5b4d656788193190e45f61a53aa66ef8b390634a4"},
+    {file = "pytest_ruff-0.4.1.tar.gz", hash = "sha256:2c9a30f15f384c229c881b52ec86cfaf1e79d39530dd7dd5f2d6aebe278f7eb7"},
+]
+
+[package.dependencies]
+pytest = ">=5"
+ruff = ">=0.0.242"
+
+[[package]]
 name = "pytest-xdist"
 version = "3.7.0"
 description = "pytest xdist plugin for distributed testing, most importantly across multiple CPUs"
@@ -2504,4 +2520,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "~3.12.8"
-content-hash = "581ac3d70b8473e0c8a341dfde73cfba3a9418c466a641db63d7cf6ed98791cf"
+content-hash = "17ba55a7a11e457956c008aa89ab883868dfdc7316ea42a8b922b5309dcd5576"

--- a/poetry.lock
+++ b/poetry.lock
@@ -279,18 +279,18 @@ tests = ["PyHamcrest (>=2.0.2)", "mypy", "pytest (>=4.6)", "pytest-benchmark", "
 
 [[package]]
 name = "boto3"
-version = "1.38.33"
+version = "1.38.35"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["tails"]
 files = [
-    {file = "boto3-1.38.33-py3-none-any.whl", hash = "sha256:25d0717489c658f7ae6c3c7f0f7e1b4d611b30b2f08f0fcef6455ac6864a8768"},
-    {file = "boto3-1.38.33.tar.gz", hash = "sha256:6467909c1ae01ff67981f021bb2568592211765ec8a9a1d2c4529191e46c3541"},
+    {file = "boto3-1.38.35-py3-none-any.whl", hash = "sha256:97606fe56e33b2548c4110dd7cdc49487266d503ba09eaff9abf98b028baee9e"},
+    {file = "boto3-1.38.35.tar.gz", hash = "sha256:38a407e467b24914ce24e5816f53305288ea44072778f88d2b4b6a2cffbcb220"},
 ]
 
 [package.dependencies]
-botocore = ">=1.38.33,<1.39.0"
+botocore = ">=1.38.35,<1.39.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.13.0,<0.14.0"
 
@@ -299,14 +299,14 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.38.33"
+version = "1.38.35"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">=3.9"
 groups = ["tails"]
 files = [
-    {file = "botocore-1.38.33-py3-none-any.whl", hash = "sha256:ad25233e93dcebe95809b1f9393c1f11a639696327793d166295fb78dd7bc597"},
-    {file = "botocore-1.38.33.tar.gz", hash = "sha256:dbe8fea9d0426c644c89ef2018ead886ccbcc22901a02b377b4e65ce1cb69a2b"},
+    {file = "botocore-1.38.35-py3-none-any.whl", hash = "sha256:bbfae3f13a5d75ad73bf71b5ba5ff3ccd055d947d63593e8a0e84acc95a8bfa4"},
+    {file = "botocore-1.38.35.tar.gz", hash = "sha256:3c7032948e066eed5f91d64cd51ee9664d1db9beaf3279ac27da608176bb3d54"},
 ]
 
 [package.dependencies]
@@ -451,79 +451,79 @@ markers = {main = "sys_platform == \"win32\" or platform_system == \"Windows\"",
 
 [[package]]
 name = "coverage"
-version = "7.8.2"
+version = "7.9.0"
 description = "Code coverage measurement for Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "coverage-7.8.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bd8ec21e1443fd7a447881332f7ce9d35b8fbd2849e761bb290b584535636b0a"},
-    {file = "coverage-7.8.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4c26c2396674816deaeae7ded0e2b42c26537280f8fe313335858ffff35019be"},
-    {file = "coverage-7.8.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1aec326ed237e5880bfe69ad41616d333712c7937bcefc1343145e972938f9b3"},
-    {file = "coverage-7.8.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5e818796f71702d7a13e50c70de2a1924f729228580bcba1607cccf32eea46e6"},
-    {file = "coverage-7.8.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:546e537d9e24efc765c9c891328f30f826e3e4808e31f5d0f87c4ba12bbd1622"},
-    {file = "coverage-7.8.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:ab9b09a2349f58e73f8ebc06fac546dd623e23b063e5398343c5270072e3201c"},
-    {file = "coverage-7.8.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:fd51355ab8a372d89fb0e6a31719e825cf8df8b6724bee942fb5b92c3f016ba3"},
-    {file = "coverage-7.8.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:0774df1e093acb6c9e4d58bce7f86656aeed6c132a16e2337692c12786b32404"},
-    {file = "coverage-7.8.2-cp310-cp310-win32.whl", hash = "sha256:00f2e2f2e37f47e5f54423aeefd6c32a7dbcedc033fcd3928a4f4948e8b96af7"},
-    {file = "coverage-7.8.2-cp310-cp310-win_amd64.whl", hash = "sha256:145b07bea229821d51811bf15eeab346c236d523838eda395ea969d120d13347"},
-    {file = "coverage-7.8.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b99058eef42e6a8dcd135afb068b3d53aff3921ce699e127602efff9956457a9"},
-    {file = "coverage-7.8.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5feb7f2c3e6ea94d3b877def0270dff0947b8d8c04cfa34a17be0a4dc1836879"},
-    {file = "coverage-7.8.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:670a13249b957bb9050fab12d86acef7bf8f6a879b9d1a883799276e0d4c674a"},
-    {file = "coverage-7.8.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0bdc8bf760459a4a4187b452213e04d039990211f98644c7292adf1e471162b5"},
-    {file = "coverage-7.8.2-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:07a989c867986c2a75f158f03fdb413128aad29aca9d4dbce5fc755672d96f11"},
-    {file = "coverage-7.8.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2db10dedeb619a771ef0e2949ccba7b75e33905de959c2643a4607bef2f3fb3a"},
-    {file = "coverage-7.8.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e6ea7dba4e92926b7b5f0990634b78ea02f208d04af520c73a7c876d5a8d36cb"},
-    {file = "coverage-7.8.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ef2f22795a7aca99fc3c84393a55a53dd18ab8c93fb431004e4d8f0774150f54"},
-    {file = "coverage-7.8.2-cp311-cp311-win32.whl", hash = "sha256:641988828bc18a6368fe72355df5f1703e44411adbe49bba5644b941ce6f2e3a"},
-    {file = "coverage-7.8.2-cp311-cp311-win_amd64.whl", hash = "sha256:8ab4a51cb39dc1933ba627e0875046d150e88478dbe22ce145a68393e9652975"},
-    {file = "coverage-7.8.2-cp311-cp311-win_arm64.whl", hash = "sha256:8966a821e2083c74d88cca5b7dcccc0a3a888a596a04c0b9668a891de3a0cc53"},
-    {file = "coverage-7.8.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e2f6fe3654468d061942591aef56686131335b7a8325684eda85dacdf311356c"},
-    {file = "coverage-7.8.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:76090fab50610798cc05241bf83b603477c40ee87acd358b66196ab0ca44ffa1"},
-    {file = "coverage-7.8.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2bd0a0a5054be160777a7920b731a0570284db5142abaaf81bcbb282b8d99279"},
-    {file = "coverage-7.8.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:da23ce9a3d356d0affe9c7036030b5c8f14556bd970c9b224f9c8205505e3b99"},
-    {file = "coverage-7.8.2-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c9392773cffeb8d7e042a7b15b82a414011e9d2b5fdbbd3f7e6a6b17d5e21b20"},
-    {file = "coverage-7.8.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:876cbfd0b09ce09d81585d266c07a32657beb3eaec896f39484b631555be0fe2"},
-    {file = "coverage-7.8.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:3da9b771c98977a13fbc3830f6caa85cae6c9c83911d24cb2d218e9394259c57"},
-    {file = "coverage-7.8.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9a990f6510b3292686713bfef26d0049cd63b9c7bb17e0864f133cbfd2e6167f"},
-    {file = "coverage-7.8.2-cp312-cp312-win32.whl", hash = "sha256:bf8111cddd0f2b54d34e96613e7fbdd59a673f0cf5574b61134ae75b6f5a33b8"},
-    {file = "coverage-7.8.2-cp312-cp312-win_amd64.whl", hash = "sha256:86a323a275e9e44cdf228af9b71c5030861d4d2610886ab920d9945672a81223"},
-    {file = "coverage-7.8.2-cp312-cp312-win_arm64.whl", hash = "sha256:820157de3a589e992689ffcda8639fbabb313b323d26388d02e154164c57b07f"},
-    {file = "coverage-7.8.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ea561010914ec1c26ab4188aef8b1567272ef6de096312716f90e5baa79ef8ca"},
-    {file = "coverage-7.8.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cb86337a4fcdd0e598ff2caeb513ac604d2f3da6d53df2c8e368e07ee38e277d"},
-    {file = "coverage-7.8.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:26a4636ddb666971345541b59899e969f3b301143dd86b0ddbb570bd591f1e85"},
-    {file = "coverage-7.8.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5040536cf9b13fb033f76bcb5e1e5cb3b57c4807fef37db9e0ed129c6a094257"},
-    {file = "coverage-7.8.2-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc67994df9bcd7e0150a47ef41278b9e0a0ea187caba72414b71dc590b99a108"},
-    {file = "coverage-7.8.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6e6c86888fd076d9e0fe848af0a2142bf606044dc5ceee0aa9eddb56e26895a0"},
-    {file = "coverage-7.8.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:684ca9f58119b8e26bef860db33524ae0365601492e86ba0b71d513f525e7050"},
-    {file = "coverage-7.8.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8165584ddedb49204c4e18da083913bdf6a982bfb558632a79bdaadcdafd0d48"},
-    {file = "coverage-7.8.2-cp313-cp313-win32.whl", hash = "sha256:34759ee2c65362163699cc917bdb2a54114dd06d19bab860725f94ef45a3d9b7"},
-    {file = "coverage-7.8.2-cp313-cp313-win_amd64.whl", hash = "sha256:2f9bc608fbafaee40eb60a9a53dbfb90f53cc66d3d32c2849dc27cf5638a21e3"},
-    {file = "coverage-7.8.2-cp313-cp313-win_arm64.whl", hash = "sha256:9fe449ee461a3b0c7105690419d0b0aba1232f4ff6d120a9e241e58a556733f7"},
-    {file = "coverage-7.8.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:8369a7c8ef66bded2b6484053749ff220dbf83cba84f3398c84c51a6f748a008"},
-    {file = "coverage-7.8.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:159b81df53a5fcbc7d45dae3adad554fdbde9829a994e15227b3f9d816d00b36"},
-    {file = "coverage-7.8.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e6fcbbd35a96192d042c691c9e0c49ef54bd7ed865846a3c9d624c30bb67ce46"},
-    {file = "coverage-7.8.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:05364b9cc82f138cc86128dc4e2e1251c2981a2218bfcd556fe6b0fbaa3501be"},
-    {file = "coverage-7.8.2-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46d532db4e5ff3979ce47d18e2fe8ecad283eeb7367726da0e5ef88e4fe64740"},
-    {file = "coverage-7.8.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:4000a31c34932e7e4fa0381a3d6deb43dc0c8f458e3e7ea6502e6238e10be625"},
-    {file = "coverage-7.8.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:43ff5033d657cd51f83015c3b7a443287250dc14e69910577c3e03bd2e06f27b"},
-    {file = "coverage-7.8.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:94316e13f0981cbbba132c1f9f365cac1d26716aaac130866ca812006f662199"},
-    {file = "coverage-7.8.2-cp313-cp313t-win32.whl", hash = "sha256:3f5673888d3676d0a745c3d0e16da338c5eea300cb1f4ada9c872981265e76d8"},
-    {file = "coverage-7.8.2-cp313-cp313t-win_amd64.whl", hash = "sha256:2c08b05ee8d7861e45dc5a2cc4195c8c66dca5ac613144eb6ebeaff2d502e73d"},
-    {file = "coverage-7.8.2-cp313-cp313t-win_arm64.whl", hash = "sha256:1e1448bb72b387755e1ff3ef1268a06617afd94188164960dba8d0245a46004b"},
-    {file = "coverage-7.8.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:496948261eaac5ac9cf43f5d0a9f6eb7a6d4cb3bedb2c5d294138142f5c18f2a"},
-    {file = "coverage-7.8.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:eacd2de0d30871eff893bab0b67840a96445edcb3c8fd915e6b11ac4b2f3fa6d"},
-    {file = "coverage-7.8.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b039ffddc99ad65d5078ef300e0c7eed08c270dc26570440e3ef18beb816c1ca"},
-    {file = "coverage-7.8.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0e49824808d4375ede9dd84e9961a59c47f9113039f1a525e6be170aa4f5c34d"},
-    {file = "coverage-7.8.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b069938961dfad881dc2f8d02b47645cd2f455d3809ba92a8a687bf513839787"},
-    {file = "coverage-7.8.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:de77c3ba8bb686d1c411e78ee1b97e6e0b963fb98b1637658dd9ad2c875cf9d7"},
-    {file = "coverage-7.8.2-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:1676628065a498943bd3f64f099bb573e08cf1bc6088bbe33cf4424e0876f4b3"},
-    {file = "coverage-7.8.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:8e1a26e7e50076e35f7afafde570ca2b4d7900a491174ca357d29dece5aacee7"},
-    {file = "coverage-7.8.2-cp39-cp39-win32.whl", hash = "sha256:6782a12bf76fa61ad9350d5a6ef5f3f020b57f5e6305cbc663803f2ebd0f270a"},
-    {file = "coverage-7.8.2-cp39-cp39-win_amd64.whl", hash = "sha256:1efa4166ba75ccefd647f2d78b64f53f14fb82622bc94c5a5cb0a622f50f1c9e"},
-    {file = "coverage-7.8.2-pp39.pp310.pp311-none-any.whl", hash = "sha256:ec455eedf3ba0bbdf8f5a570012617eb305c63cb9f03428d39bf544cb2b94837"},
-    {file = "coverage-7.8.2-py3-none-any.whl", hash = "sha256:726f32ee3713f7359696331a18daf0c3b3a70bb0ae71141b9d3c52be7c595e32"},
-    {file = "coverage-7.8.2.tar.gz", hash = "sha256:a886d531373a1f6ff9fad2a2ba4a045b68467b779ae729ee0b3b10ac20033b27"},
+    {file = "coverage-7.9.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:3d494fa4256e3cb161ca1df14a91d2d703c27d60452eb0d4a58bb05f52f676e4"},
+    {file = "coverage-7.9.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b613efceeabf242978d14e1a65626ec3be67c5261918a82a985f56c2a05475ee"},
+    {file = "coverage-7.9.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:673a4d2cb7ec78e1f2f6f41039f6785f27bca0f6bc0e722b53a58286d12754e1"},
+    {file = "coverage-7.9.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1edc2244932e9fed92ad14428b9480a97ecd37c970333688bd35048f6472f260"},
+    {file = "coverage-7.9.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec8b92a7617faa2017bd44c94583830bab8be175722d420501680abc4f5bc794"},
+    {file = "coverage-7.9.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d8f3ca1f128f11812d3baf0a482e7f36ffb856ac1ae14de3b5d1adcfb7af955d"},
+    {file = "coverage-7.9.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:c30eed34eb8206d9b8c2d0d9fa342fa98e10f34b1e9e1eb05f79ccbf4499c8ff"},
+    {file = "coverage-7.9.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:24e6f8e5f125cd8bff33593a484a079305c9f0be911f76c6432f580ade5c1a17"},
+    {file = "coverage-7.9.0-cp310-cp310-win32.whl", hash = "sha256:a1b0317b4a8ff4d3703cd7aa642b4f963a71255abe4e878659f768238fab6602"},
+    {file = "coverage-7.9.0-cp310-cp310-win_amd64.whl", hash = "sha256:512b1ea57a11dfa23b7f3d8fe8690fcf8cd983a70ae4c2c262cf5c972618fa15"},
+    {file = "coverage-7.9.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:55b7b9df45174956e0f719a56cf60c0cb4a7f155668881d00de6384e2a3402f4"},
+    {file = "coverage-7.9.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:87bceebbc91a58c9264c43638729fcb45910805b9f86444f93654d988305b3a2"},
+    {file = "coverage-7.9.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:81da3b6e289bf9fc7dc159ab6d5222f5330ac6e94a6d06f147ba46e53fa6ec82"},
+    {file = "coverage-7.9.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b361684a91224d4362879c1b1802168d2435ff76666f1b7ba52fc300ad832dbc"},
+    {file = "coverage-7.9.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9a384ea4f77ac0a7e36c9a805ed95ef10f423bdb68b4e9487646cdf548a6a05"},
+    {file = "coverage-7.9.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:38a5642aa82ea6de0e4331e346f5ba188a9fdb7d727e00199f55031b85135d0a"},
+    {file = "coverage-7.9.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8c5ff4ca4890c0b57d3e80850534609493280c0f9e6ea2bd314b10cb8cbd76e0"},
+    {file = "coverage-7.9.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:cd052a0c4727ede06393da3c1df1ae6ef6c079e6bdfefb39079877404b3edc22"},
+    {file = "coverage-7.9.0-cp311-cp311-win32.whl", hash = "sha256:f73fd1128165e1d665cb7f863a91d00f073044a672c7dfa04ab400af4d1a9226"},
+    {file = "coverage-7.9.0-cp311-cp311-win_amd64.whl", hash = "sha256:dd62d62e782d3add529c8e7943f5600efd0d07dadf3819e5f9917edb4acf85d8"},
+    {file = "coverage-7.9.0-cp311-cp311-win_arm64.whl", hash = "sha256:f75288785cc9a67aff3b04dafd8d0f0be67306018b224d319d23867a161578d6"},
+    {file = "coverage-7.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:969ed1ed0ab0325b50af3204f9024782180e64fb281f5a2952f479ec60a02aba"},
+    {file = "coverage-7.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1abd41781c874e716aaeecb8b27db5f4f2bc568f2ed8d41228aa087d567674f0"},
+    {file = "coverage-7.9.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0eb6e99487dffd28c88a4fc2ea4286beaf0207a43388775900c93e56cc5a8ae3"},
+    {file = "coverage-7.9.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c425c85ddb62b32d44f83fb20044fe32edceceee1db1f978c062eec020a73ea5"},
+    {file = "coverage-7.9.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d0a1f7676bc90ceba67caa66850d689947d586f204ccf6478400c2bf39da5790"},
+    {file = "coverage-7.9.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f17055c50768d710d6abc789c9469d0353574780935e1381b83e63edc49ff530"},
+    {file = "coverage-7.9.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:298d2917a6bfadbb272e08545ed026af3965e4d2fe71e3f38bf0a816818b226e"},
+    {file = "coverage-7.9.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d9be5d26e5f817d478506e4d3c4ff7b92f17d980670b4791bf05baaa37ce2f88"},
+    {file = "coverage-7.9.0-cp312-cp312-win32.whl", hash = "sha256:dc2784edd9ac9fe8692fc5505667deb0b05d895c016aaaf641031ed4a5f93d53"},
+    {file = "coverage-7.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:18223198464a6d5549db1934cf77a15deb24bb88652c4f5f7cb21cd3ad853704"},
+    {file = "coverage-7.9.0-cp312-cp312-win_arm64.whl", hash = "sha256:3b00194ff3c84d4b821822ff6c041f245fc55d0d5c7833fc4311d082e97595e8"},
+    {file = "coverage-7.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:122c60e92ab66c9c88e17565f67a91b3b3be5617cb50f73cfd34a4c60ed4aab0"},
+    {file = "coverage-7.9.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:813c11b367a6b3cf37212ec36b230f8d086c22b69dbf62877b40939fb2c79e74"},
+    {file = "coverage-7.9.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3f05e0f5e87f23d43fefe49e86655c6209dd4f9f034786b983e6803cf4554183"},
+    {file = "coverage-7.9.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:62f465886fa4f86d5515da525aead97c5dff13a5cf997fc4c5097a1a59e063b2"},
+    {file = "coverage-7.9.0-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:549ea4ca901595bbe3270e1afdef98bf5d4d5791596efbdc90b00449a2bb1f91"},
+    {file = "coverage-7.9.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8cae1d4450945c74a6a65a09864ed3eaa917055cf70aa65f83ac1b9b0d8d5f9a"},
+    {file = "coverage-7.9.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:d7b263910234c0d5ec913ec79ca921152fe874b805a7bcaf67118ef71708e5d2"},
+    {file = "coverage-7.9.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7d7b7425215963da8f5968096a20c5b5c9af4a86a950fcc25dcc2177ab33e9e5"},
+    {file = "coverage-7.9.0-cp313-cp313-win32.whl", hash = "sha256:e7dcfa92867b0c53d2e22e985c66af946dc09e8bb13c556709e396e90a0adf5c"},
+    {file = "coverage-7.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:aa34ca040785a2b768da489df0c036364d47a6c1c00bdd8f662b98fd3277d3d4"},
+    {file = "coverage-7.9.0-cp313-cp313-win_arm64.whl", hash = "sha256:9c5dcb5cd3c52d84c5f52045e1c87c16bf189c2fbfa57cc0d811a3b4059939df"},
+    {file = "coverage-7.9.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:b52d2fdc1940f90c4572bd48211475a7b102f75a7f9a5e6cfc6e3da7dc380c44"},
+    {file = "coverage-7.9.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4cc555a3e6ceb8841df01a4634374f5f9635e661f5c307da00bce19819e8bcdf"},
+    {file = "coverage-7.9.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:244f613617876b7cd32a097788d49c952a8f1698afb25275b2a825a4e895854e"},
+    {file = "coverage-7.9.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5c335d77539e66bc6f83e8f1ef207d038129d9b9acd9dc9f0ca42fa9eedf564a"},
+    {file = "coverage-7.9.0-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6b335c7077c8da7bb8173d4f9ebd90ff1a97af6a6bec4fc4e6db4856ae80b31e"},
+    {file = "coverage-7.9.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:01cbc2c36895b7ab906514042c92b3fc9dd0526bf1c3251cb6aefd9c71ae6dda"},
+    {file = "coverage-7.9.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:1ac62880a9dff0726a193ce77a1bcdd4e8491009cb3a0510d31381e8b2c46d7a"},
+    {file = "coverage-7.9.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:95314eb306cf54af3d1147e27ba008cf78eed6f1309a1310772f4f05b12c9c65"},
+    {file = "coverage-7.9.0-cp313-cp313t-win32.whl", hash = "sha256:c5cbf3ddfb68de8dc8ce33caa9321df27297a032aeaf2e99b278f183fb4ebc37"},
+    {file = "coverage-7.9.0-cp313-cp313t-win_amd64.whl", hash = "sha256:e3ec9e1525eb7a0f89d31083539b398d921415d884e9f55400002a1e9fe0cf63"},
+    {file = "coverage-7.9.0-cp313-cp313t-win_arm64.whl", hash = "sha256:a02efe6769f74245ce476e89db3d4e110db07b4c0c3d3f81728e2464bbbbcb8e"},
+    {file = "coverage-7.9.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:64dab59d812c1cbfc9cebadada377365874964acdf59b12e86487d25c2e0c29f"},
+    {file = "coverage-7.9.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:46b9dc640c6309fb49625d3569d4ba7abe2afcba645eb1e52bad97510f60ac26"},
+    {file = "coverage-7.9.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:89358f4025ed424861311b33815a2866f7c94856c932b0ffc98180f655e813e2"},
+    {file = "coverage-7.9.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:589e37ae75d81fd53cd1ca624e07af4466e9e4ce259e3bfe2b147896857c06ea"},
+    {file = "coverage-7.9.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:29dea81eef5432076cee561329b3831bc988a4ce1bfaec90eee2078ff5311e6e"},
+    {file = "coverage-7.9.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:7b3482588772b6b24601d1677aef299af28d6c212c70b0be27bdfc2e10fb00fe"},
+    {file = "coverage-7.9.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:2debc0b9481b5fc76f771b3b31e89a0cd8791ad977654940a3523f3f2e5d98fe"},
+    {file = "coverage-7.9.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:304ded640bc2a60f14a2ff0fec98cce4c3f2e573c122f0548728c8dceba5abe7"},
+    {file = "coverage-7.9.0-cp39-cp39-win32.whl", hash = "sha256:8e0a3a3f9b968007e1f56418a3586f9a983c84ac4e84d28d1c4f8b76c4226282"},
+    {file = "coverage-7.9.0-cp39-cp39-win_amd64.whl", hash = "sha256:cb3c07dd71d1ff52156d35ee6fa48458c3cec1add7fcce6a934f977fb80c48a5"},
+    {file = "coverage-7.9.0-pp39.pp310.pp311-none-any.whl", hash = "sha256:ccf1540a0e82ff525844880f988f6caaa2d037005e57bfe203b71cac7626145d"},
+    {file = "coverage-7.9.0-py3-none-any.whl", hash = "sha256:79ea9a26b27c963cdf541e1eb9ac05311b012bc367d0e31816f1833b06c81c02"},
+    {file = "coverage-7.9.0.tar.gz", hash = "sha256:1a93b43de2233a7670a8bf2520fed8ebd5eea6a65b47417500a9d882b0533fa2"},
 ]
 
 [package.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ pre-commit = "~4.2.0"
 pytest = "~8.3.2"
 pytest-cov = "~6.1.0"
 pytest-mock = "~3.14.0"
+pytest-ruff = "^0.4.1"
 pytest-xdist = "^3.6.1"
 ruff = "~0.11.12"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ lint.select = [
   "F",     # pyflakes (detect invalid Python code)
   "I",     # isort (import sorting)
   "N",     # pep8-naming (naming conventions)
+  "PERF",  # perflint (performance anti-patterns)
   "PL",    # pylint
   "RUF",   # ruff-specific rules
   "UP",    # pyupgrade (upgrade syntax)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ lint.select = [
   "D",     # pydocstyle (docstring style)
   "E",     # pycodestyle errors (style errors)
   "F",     # pyflakes (detect invalid Python code)
+  "FAST",  # fastapi
   "I",     # isort (import sorting)
   "N",     # pep8-naming (naming conventions)
   "PERF",  # perflint (performance anti-patterns)
@@ -111,6 +112,7 @@ lint.ignore = [
   "PLR0915", # Too many statements
 
   # Maybe fix:
+  "FAST002", # FastAPI dependency without `Annotated`
   "PLR2004", # Magic value used in comparison, consider replacing `500` with a constant variable
 
   # Won't fix:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,17 +75,18 @@ line-length = 88
 lint.pycodestyle.max-line-length = 120
 target-version = "py312"
 lint.select = [
-  "B",   # flake8-bugbear (detect likely bugs)
-  "C",   # mccabe (code complexity)
-  "D",   # pydocstyle (docstring style)
-  "E",   # pycodestyle errors (style errors)
-  "F",   # pyflakes (detect invalid Python code)
-  "I",   # isort (import sorting)
-  "N",   # pep8-naming (naming conventions)
-  "PL",  # pylint
-  "RUF", # ruff-specific rules
-  "UP",  # pyupgrade (upgrade syntax)
-  "W",   # pycodestyle warnings (style warnings)
+  "ASYNC", # flake8-async (async/await)
+  "B",     # flake8-bugbear (detect likely bugs)
+  "C",     # mccabe (code complexity)
+  "D",     # pydocstyle (docstring style)
+  "E",     # pycodestyle errors (style errors)
+  "F",     # pyflakes (detect invalid Python code)
+  "I",     # isort (import sorting)
+  "N",     # pep8-naming (naming conventions)
+  "PL",    # pylint
+  "RUF",   # ruff-specific rules
+  "UP",    # pyupgrade (upgrade syntax)
+  "W",     # pycodestyle warnings (style warnings)
 ]
 lint.ignore = [
   # Docstring related:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "acapy-cloud"
-version = "5.0.0-rc4"
+version = "5.0.0-rc5"
 description = "Main project configuration for acapy-cloud"
 authors = [
   { name = "Mourits de Beer", email = "mourits.debeer@didx.co.za" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,7 @@ lint.ignore = [
   # False positives:
   "PLE1205", # Too many arguments detected for loguru {} formatted strings
 ]
-exclude = [".git/*"]
+exclude = [".git/*", ".venv/*"]
 
 [build-system]
 requires = ["poetry-core>=2.1"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ lint.select = [
   "PERF",  # perflint (performance anti-patterns)
   "PL",    # pylint
   "RUF",   # ruff-specific rules
+  "T20",   # flake8-print (print statements)
   "UP",    # pyupgrade (upgrade syntax)
   "W",     # pycodestyle warnings (style warnings)
 ]

--- a/shared/constants.py
+++ b/shared/constants.py
@@ -6,7 +6,7 @@ ADMIN_API_KEY = "adminApiKey"
 
 # pylint: disable=invalid-name
 
-PROJECT_VERSION = os.getenv("PROJECT_VERSION", "5.0.0-rc4")
+PROJECT_VERSION = os.getenv("PROJECT_VERSION", "5.0.0-rc5")
 
 # the ACAPY_LABEL field with which the governance agent is initialised
 GOVERNANCE_LABEL = os.getenv("GOVERNANCE_ACAPY_LABEL", "Governance")

--- a/tails/tests/test_main.py
+++ b/tails/tests/test_main.py
@@ -36,6 +36,5 @@ async def test_health_ready_failure():
 @pytest.mark.anyio
 async def test_docs():
     response = await scalar_html()
-    print(response.body)
     assert response.status_code == 200
     assert "html" in response.body.decode("utf-8")

--- a/trustregistry/registry/registry_actors.py
+++ b/trustregistry/registry/registry_actors.py
@@ -12,7 +12,7 @@ logger = get_logger(__name__)
 router = APIRouter(prefix="/registry/actors", tags=["actor"])
 
 
-@router.get("", response_model=list[Actor])
+@router.get("")
 async def get_actors(db_session: Session = Depends(get_db)) -> list[Actor]:
     logger.debug("GET request received: Fetch all actors")
     db_actors = crud.get_actors(db_session)
@@ -20,7 +20,7 @@ async def get_actors(db_session: Session = Depends(get_db)) -> list[Actor]:
     return db_actors
 
 
-@router.post("", response_model=Actor)
+@router.post("")
 async def register_actor(actor: Actor, db_session: Session = Depends(get_db)) -> Actor:
     bound_logger = logger.bind(body={"actor": actor})
     bound_logger.debug("POST request received: Register actor")
@@ -36,7 +36,7 @@ async def register_actor(actor: Actor, db_session: Session = Depends(get_db)) ->
     return created_actor
 
 
-@router.put("/{actor_id}", response_model=Actor)
+@router.put("/{actor_id}")
 async def update_actor(
     actor_id: str, actor: Actor, db_session: Session = Depends(get_db)
 ) -> Actor:
@@ -63,7 +63,7 @@ async def update_actor(
     return update_actor_result
 
 
-@router.get("/did/{actor_did}", response_model=Actor)
+@router.get("/did/{actor_did}")
 async def get_actor_by_did(
     actor_did: str, db_session: Session = Depends(get_db)
 ) -> Actor:
@@ -80,7 +80,7 @@ async def get_actor_by_did(
     return actor
 
 
-@router.get("/{actor_id}", response_model=Actor)
+@router.get("/{actor_id}")
 async def get_actor_by_id(
     actor_id: str, db_session: Session = Depends(get_db)
 ) -> Actor:
@@ -97,7 +97,7 @@ async def get_actor_by_id(
     return actor
 
 
-@router.get("/name/{actor_name}", response_model=Actor)
+@router.get("/name/{actor_name}")
 async def get_actor_by_name(
     actor_name: str, db_session: Session = Depends(get_db)
 ) -> Actor:

--- a/trustregistry/registry/registry_schemas.py
+++ b/trustregistry/registry/registry_schemas.py
@@ -18,7 +18,7 @@ class SchemaID(BaseModel):
     schema_id: str = Field(..., examples=["WgWxqztrNooG92RXvxSTWv:2:schema_name:1.0"])
 
 
-@router.get("", response_model=list[Schema])
+@router.get("")
 async def get_schemas(db_session: Session = Depends(get_db)) -> list[Schema]:
     logger.debug("GET request received: Fetch all schemas")
     db_schemas = crud.get_schemas(db_session)
@@ -26,7 +26,7 @@ async def get_schemas(db_session: Session = Depends(get_db)) -> list[Schema]:
     return db_schemas
 
 
-@router.post("", response_model=Schema)
+@router.post("")
 async def register_schema(
     schema_id: SchemaID, db_session: Session = Depends(get_db)
 ) -> Schema:
@@ -61,7 +61,7 @@ async def register_schema(
     return create_schema_res
 
 
-@router.put("/{schema_id}", response_model=Schema)
+@router.put("/{schema_id}")
 async def update_schema(
     schema_id: str, new_schema_id: SchemaID, db_session: Session = Depends(get_db)
 ) -> Schema:
@@ -102,7 +102,7 @@ async def update_schema(
     return update_schema_res
 
 
-@router.get("/{schema_id:path}", response_model=Schema)
+@router.get("/{schema_id:path}")
 async def get_schema(schema_id: str, db_session: Session = Depends(get_db)) -> Schema:
     bound_logger = logger.bind(body={"schema_id": schema_id})
     bound_logger.debug("GET request received: Fetch schema")

--- a/waypoint/tests/routers/test_waypoint_sse.py
+++ b/waypoint/tests/routers/test_waypoint_sse.py
@@ -90,18 +90,21 @@ async def test_sse_event_stream_generator_wallet_id_topic_field_desired_state(
         mock_event_generator()
     )
 
-    events = [event async for event in nats_event_stream_generator(
-        request=request_mock,
-        background_tasks=BackgroundTasks(),
-        wallet_id=wallet_id,
-        topic=topic,
-        field=field,
-        field_id=field_id,
-        desired_state=desired_state,
-        group_id=group_id,
-        nats_processor=nats_processor_mock,
-        look_back=300,
-    )]
+    events = [
+        event
+        async for event in nats_event_stream_generator(
+            request=request_mock,
+            background_tasks=BackgroundTasks(),
+            wallet_id=wallet_id,
+            topic=topic,
+            field=field,
+            field_id=field_id,
+            desired_state=desired_state,
+            group_id=group_id,
+            nats_processor=nats_processor_mock,
+            look_back=300,
+        )
+    ]
 
     assert len(events) == 1
     assert events[0] == expected_cloudapi_event.model_dump_json()

--- a/waypoint/tests/routers/test_waypoint_sse.py
+++ b/waypoint/tests/routers/test_waypoint_sse.py
@@ -90,8 +90,7 @@ async def test_sse_event_stream_generator_wallet_id_topic_field_desired_state(
         mock_event_generator()
     )
 
-    events = []
-    async for event in nats_event_stream_generator(
+    events = [event async for event in nats_event_stream_generator(
         request=request_mock,
         background_tasks=BackgroundTasks(),
         wallet_id=wallet_id,
@@ -102,8 +101,7 @@ async def test_sse_event_stream_generator_wallet_id_topic_field_desired_state(
         group_id=group_id,
         nats_processor=nats_processor_mock,
         look_back=300,
-    ):
-        events.append(event)
+    )]
 
     assert len(events) == 1
     assert events[0] == expected_cloudapi_event.model_dump_json()

--- a/waypoint/tests/services/test_nats_service.py
+++ b/waypoint/tests/services/test_nats_service.py
@@ -170,9 +170,7 @@ async def test_process_events_cancelled_error(
             stop_event=stop_event,
             duration=0.01,
         ) as event_generator:
-            events = []
-            async for event in event_generator:
-                events.append(event)
+            events = [event async for event in event_generator]
 
     assert len(events) == 0
     assert stop_event.is_set()
@@ -197,9 +195,7 @@ async def test_process_events_fetch_timeout_error(
         stop_event=stop_event,
         duration=0.01,
     ) as event_generator:
-        events = []
-        async for event in event_generator:
-            events.append(event)
+        events = [event async for event in event_generator]
 
     assert len(events) == 0
     assert stop_event.is_set()
@@ -300,9 +296,7 @@ async def test_process_events_bad_subscription_error_on_unsubscribe(
         stop_event=stop_event,
         duration=0.01,
     ) as event_generator:
-        events = []
-        async for event in event_generator:
-            events.append(event)
+        events = [event async for event in event_generator]
 
     # Assert no events are yielded
     assert len(events) == 0
@@ -340,9 +334,7 @@ async def test_process_events_base_exception(
             stop_event=stop_event,
             duration=0.01,
         ) as event_generator:
-            events = []
-            async for event in event_generator:
-                events.append(event)
+            events = [event async for event in event_generator]
 
     # Assert no events are yielded due to the base exception
     assert len(events) == 0
@@ -451,9 +443,7 @@ async def test_general_error_handling(
             stop_event=stop_event,
             duration=0.01,
         ) as event_generator:
-            events = []
-            async for event in event_generator:
-                events.append(event)
+            events = [event async for event in event_generator]
 
     # Assert no events are yielded due to the error
     assert len(events) == 0

--- a/waypoint/tests/services/test_nats_service.py
+++ b/waypoint/tests/services/test_nats_service.py
@@ -326,6 +326,7 @@ async def test_process_events_base_exception(
 
     # Process events
     with pytest.raises(ArithmeticError):
+        events = []
         async with processor.process_events(
             group_id="group_id",
             wallet_id="wallet_id",
@@ -435,6 +436,7 @@ async def test_general_error_handling(
     stop_event = asyncio.Event()
 
     with pytest.raises(Error):
+        events = []
         async with processor.process_events(
             group_id="group_id",
             wallet_id="wallet_id",


### PR DESCRIPTION
(plugin to automatically check ruff linting when running tests)

:art: Expand ruff rules:
- flake8-async (proper async patterns)
- fastapi lint checking
- perflint (ensure no performance anti-patterns)
- flake8-print (remove print statements)

:wrench: Adds .venv to ruff.exclude (prevents showing errors when navigating dependency packages)