### PR TITLE
:sparkles: Add Governance DID bootstrap job

### DIFF
--- a/helm/acapy-cloud/conf/dev/governance-agent.yaml
+++ b/helm/acapy-cloud/conf/dev/governance-agent.yaml
@@ -183,7 +183,7 @@ secretData:
   ACAPY_TENANT_AGENT_API_KEY: adminApiKey
   ACAPY_WALLET_KEY: verySecretGovernanceWalletKey
   ACAPY_WALLET_NAME: governance
-  # ACAPY_WALLET_SEED: verySecretPaddedWalletSeedPadded
+  WALLET_SEED: verySecretPaddedWalletSeedPadded
 
   ACAPY_WALLET_STORAGE_CONFIG: '{ "max_connections":10, "min_connections":1, "url":"cloudapi-postgresql:5432" }'
   ACAPY_WALLET_STORAGE_CREDS: '{ "account": "governance", "admin_account": "governance", "admin_password": "governance", "password": "governance" }'
@@ -241,6 +241,9 @@ env:
   ACAPY_REQUESTS_THROUGH_PUBLIC_DID: true
   ACAPY_EMIT_NEW_DIDCOMM_PREFIX: true
   ACAPY_EMIT_NEW_DIDCOMM_MIME_TYPE: true
+
+  ## Allows us to bootstrap the agent did with a seed
+  ACAPY_WALLET_ALLOW_INSECURE_SEED: true
 
   ACAPY_LOG_LEVEL: info
   ACAPY_LOG_CONFIG: /home/aries/logging_config.yaml

