### PR TITLE
:arrow_up: Cheqd Localnet `4.1.0`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,6 @@ tilt/docker
 # Helm chart dependencies
 helm/**/charts
 
-# Cheqd Node
-tilt/.cheqd-node
-
 # Nats credentials
 **.creds
 

--- a/helm/acapy-cloud.yaml.gotmpl
+++ b/helm/acapy-cloud.yaml.gotmpl
@@ -9,7 +9,7 @@ environments:
       ddProfilingEnabled:
         default: false
         overrides: {}
-      cheqd:
+      cheqdLocalNet:
         enabled: true
         config: {}
       natsReplicaCount: 1
@@ -40,7 +40,7 @@ environments:
           # governance-agent: true
           # multitenant-web: true
           # tenant-web: true
-      cheqd:
+      cheqdLocalNet:
         enabled: true
         config:
           log_level: warn
@@ -114,7 +114,7 @@ releases:
     labels:
       app: cheqd
     namespace: {{ .Values.namespace }}
-    installed: {{ .Values.cheqd.enabled }}
+    installed: {{ .Values.cheqdLocalNet.enabled }}
     chart: ./cheqd
     version: 0.1.0
     values:
@@ -126,7 +126,7 @@ releases:
         {{- if not (eq .Environment.Name "local") }}
         ingress: null # Disable ingress for non-local environments
         {{- end }}
-      {{- with .Values.cheqd.config }}
+      {{- with .Values.cheqdLocalNet.config }}
       - config:
           config_toml:
             log_level: {{ .log_level }}

--- a/helm/cheqd/conf/localnet/values.yaml
+++ b/helm/cheqd/conf/localnet/values.yaml
@@ -1,3 +1,6 @@
+image:
+  tag: 4.1.0
+
 podLabels:
   sidecar.istio.io/inject: "false"
 

--- a/helm/cheqd/conf/localnet/values.yaml
+++ b/helm/cheqd/conf/localnet/values.yaml
@@ -1,3 +1,4 @@
+# https://github.com/cheqd/cheqd-node
 image:
   tag: 4.1.0
 

--- a/helm/cheqd/templates/statefulset.yaml
+++ b/helm/cheqd/templates/statefulset.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   serviceName: {{ include "cheqd.fullname" . }}-headless
   replicas: {{ .Values.replicaCount }}
-  podManagementPolicy: Parallel
+  podManagementPolicy: {{ .Values.podManagementPolicy }}
   selector:
     matchLabels:
       {{- include "cheqd.selectorLabels" . | nindent 6 }}

--- a/helm/cheqd/templates/statefulset.yaml
+++ b/helm/cheqd/templates/statefulset.yaml
@@ -231,10 +231,10 @@ spec:
               protocol: TCP
           env:
             - name: CHEQD_NODED_P2P_PERSISTENT_PEERS
-              {{- if and .Values.lbService.enabled .Values.lbService.hostname }}
-              value: "{{ range $i, $nodeId := .Values.nodeIds }}{{ if $i }},{{ end }}{{ $nodeId }}@{{ $.Values.lbService.hostname }}:{{ add $i $.Values.service.p2pPort }}{{ end }}"
+              {{- if .Values.lbService.enabled }}
+              value: "{{ range $i, $nodeId := .Values.nodeIds }}{{ if $i }},{{ end }}{{ $nodeId }}@{{ include "cheqd.fullname" $ }}-lb.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}:{{ add $i $.Values.service.p2pPort }}{{ end }}"
               {{- else }}
-              value: "{{ range $i, $nodeId := .Values.nodeIds }}{{ if $i }},{{ end }}{{ $nodeId }}@{{ include "cheqd.fullname" $ }}-{{ $i }}.{{ include "cheqd.fullname" $ }}-headless.{{ $.Release.Namespace }}.svc.cluster.local:{{ add $i $.Values.service.p2pPort }}{{ end }}"
+              value: "{{ range $i, $nodeId := .Values.nodeIds }}{{ if $i }},{{ end }}{{ $nodeId }}@{{ include "cheqd.fullname" $ }}-{{ $i }}.{{ include "cheqd.fullname" $ }}-headless.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}:{{ add $i $.Values.service.p2pPort }}{{ end }}"
               {{- end }}
             - name: POD_NAME
               valueFrom:

