### PR TITLE
:wrench: Add lifecycle hook support to Cheqd Helm chart

### DIFF
--- a/helm/cheqd/templates/statefulset.yaml
+++ b/helm/cheqd/templates/statefulset.yaml
@@ -215,6 +215,10 @@ spec:
               {{- tpl (toYaml .) $ | nindent 14 }}
               {{- end }}
             {{- end }}
+          {{- if .Values.lifecycle }}
+          lifecycle:
+            {{- tpl (toYaml .Values.lifecycle) . | nindent 12 }}
+          {{- end }}
           {{- if .Values.startupProbe }}
           startupProbe:
             {{- tpl (toYaml .Values.startupProbe) . | nindent 12 }}

--- a/helm/cheqd/values.yaml
+++ b/helm/cheqd/values.yaml
@@ -136,7 +136,7 @@ resources: {}
   #   memory: 2Gi
   # limits:
   #   cpu: 4000m
-  #   memory: 4Gi
+  #   memory: 2.75Gi
 
 # This is to setup the startup, liveness, and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 startupProbe:
@@ -179,7 +179,7 @@ volumeMounts: []
 podAntiAffinityPreset: soft # soft or hard, ignored if `affinity` is set.
 affinity: {}
 
-## topologySpreadConstraints Topology Spread Constraints for Cheqd pods assignment spread across your cluster among failure-domains
+## Topology Spread Constraints for Cheqd pods assignment spread across your cluster among failure-domains
 ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods
 topologySpreadConstraints: []
   # - maxSkew: 1 # Allow max 1 pods in the same zone
@@ -207,7 +207,25 @@ nodeAffinityPreset:
   ##
   values: []
 
+## Lifecycle hooks for the Cheqd container
+## Ref: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks
+lifecycle:
+  preStop:
+    sleep:
+      seconds: 5
+
 env: {}
+  ## Provides the Go Runtime with a soft memory limit.
+  ## `go doc runtime/debug.SetMemoryLimit`
+  # GOMEMLIMIT:
+  #   valueFrom:
+  #     resourceFieldRef:
+  #       resource: requests.memory
+  ## Limits the number of OS threads that can execute user-level Go code simultaneously
+  # GOMAXPROCS:
+  #   valueFrom:
+  #     resourceFieldRef:
+  #       resource: limits.cpu
   # FOO: bar
   # BAZ:
   #   valueFrom:


### PR DESCRIPTION
* Add conditional lifecycle configuration block to StatefulSet
  template that references `.Values.lifecycle`
* Include preStop hook with 5-second sleep delay in default
  values for graceful pod termination
* Add commented examples for `GOMEMLIMIT` and `GOMAXPROCS`
  environment variables with resource field references
* Update commented memory limit example from 4Gi to 2.75Gi

This enables users to configure custom lifecycle hooks for the
cheqd container, improving graceful shutdown behavior and
providing better resource management options.