### PR TITLE
:memo: Improve Go runtime config documentation

### DIFF
--- a/helm/cheqd/values.yaml
+++ b/helm/cheqd/values.yaml
@@ -218,21 +218,21 @@ lifecycle:
 env: {}
   ## Provides the Go Runtime with a soft memory limit.
   ## `go doc runtime/debug.SetMemoryLimit`
+  ## https://tip.golang.org/doc/gc-guide
   # GOMEMLIMIT:
   #   valueFrom:
   #     resourceFieldRef:
   #       resource: requests.memory
-  ## Limits the number of OS threads that can execute user-level Go code simultaneously
+  ## Determines the trade-off between GC CPU and memory.
+  ## https://tip.golang.org/doc/gc-guide#GOGC
+  # GOGC: 50 # Default is 100
+  ## Enable garbage collection trace output.
+  # GODEBUG: gctrace=1
+  ## Limits the number of OS threads that can execute user-level Go code simultaneously.
   # GOMAXPROCS:
   #   valueFrom:
   #     resourceFieldRef:
   #       resource: limits.cpu
-  # FOO: bar
-  # BAZ:
-  #   valueFrom:
-  #     secretKeyRef:
-  #       name: example-secret
-  #       key: baz
 
 
 ## When doing HA, we need to configure persistent peers to connect to each other.


### PR DESCRIPTION
Enhance the Go runtime environment variable documentation in the
Helm values file with more detailed explanations and helpful
references.

Changes:
* Add link to official Go GC guide for `GOMEMLIMIT`
* Document `GOGC` variable with explanation of GC CPU/memory trade-off
* Add `GODEBUG` option for garbage collection tracing
* Remove generic example environment variables (`FOO`, `BAZ`)

---

Before:
```
$ kubectl top pods -n cheqd-testnet
NAME      CPU(cores)   MEMORY(bytes)   
cheqd-0   3536m        2269Mi
```
After:
```
$ kubectl top pods -n cheqd-testnet
NAME      CPU(cores)   MEMORY(bytes)   
cheqd-0   55m          2055Mi
```