--- a/helm/cheqd/values.yaml
+++ b/helm/cheqd/values.yaml
@@ -74,6 +74,9 @@ statefulSetLabels: {}
 # For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 podLabels: {}
 
+# This is for setting the pod management policy more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policy
+podManagementPolicy: OrderedReady # OrderedReady or Parallel
+
 podSecurityContext:
   fsGroup: 1000
 

--- a/helm/cheqd/values.yaml
+++ b/helm/cheqd/values.yaml
@@ -85,6 +85,9 @@ securityContext:
   runAsNonRoot: true
   runAsUser: 1000
 
+# Default Kubernetes cluster domain
+clusterDomain: cluster.local
+
 # This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
 service:
   # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types

--- a/tilt/acapy-cloud/Tiltfile
+++ b/tilt/acapy-cloud/Tiltfile
@@ -3,7 +3,7 @@ load("ext://color", "color")
 load("ext://helm_resource", "helm_resource", "helm_repo")
 
 # https://github.com/cheqd/cheqd-node
-cheqd_noded_version = "v3.1.9"
+cheqd_noded_version = "v4.1.0"
 # https://github.com/bitnami/charts/tree/main/bitnami/minio
 minio_version = "17.0.9"
 # https://github.com/rowanruseler/helm-charts/tree/main/charts/pgadmin4

--- a/tilt/acapy-cloud/Tiltfile
+++ b/tilt/acapy-cloud/Tiltfile
@@ -2,8 +2,6 @@ load("../utils/Tiltfile", "namespace_create_wrap", "generate_ingress_domain")
 load("ext://color", "color")
 load("ext://helm_resource", "helm_resource", "helm_repo")
 
-# https://github.com/cheqd/cheqd-node
-cheqd_noded_version = "v4.1.0"
 # https://github.com/bitnami/charts/tree/main/bitnami/minio
 minio_version = "17.0.9"
 # https://github.com/rowanruseler/helm-charts/tree/main/charts/pgadmin4
@@ -453,56 +451,14 @@ def setup_cheqd_localnet(namespace, ingress_domain):
     print(color.green("Installing Cheqd Localnet..."))
 
     project_root = os.getcwd()
