### PR TITLE
:lock: :pushpin: Add mise lockfile and upgrade tool versions

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -51,9 +51,9 @@ on:
 permissions: {}
 
 env:
-  HELM_VERSION: v3.18.3
+  HELM_VERSION: v3.18.4
   HELMFILE_VERSION: v1.1.2
-  MISE_VERSION: 2025.6.5
+  MISE_VERSION: 2025.7.2
 
   RESET_DEPLOYMENTS: ${{ github.event.inputs.reset-deployments || 'false' }}
   RUN_E2E_TESTS: ${{ github.event.inputs.run-e2e-tests || 'true' }}

--- a/.github/workflows/deploy-test-eks.yml
+++ b/.github/workflows/deploy-test-eks.yml
@@ -115,7 +115,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  HELM_VERSION_DEFAULT: v3.18.3
+  HELM_VERSION_DEFAULT: v3.18.4
   HELMFILE_VERSION_DEFAULT: v1.1.2
 
 jobs:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -21,6 +21,7 @@ jobs:
 
       - name: Overwrite .mise.toml # The full `mise.toml` isn't needed for this workflow
         run: |
+          rm -f .mise.lock
           cat <<EOF > .mise.toml
           [tools]
           python = "3.12"

--- a/.github/workflows/local-tests.yml
+++ b/.github/workflows/local-tests.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: .venv
-          key: python-${{ hashFiles('**/poetry.lock', '.mise.toml') }}
+          key: python-${{ hashFiles('**/poetry.lock', '.mise.lock') }}
 
       - name: Set up Mise
         uses: jdx/mise-action@5cb1df66ed5e1fb3c670ea0b62fd17a76979826a # v2.3.1

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -54,6 +54,7 @@ jobs:
 
       - name: Overwrite .mise.toml # Simplify mise in this workflow
         run: |
+          rm -f .mise.lock
           cat <<EOF > .mise.toml
           [tools]
           poetry = "2.1"
@@ -71,7 +72,7 @@ jobs:
 
           [tasks."poetry:install"]
           description = "Poetry Install dependencies"
-          run = "poetry install"
+          run = "poetry install --with dev"
           EOF
 
       - name: Cache Python venv

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: .venv
-          key: python-${{ hashFiles('**/poetry.lock', '.mise.toml') }}
+          key: python-${{ hashFiles('**/poetry.lock', '.mise.lock') }}
 
       - name: Set up Mise
         uses: jdx/mise-action@5cb1df66ed5e1fb3c670ea0b62fd17a76979826a # v2.3.1

--- a/.mise.lock
+++ b/.mise.lock
@@ -1,0 +1,84 @@
+[tools."aqua:nats-io/natscli"]
+version = "0.2.3"
+backend = "aqua:nats-io/natscli"
+
+[tools."aqua:nats-io/natscli".checksums]
+"nats-0.2.3-darwin-arm64.zip" = "sha256:b6258ef8b662e07902f9cec1a293c615a4d06f2aa30dce3c6b32f35a0c42f0f8"
+
+[tools.helm]
+version = "3.18.3"
+backend = "aqua:helm/helm"
+
+[tools.helm.checksums]
+"helm-v3.18.3-darwin-arm64.tar.gz" = "sha256:3fe3e9739ab3c75d88bfe13e464a79a2a7a804fc692c3258fa6a9d185d53e377"
+
+[tools.helmfile]
+version = "1.1.2"
+backend = "aqua:helmfile/helmfile"
+
+[tools.helmfile.checksums]
+"helmfile_1.1.2_darwin_arm64.tar.gz" = "sha256:0a6c136246fd0d3bb1593ef046f00f41385a1c1955990da9a0bcb7e3246b319c"
+
+[tools.istioctl]
+version = "1.26.2"
+backend = "aqua:istio/istio/istioctl"
+
+[tools.istioctl.checksums]
+"istioctl-1.26.2-osx-arm64.tar.gz" = "sha256:e6977f35c8b547d1ae404074e2981f80d980c477786436007259a7e895748dfe"
+
+[tools.jq]
+version = "1.8.1"
+backend = "aqua:jqlang/jq"
+
+[tools.jq.checksums]
+jq-macos-arm64 = "sha256:a9fe3ea2f86dfc72f6728417521ec9067b343277152b114f4e98d8cb0e263603"
+
+[tools.kind]
+version = "0.29.0"
+backend = "aqua:kubernetes-sigs/kind"
+
+[tools.kind.checksums]
+kind-darwin-arm64 = "sha256:314d8f1428842fd1ba2110fd0052a0f0b3ab5773ab1bdcdad1ff036e913310c9"
+
+[tools.kubectl]
+version = "1.33.2"
+backend = "aqua:kubernetes/kubectl"
+
+[tools.kubectl.checksums]
+kubectl = "sha256:8730bf6dab538a1e9710a3668e2cd5f1bdc3c25c68b65a57c5418bdc3472769c"
+
+[tools.poetry]
+version = "2.1.3"
+backend = "asdf:poetry"
+
+[tools.pre-commit]
+version = "4.2.0"
+backend = "aqua:pre-commit/pre-commit"
+
+[tools.pre-commit.checksums]
+"pre-commit-4.2.0.pyz" = "sha256:0d4d80fd598dd1f7c268569de49e7c7a692a3de6f7a97cf14ad4e6cce993bbdf"
+
+[tools.python]
+version = "3.12.11"
+backend = "core:python"
+
+[tools.tilt]
+version = "0.35.0"
+backend = "aqua:tilt-dev/tilt"
+
+[tools.tilt.checksums]
+"tilt.0.35.0.mac.arm64.tar.gz" = "sha256:8e1737f2ae71fd5c67750d8ea3fe41b09dcc1e11d929b305fa03b1366695009e"
+
+[tools.usage]
+version = "2.1.1"
+backend = "ubi:jdx/usage"
+
+[tools.usage.checksums]
+usage-macos-aarch64 = "sha256:890b4d1439692046d8e14087667fd48bbfc5046f3aa2d85233d0b43029ce3fec"
+
+[tools.yq]
+version = "4.45.4"
+backend = "aqua:mikefarah/yq"
+
+[tools.yq.checksums]
+yq_darwin_arm64 = "sha256:602dbbc116af9eb8a91d2239d0ec286eb9c90b94e76676d5268ab6ca184719b6"


### PR DESCRIPTION
* Add `.mise.lock` file to enable checksum verification for all
  tools, improving supply chain security
* Upgrade Helm from `v3.18.3` to `v3.18.4`
* Upgrade Mise from `2025.6.5` to `2025.7.2`
* Update GitHub Actions cache keys to use `.mise.lock` instead of
  `.mise.toml` for more accurate cache invalidation
* Remove existing `.mise.lock` files in workflows that override
  the configuration to prevent conflicts
* Update SonarCloud workflow to install dev dependencies with
  `poetry install --with dev`

The lockfile ensures reproducible builds by pinning exact versions
and verifying checksums of all development tools, preventing
potential supply chain attacks and dependency confusion.