### PR TITLE
:sparkles: Add snapshot reset functionality to Cheqd Helm

### DIFF
--- a/helm/cheqd/templates/statefulset.yaml
+++ b/helm/cheqd/templates/statefulset.yaml
@@ -116,6 +116,10 @@ spec:
               mkdir -p /cheqd/config
               rm -rf /cheqd/lost+found
 
+              {{- if .Values.snapshot.reset }}
+              rm -rf /cheqd/data
+              {{- end }}
+
               # Check if data directory exists with expected content
               if [ -d /cheqd/data/application.db ] && \
                  [ -d /cheqd/data/blockstore.db ] && \

--- a/helm/cheqd/values.yaml
+++ b/helm/cheqd/values.yaml
@@ -273,11 +273,15 @@ secrets: {}
 network: testnet # localnet, testnet, or mainnet
 networkId: testnet-6 # cheqd (localnet), testnet-6, or mainnet-1
 snapshot:
-  # https://snapshots.cheqd.net
+  ## https://snapshots.cheqd.net
+  ## https://www.polkachu.com/tendermint_snapshots/cheqd
+  ## https://www.publicnode.com/snapshots#cheqd
   date: 2025-06-10
   filename: cheqd-{{ .Values.networkId }}_{{ .Values.snapshot.date }}.tar.lz4
   url: https://cheqd-node-backups.ams3.digitaloceanspaces.com/{{ .Values.network }}/{{ .Values.snapshot.date }}/{{ tpl .Values.snapshot.filename . }}
   checksum: b188a8605dccffbdaa73ee61397ab7c5de82b59967e70f496c55cb98653ba816
+  # Delete the data directory to redownload the snapshot
+  reset: false
 
 config:
   app_toml:


### PR DESCRIPTION
Add optional data directory reset before snapshot restoration.
This allows operators to force a clean snapshot download by
setting `snapshot.reset: true` in values.yaml.

Changes:
* Add conditional data directory removal in statefulset init
* Add `reset: false` configuration option to values.yaml

The reset functionality removes `/cheqd/data` when enabled,
ensuring a fresh snapshot download instead of resuming from
existing blockchain state.