### PR TITLE
:arrow_up: Upgrade Bitnami chart dependencies

### DIFF
--- a/helm/acapy-cloud.yaml.gotmpl
+++ b/helm/acapy-cloud.yaml.gotmpl
@@ -170,7 +170,7 @@ releases:
       app: valkey
     namespace: {{ .Values.namespace }}
     chart: oci://registry-1.docker.io/bitnamicharts/valkey
-    version: 3.0.15
+    version: 3.0.16
     values:
       - ./acapy-cloud/conf/valkey.yaml
       - primary:
@@ -186,7 +186,7 @@ releases:
       app: postgres
     namespace: {{ .Values.namespace }}
     chart: oci://registry-1.docker.io/bitnamicharts/postgresql-ha
-    version: 16.0.14
+    version: 16.0.15
     values:
       - ./acapy-cloud/conf/postgres.yaml
       - postgresql:
@@ -261,7 +261,7 @@ releases:
     installed: {{ .Values.minio.enabled }}
     namespace: {{ .Values.namespace }}
     chart: oci://registry-1.docker.io/bitnamicharts/minio
-    version: 17.0.6
+    version: 17.0.9
     labels:
       app: minio
     values:

--- a/helm/nats/Chart.lock
+++ b/helm/nats/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 2.31.3
 - name: nats
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 9.0.20
-digest: sha256:5ae0d8ceb1a02b245a3376f441d9c34da880fdc67e8542994faf109e62790442
-generated: "2025-06-23T16:58:23.486396+02:00"
+  version: 9.0.21
+digest: sha256:c0652726502601499aaaf90b719357d923c55dc8411a7a6715108824479825b7
+generated: "2025-06-30T13:30:47.340583+02:00"

--- a/tilt/acapy-cloud/Tiltfile
+++ b/tilt/acapy-cloud/Tiltfile
@@ -5,15 +5,15 @@ load("ext://helm_resource", "helm_resource", "helm_repo")
 # https://github.com/cheqd/cheqd-node
 cheqd_noded_version = "v3.1.9"
 # https://github.com/bitnami/charts/tree/main/bitnami/minio
-minio_version = "17.0.6"
+minio_version = "17.0.9"
 # https://github.com/rowanruseler/helm-charts/tree/main/charts/pgadmin4
 pgadmin_version = "1.47.0"
 # https://github.com/bitnami/charts/tree/main/bitnami/postgresql-ha
-postgres_version = "16.0.14"
+postgres_version = "16.0.15"
 # https://github.com/redpanda-data/helm-charts/tree/main/charts/connect
 redpanda_connect_version = "3.0.3"
 # https://github.com/bitnami/charts/tree/main/bitnami/valkey
-valkey_version = "3.0.15"
+valkey_version = "3.0.16"
 
 # Mnemonic for the Cheqd Localnet Validator
 # Will be used for Localnet as well as the Fee Payer for Cheqd DID Driver


### PR DESCRIPTION
* Update valkey from 3.0.15 to 3.0.16
* Update postgresql-ha from 16.0.14 to 16.0.15
* Update minio from 17.0.6 to 17.0.9
* Update nats from 9.0.20 to 9.0.21
* Update corresponding version variables in Tiltfile

These updates bring all Bitnami chart dependencies to their
latest stable releases for improved security and bug fixes.