--- a/helm/acapy-cloud/conf/dev/governance-web.yaml
+++ b/helm/acapy-cloud/conf/dev/governance-web.yaml
@@ -223,3 +223,62 @@ istio:
                   paths:
                     - /governance
                     - /governance/*
+
+jobs:
+  # Post Install/Upgrade hook to bootstrap Governance DID
+  bootstrap-governance-did:
+    enabled: true
+    labels: {}
+    podLabels: {}
+    annotations:
+      helm.sh/hook: post-install,post-upgrade
+      helm.sh/hook-delete-policy: before-hook-creation
+    podAnnotations:
+      ad.datadoghq.com/exclude: "true"
+      sidecar.istio.io/inject: "false"
+    image: curlimages/curl
+    command:
+      - /bin/sh
+      - -c
+      - |
+        set -euo pipefail
+
+        # Check if Governance DID already exists
+        DID=$(curl ${URL}/governance/v1/wallet/dids \
+          -sX GET \
+          -H "X-API-Key: governance.${API_KEY}")
+        if echo "${DID}" | grep -q "did:cheqd"; then
+          echo "Governance DID already exists, skipping bootstrap."
+          echo "${DID}"
+          exit 0
+        fi
+
+        echo "Bootstrapping Governance DID..."
+        RESULT=$(curl ${URL}/governance/v1/wallet/dids \
+          -sX POST \
+          -H "Content-Type: application/json" \
+          -H "X-API-Key: governance.${API_KEY}" \
+          -d '{"method": "cheqd", "seed": "'${WALLET_SEED}'"}')
+
+        echo "DID created: ${RESULT}"
+    env:
+      URL: http://{{ include "acapy-cloud.fullname" . }}:{{ .Values.service.port }}
+      WALLET_SEED:
+        valueFrom:
+          secretKeyRef:
+            name: governance-agent-env
+            key: WALLET_SEED
+      API_KEY:
+        valueFrom:
+          secretKeyRef:
+            name: '{{ include "acapy-cloud.fullname" . }}-env'
+            key: ACAPY_GOVERNANCE_AGENT_API_KEY
+    podSecurityContext: {}
+      # fsGroup: 65534
+    securityContext:
+      capabilities:
+        drop:
+        - ALL
+      readOnlyRootFilesystem: true
+      runAsNonRoot: true
+      runAsUser: 65534

--- a/helm/acapy-cloud/conf/local/governance-agent.yaml
+++ b/helm/acapy-cloud/conf/local/governance-agent.yaml
@@ -171,7 +171,7 @@ secretData:
   ACAPY_TENANT_AGENT_API_KEY: adminApiKey
   ACAPY_WALLET_KEY: verySecretGovernanceWalletKey
   ACAPY_WALLET_NAME: governance
-  # ACAPY_WALLET_SEED: verySecretPaddedWalletSeedPadded
+  WALLET_SEED: verySecretPaddedWalletSeedPadded
 
   ACAPY_WALLET_STORAGE_CONFIG: '{ "max_connections":10, "min_idle_count":10, "url":"cloudapi-postgresql:5432" }'
   ACAPY_WALLET_STORAGE_CREDS: '{ "account": "governance", "admin_account": "governance", "admin_password": "governance", "password": "governance" }'
@@ -231,6 +231,9 @@ env:
   ACAPY_REQUESTS_THROUGH_PUBLIC_DID: true
   ACAPY_EMIT_NEW_DIDCOMM_PREFIX: true
   ACAPY_EMIT_NEW_DIDCOMM_MIME_TYPE: true
+
+  ## Allows us to bootstrap the agent did with a seed
+  ACAPY_WALLET_ALLOW_INSECURE_SEED: true
 
   # ACAPY_LOG_CONFIG: /home/aries/logging_config.yaml
 

--- a/helm/acapy-cloud/conf/local/governance-web.yaml
+++ b/helm/acapy-cloud/conf/local/governance-web.yaml
@@ -216,3 +216,62 @@ istio:
                   paths:
                     - /governance
                     - /governance/*
+
+jobs:
+  # Post Install/Upgrade hook to bootstrap Governance DID
+  bootstrap-governance-did:
+    enabled: true
+    labels: {}
+    podLabels: {}
+    annotations:
+      helm.sh/hook: post-install,post-upgrade
+      helm.sh/hook-delete-policy: before-hook-creation
+    podAnnotations:
+      ad.datadoghq.com/exclude: "true"
+      sidecar.istio.io/inject: "false"
+    image: curlimages/curl
+    command:
+      - /bin/sh
+      - -c
+      - |
+        set -euo pipefail
+
+        # Check if Governance DID already exists
+        DID=$(curl ${URL}/governance/v1/wallet/dids \
+          -sX GET \
+          -H "X-API-Key: governance.${API_KEY}")
+        if echo "${DID}" | grep -q "did:cheqd"; then
+          echo "Governance DID already exists, skipping bootstrap."
+          echo "${DID}"
+          exit 0
+        fi
+
+        echo "Bootstrapping Governance DID..."
+        RESULT=$(curl ${URL}/governance/v1/wallet/dids \
+          -sX POST \
+          -H "Content-Type: application/json" \
+          -H "X-API-Key: governance.${API_KEY}" \
+          -d '{"method": "cheqd", "seed": "'${WALLET_SEED}'"}')
+
+        echo "DID created: ${RESULT}"
+    env:
+      URL: http://{{ include "acapy-cloud.fullname" . }}:{{ .Values.service.port }}
+      WALLET_SEED:
+        valueFrom:
+          secretKeyRef:
+            name: governance-agent-env
+            key: WALLET_SEED
+      API_KEY:
+        valueFrom:
+          secretKeyRef:
+            name: '{{ include "acapy-cloud.fullname" . }}-env'
+            key: ACAPY_GOVERNANCE_AGENT_API_KEY
+    podSecurityContext: {}
+      # fsGroup: 65534
+    securityContext:
+      capabilities:
+        drop:
+        - ALL
+      readOnlyRootFilesystem: true
+      runAsNonRoot: true
+      runAsUser: 65534

--- a/helm/acapy-cloud/templates/job.yaml
+++ b/helm/acapy-cloud/templates/job.yaml
@@ -1,0 +1,68 @@
+{{- $jobCount := 0 }}
+{{- range $k,$v := .Values.jobs }}
+{{- if .enabled }}
+{{- if gt $jobCount 0 }}
+---
+{{- end }}
+{{- $jobCount = add $jobCount 1 }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ tpl ($k) $ }}
+  labels:
+    {{- include "acapy-cloud.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
+    {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+spec:
+  template:
+    metadata:
+      labels:
+        {{- include "acapy-cloud.labels" $ | nindent 8 }}
+        {{- with .podLabels }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
+        {{- end }}
+      {{- with .podAnnotations }}
+      annotations:
+        {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "acapy-cloud.serviceAccountName" $ }}
+      restartPolicy: {{ default "Never" .restartPolicy }}
+      securityContext:
+        {{- tpl (toYaml .podSecurityContext) $ | nindent 8 }}
+      {{- with .initContainers }}
+      initContainers:
+        {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+      {{- if .volumes }}
+      volumes:
+        {{- tpl (toYaml .volumes) $ | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ tpl ($k) $ }}
+          image: {{ tpl .image $ }}
+          imagePullPolicy: {{ tpl (default "IfNotPresent" .imagePullPolicy) $ }}
+          command: {{- tpl (toYaml .command) $ | nindent 12 }}
+          env:
+            {{- range $k,$v := .env }}
+            - name: {{ $k }}
+              {{- $type := printf "%s" (typeOf $v) }}
+              {{- if or (eq $type "string") (eq $type "float64") (eq $type "bool") }}
+              value: {{ tpl (toString $v) $ | quote }}
+              {{- else }}
+              {{- include "common.tplvalues.render" (dict "value" . "context" $) | nindent 14 }}
+              {{- end }}
+            {{- end }}
+          securityContext:
+            {{- tpl (toYaml .securityContext) $ | nindent 12 }}
+          {{- if .volumeMounts }}
+          volumeMounts:
+            {{- tpl (toYaml .volumeMounts) $ | nindent 12 }}
+          {{- end }}
+{{- end }}
+{{- end }}

--- a/helm/acapy-cloud/values.yaml
+++ b/helm/acapy-cloud/values.yaml
@@ -307,3 +307,37 @@ istio:
     labels: {}
     annotations: {}
     patches: []
+
+jobs: {}
+  # example-job:
+  #   enabled: false
+  #   labels: {}
+  #   podLabels: {}
+  #   annotations:
+  #     helm.sh/hook: post-install,post-upgrade
+  #     helm.sh/hook-delete-policy: before-hook-creation
+  #   podAnnotations:
+  #     ad.datadoghq.com/exclude: "true"
+  #     sidecar.istio.io/inject: "false"
+  #   image: curlimages/curl
+  #   command:
+  #     - /bin/sh
+  #     - -c
+  #     - curl -sIX GET example.com
+  #   env: {}
+  #   #   FOO: bar
+  #   #   BAZ:
+  #   #     valueFrom:
+  #   #       secretKeyRef:
+  #   #         name: example-secret
+  #   #         key: baz
+  #   # restartPolicy: Never
+  #   podSecurityContext: {}
+  #     # fsGroup: 65534
+  #   securityContext:
+  #     capabilities:
+  #       drop:
+  #       - ALL
+  #     readOnlyRootFilesystem: true
+  #     runAsNonRoot: true
+  #     runAsUser: 65534

--- a/helm/cheqd/values.yaml
+++ b/helm/cheqd/values.yaml
@@ -267,9 +267,6 @@ snapshot:
   filename: cheqd-{{ .Values.networkId }}_{{ .Values.snapshot.date }}.tar.lz4
   url: https://cheqd-node-backups.ams3.digitaloceanspaces.com/{{ .Values.network }}/{{ .Values.snapshot.date }}/{{ tpl .Values.snapshot.filename . }}
   checksum: b188a8605dccffbdaa73ee61397ab7c5de82b59967e70f496c55cb98653ba816
-  podLabels: {}
-  podAnnotations:
-    ad.datadoghq.com/exclude: "true"
 
 config:
   app_toml:


### PR DESCRIPTION
* Add `ACAPY_WALLET_ALLOW_INSECURE_SEED` environment variable to
  governance agent configurations (dev and local) to enable DID
  bootstrapping with a predefined seed
* Implement post-install/post-upgrade Helm hook job that automatically
  creates a governance DID if one doesn't already exist, using the
  cheqd method and a wallet seed
* Add job template support to acapy-cloud Helm chart with configurable
  jobs section in values.yaml to enable running arbitrary jobs as part
  of chart lifecycle
* Remove unused podLabels and podAnnotations from cheqd snapshot
  configuration

This change eliminates the need for manual DID creation after
deployment by automating the governance DID bootstrap process,
ensuring the governance agent is ready to use immediately after
installation.