-    cheqd_path = project_root + "/tilt/.cheqd-node"
-
-    build_enabled = cpu_arch == "arm64"
-
-    if build_enabled:
-        if not os.path.exists(cheqd_path):
-            print(color.green("Cloning cheqd-node repository..."))
-            clone_cmd = (
-                "git clone https://github.com/cheqd/cheqd-node.git --depth 1 "
-                + "--branch "
-                + cheqd_noded_version
-                + " "
-                + cheqd_path
-            )
-        else:
-            print(color.green("Checking out correct branch/tag for cheqd-node..."))
-            clone_cmd = (
-                "cd "
-                + cheqd_path
-                + " && "
-                + "git fetch origin"
-                + " && "
-                + "git checkout "
-                + cheqd_noded_version
-            )
-    else:
-        clone_cmd = "echo 'Build is disabled, skipping cheqd-node setup'"
-
-    local_resource(
-        name="checkout-cheqd-node",
-        cmd=clone_cmd,
-        allow_parallel=True,
-        labels=["11-cheqd"],
-    )
 
     setup_cloudapi_service(
         "cheqd",
         "./helm/cheqd",
         namespace,
         ingress_domain,
-        build_enabled,
-        {
-            "depends": ["checkout-cheqd-node"],
-            "image": {
-                "registry": "ghcr.io",
-                "tag": cheqd_noded_version.lstrip("v"),
-                "dockerfile": project_root + "/tilt/.cheqd-node/docker/Dockerfile",
-                "context": project_root + "/tilt/.cheqd-node",
-                "ignore": ["**", "!tilt/.cheqd-node"],
-            },
+        build_enabled=False,
+        release_config={
             "flags": [
                 "--set",
                 "secrets.validatorMnemonic=" + cheqd_validator_mnemonic,

--- a/tilt/acapy-cloud/Tiltfile
+++ b/tilt/acapy-cloud/Tiltfile
@@ -457,22 +457,29 @@ def setup_cheqd_localnet(namespace, ingress_domain):
 
     build_enabled = cpu_arch == "arm64"
 
-    if build_enabled and not os.path.exists(cheqd_path):
-        clone_cmd = (
-            "git clone https://github.com/cheqd/cheqd-node.git --depth 1 "
-            + "--branch "
-            + cheqd_noded_version
-            + " "
-            + cheqd_path
-        )
-        print(color.green("Cloning cheqd-node repository..."))
-    else:
-        clone_cmd = "echo 'Cheqd node directory already exists or build is disabled, skipping clone'"
-        print(
-            color.green(
-                "Cheqd node directory already exists or build is disabled, skipping clone"
+    if build_enabled:
+        if not os.path.exists(cheqd_path):
+            print(color.green("Cloning cheqd-node repository..."))
+            clone_cmd = (
+                "git clone https://github.com/cheqd/cheqd-node.git --depth 1 "
+                + "--branch "
+                + cheqd_noded_version
+                + " "
+                + cheqd_path
             )
-        )
+        else:
+            print(color.green("Checking out correct branch/tag for cheqd-node..."))
+            clone_cmd = (
+                "cd "
+                + cheqd_path
+                + " && "
+                + "git fetch origin"
+                + " && "
+                + "git checkout "
+                + cheqd_noded_version
+            )
+    else:
+        clone_cmd = "echo 'Build is disabled, skipping cheqd-node setup'"
 
     local_resource(
         name="checkout-cheqd-node",
@@ -494,7 +501,7 @@ def setup_cheqd_localnet(namespace, ingress_domain):
                 "tag": cheqd_noded_version.lstrip("v"),
                 "dockerfile": project_root + "/tilt/.cheqd-node/docker/Dockerfile",
                 "context": project_root + "/tilt/.cheqd-node",
-                "ignore": ["**"],
+                "ignore": ["**", "!tilt/.cheqd-node"],
             },
             "flags": [
                 "--set",
@@ -503,23 +510,23 @@ def setup_cheqd_localnet(namespace, ingress_domain):
             "labels": ["11-cheqd"],
             "links": [
                 link(
-                    "http://api.cheqd." + ingress_domain,
+                    "http://api.cheqd.cloudapi." + ingress_domain,
                     "Cheqd API",
                 ),
                 link(
-                    "http://api.cheqd." + ingress_domain + "/swagger/",
+                    "http://api.cheqd.cloudapi." + ingress_domain + "/swagger/",
                     "Cheqd API Docs",
                 ),
                 link(
-                    "http://rpc.cheqd." + ingress_domain,
+                    "http://rpc.cheqd.cloudapi." + ingress_domain,
                     "Cheqd RPC",
                 ),
                 link(
-                    "https://grpc.cheqd." + ingress_domain,
+                    "https://grpc.cheqd.cloudapi." + ingress_domain,
                     "Cheqd gRPC",
                 ),
                 link(
-                    "http://grpc-web.cheqd." + ingress_domain,
+                    "http://grpc-web.cheqd.cloudapi." + ingress_domain,
                     "Cheqd gRPC Web",
                 ),
             ],


### PR DESCRIPTION
This PR upgrades the cheqd-node dependency from v3.1.9 to v4.1.0 to
maintain parity with the cheqd testnet, which is upgrading to v4.1.0
on July 2nd, 2025.

### What changed

* Upgrade cheqd-node version to v4.1.0 in Helm values
* Remove local build and checkout logic for cheqd-node repository  
* Fix Tilt UI links to use correct `cloudapi` domain structure
* Rename configuration key from `cheqd` to `cheqdLocalNet` for clarity
* Clean up `.gitignore` to remove `.cheqd-node` directory reference
* Remove `cheqd_noded_version` variable from Tiltfile

### Why these changes

**Primary motivation**: The cheqd testnet is upgrading from v3.1.9 to 
v4.1.0 on July 2nd, 2025. To ensure our local development environment 
remains compatible and behaves consistently with the testnet, we need 
to upgrade our localnet deployment to match this version.

**Additional benefit**: cheqd-node v4.1.0 now provides multi-architecture 
Docker images, which allows us to simplify our deployment by removing 
the complex local build system that was previously required for ARM64 
systems.

### Additional improvements

* Corrected Tilt dashboard links for Cheqd services  
* Clearer configuration naming with `cheqdLocalNet`
* Reduced maintenance overhead by removing build infrastructure
* Use official pre-built images directly from registry

---

> [!WARNING]
> Will require a reset of EKS Dev environments

> [!NOTE]
> Testnet upgrade is scheduled for 2 July 2025 at 09:30 GMT
> https://testnet-explorer.cheqd.io/proposals/22
