### PR TITLE
♻️ K6 refactor: fix variable naming and parallel execution

### DIFF
--- a/scripts/k6/libs/setup.js
+++ b/scripts/k6/libs/setup.js
@@ -44,10 +44,10 @@ export function bootstrapIssuer(
     if (credentialDefinitionId) {
       log.info(`Credential definition already exists for issuer ${walletName}_0 - Skipping creation`)
       issuers.push({
-        walletName: walletName,
-        walletId: issuerWalletId,
-        accessToken: issuerAccessToken,
-        credentialDefinitionId,
+        wallet_name: walletName,
+        wallet_id: issuerWalletId,
+        access_token: issuerAccessToken,
+        credential_definition_id: credentialDefinitionId,
       });
     } else {
       log.info(`Credential definition not found for issuer ${walletName}_0 - Creating new one`);
@@ -77,10 +77,10 @@ export function bootstrapIssuer(
         );
         log.info(`definition created successfully for issuer ${walletName}_0`);
         issuers.push({
-          walletName: walletName,
-          walletId: issuerWalletId,
-          accessToken: issuerAccessToken,
-          credentialDefinitionId: credentialDefinitionId,
+          wallet_name: walletName,
+          wallet_id: issuerWalletId,
+          access_token: issuerAccessToken,
+          credential_definition_id: credentialDefinitionId,
         });
       } else {
         log.error(`Failed to create credential definition for issuer ${walletName}_0`);

--- a/scripts/k6/scenarios/create-credentials.js
+++ b/scripts/k6/scenarios/create-credentials.js
@@ -78,17 +78,17 @@ export default function (data) {
   const holders = data.holders;
   const epochTimestamp = data.epochTimestamp;
   const walletIndex = getWalletIndex(__VU, __ITER, iterations);
-  const wallet = holders[walletIndex];
+  const holder = holders[walletIndex];
 
-  log.debug(`Wallet Index: ${walletIndex}, Issuer Wallet ID: ${wallet.issuer_wallet_id}`);
+  log.debug(`Wallet Index: ${walletIndex}, Issuer Wallet ID: ${holder.issuer_wallet_id}`);
 
   let createCredentialResponse;
   try {
     createCredentialResponse = retry(() => {
       const response = createCredential(
-        wallet.issuer_access_token,
-        wallet.issuer_credential_definition_id,
-        wallet.issuer_connection_id,
+        holder.issuer_access_token,
+        holder.issuer_credential_definition_id,
+        holder.issuer_connection_id,
         epochTimestamp.toString() // Pass epoch timestamp as date_of_issue
       );
       if (response.status !== 200) {
@@ -116,11 +116,11 @@ export default function (data) {
   const { thread_id: threadId, credential_exchange_id: issuerCredentialExchangeId } =
     JSON.parse(createCredentialResponse.body);
 
-  log.debug(`walletIndex: ${walletIndex}, walletId: ${wallet.wallet_id} issuerConnectionId: ${wallet.issuer_connection_id}`);
+  log.debug(`walletIndex: ${walletIndex}, walletId: ${holder.wallet_id} issuerConnectionId: ${holder.issuer_connection_id}`);
 
   pollAndCheck({
-    accessToken: wallet.access_token,
-    walletId: wallet.wallet_id,
+    accessToken: holder.access_token,
+    walletId: holder.wallet_id,
     topic: "credentials",
     field: "thread_id",
     fieldId: threadId,
@@ -132,12 +132,12 @@ export default function (data) {
 
   log.debug(`Accepting credential for thread ID: ${threadId}`);
 
-  const holderCredentialExchangeId = getCredentialIdByThreadId(wallet.access_token, threadId);
+  const holderCredentialExchangeId = getCredentialIdByThreadId(holder.access_token, threadId);
 
   let acceptCredentialResponse;
   try {
     acceptCredentialResponse = retry(() => {
-      const response = acceptCredential(wallet.access_token, holderCredentialExchangeId);
+      const response = acceptCredential(holder.access_token, holderCredentialExchangeId);
       if (response.status !== 200) {
         throw new Error(`Non-200 status: ${response.status}`);
       }
@@ -160,8 +160,8 @@ export default function (data) {
   });
 
   pollAndCheck({
-    accessToken: wallet.access_token,
-    walletId: wallet.wallet_id,
+    accessToken: holder.access_token,
+    walletId: holder.wallet_id,
     topic: "credentials",
     field: "credential_exchange_id",
     fieldId: holderCredentialExchangeId,
@@ -172,12 +172,12 @@ export default function (data) {
   }, { perspective: "Holder" });
 
   const issuerData = JSON.stringify({
-    issuer_wallet_name: wallet.issuer_wallet_name,
-    issuer_wallet_id: wallet.issuer_wallet_id,
+    issuer_wallet_name: holder.issuer_wallet_name,
+    issuer_wallet_id: holder.issuer_wallet_id,
     credential_exchange_id: issuerCredentialExchangeId,
-    issuer_access_token: wallet.issuer_access_token,
-    issuer_credential_definition_id: wallet.issuer_credential_definition_id,
-    issuer_connection_id: wallet.issuer_connection_id,
+    issuer_access_token: holder.issuer_access_token,
+    issuer_credential_definition_id: holder.issuer_credential_definition_id,
+    issuer_connection_id: holder.issuer_connection_id,
     date_of_issue: epochTimestamp, // Include the epoch timestamp in output. Currently redundant, but potentially useful for future reference
   });
   file.appendString(outputFilepath, `${issuerData}\n`);

--- a/scripts/k6/scenarios/create-invitations.js
+++ b/scripts/k6/scenarios/create-invitations.js
@@ -271,7 +271,7 @@ export default function (data) {
   // log.debug(`Issuer connection ID Response Body: ${getIssuerConnectionIdResponse.body}`);
   const [{ connection_id: issuerConnectionId }] = JSON.parse(getIssuerConnectionIdResponse.body);
 
-  const holderData = JSON.stringify({
+  const connectionData = JSON.stringify({
     wallet_label: holder.wallet_label,
     wallet_name: holder.wallet_name,
     wallet_id: holder.wallet_id,
@@ -283,7 +283,7 @@ export default function (data) {
     issuer_access_token: issuer.access_token,
     issuer_credential_definition_id: issuer.credential_definition_id,
   });
-  file.appendString(outputFilepath, `${holderData}\n`);
+  file.appendString(outputFilepath, `${connectionData}\n`);
 
   testFunctionReqs.add(1);  // Count successful completions with tag
 }

--- a/scripts/k6/scenarios/create-invitations.js
+++ b/scripts/k6/scenarios/create-invitations.js
@@ -79,17 +79,17 @@ export default function (data) {
   const walletIndex = getWalletIndex(__VU, __ITER, iterations);
 
   const holders = data.holders;
-  const wallet = holders[walletIndex];
+  const holder = holders[walletIndex];
 
   const issuerIndex = getIssuerIndex(__VU, __ITER + 1);
   const issuer = issuers[issuerIndex];
 
-  log.debug(`Wallet Index: ${walletIndex}, Issuer Index: ${issuerIndex}, Issuer Wallet ID: ${issuer.walletId}`);
+  log.debug(`Wallet Index: ${walletIndex}, Issuer Index: ${issuerIndex}, Issuer Wallet ID: ${issuer.wallet_id}`);
 
   let publicDidResponse;
   try {
     publicDidResponse = retry(() => {
-      const response = getIssuerPublicDid(issuer.accessToken);
+      const response = getIssuerPublicDid(issuer.access_token);
       if (response.status !== 200) {
         throw new Error(`publicDidResponse: Non-200 status: ${response.body}`);
       }
@@ -123,7 +123,7 @@ export default function (data) {
     let createOobInvitationResponse;
     try {
       createOobInvitationResponse = retry(() => {
-        const response = createInvitation(issuer.accessToken, issuerPublicDid);
+        const response = createInvitation(issuer.access_token, issuerPublicDid);
         if (response.status !== 200) {
           throw new Error(`createOobInvitationResponse Non-200 status: ${response.body}`);
         }
@@ -148,7 +148,7 @@ export default function (data) {
     const { invitation: invitationObj } = JSON.parse(createOobInvitationResponse.body);
 
     const acceptInvitationResponse = acceptInvitation(
-      wallet.access_token,
+      holder.access_token,
       invitationObj
     );
 
@@ -168,7 +168,7 @@ export default function (data) {
     let getHolderPrivateDidResponse;
     try {
       getHolderPrivateDidResponse = retry(() => {
-        const response = getHolderConnections(wallet.access_token, holderConnectionId);
+        const response = getHolderConnections(holder.access_token, holderConnectionId);
         if (response.status !== 200) {
           throw new Error(`getHolderPrivateDidResponse Non-200 status: ${response.body}`);
         }
@@ -198,7 +198,7 @@ export default function (data) {
     let createInvitationResponse;
     try {
       createInvitationResponse = retry(() => {
-        const response = createDidExchangeRequest(wallet.access_token, issuerPublicDid);
+        const response = createDidExchangeRequest(holder.access_token, issuerPublicDid);
         if (response.status !== 200) {
           throw new Error(`createInvitationResponse Non-200 status: ${response.body}`);
         }
@@ -218,14 +218,14 @@ export default function (data) {
         return true;
       },
     });
-    const { invitation_msg_id: invitationMsgIdTemp } = JSON.parse(createInvitationResponse.body);
+    const { invitation_msg_id: invitationMsgIdTemp, connection_id: holderConnectionIdTemp } = JSON.parse(createInvitationResponse.body);
     invitationMsgId = invitationMsgIdTemp;
-    holderConnectionId = responseBody.connection_id;
+    holderConnectionId = holderConnectionIdTemp;
   }
 
   pollAndCheck({
-    accessToken: wallet.access_token,
-    walletId: wallet.wallet_id,
+    accessToken: holder.access_token,
+    walletId: holder.wallet_id,
     topic: "connections",
     field: "connection_id",
     fieldId: holderConnectionId,
@@ -236,8 +236,8 @@ export default function (data) {
   }, { perspective: "Holder" });
 
   pollAndCheck({
-    accessToken: issuer.accessToken,
-    walletId: issuer.walletId,
+    accessToken: issuer.access_token,
+    walletId: issuer.wallet_id,
     topic: "connections",
     field: "invitation_msg_id",
     fieldId: invitationMsgId,
@@ -252,7 +252,7 @@ export default function (data) {
   let getIssuerConnectionIdResponse;
   try {
     getIssuerConnectionIdResponse = retry(() => {
-      const response = getIssuerConnectionId(issuer.accessToken, invitationMsgId);
+      const response = getIssuerConnectionId(issuer.access_token, invitationMsgId);
       if (response.status !== 200) {
         throw new Error(`getIssuerConnectionId Non-200 status: ${response.status} ${response.body}`);
       }
@@ -272,16 +272,16 @@ export default function (data) {
   const [{ connection_id: issuerConnectionId }] = JSON.parse(getIssuerConnectionIdResponse.body);
 
   const holderData = JSON.stringify({
-    wallet_label: wallet.wallet_label,
-    wallet_name: wallet.wallet_name,
-    wallet_id: wallet.wallet_id,
-    access_token: wallet.access_token,
+    wallet_label: holder.wallet_label,
+    wallet_name: holder.wallet_name,
+    wallet_id: holder.wallet_id,
+    access_token: holder.access_token,
     connection_id: holderConnectionId,
     issuer_connection_id: issuerConnectionId,
-    issuer_wallet_name: issuer.walletName,
-    issuer_wallet_id: issuer.walletId,
-    issuer_access_token: issuer.accessToken,
-    issuer_credential_definition_id: issuer.credentialDefinitionId,
+    issuer_wallet_name: issuer.wallet_name,
+    issuer_wallet_id: issuer.wallet_id,
+    issuer_access_token: issuer.access_token,
+    issuer_credential_definition_id: issuer.credential_definition_id,
   });
   file.appendString(outputFilepath, `${holderData}\n`);
 

--- a/scripts/k6/scenarios/create-issuers.js
+++ b/scripts/k6/scenarios/create-issuers.js
@@ -53,8 +53,8 @@ const wallets = new SharedArray("wallets", () => {
     i++
   ) {
     walletsArray.push({
-      walletLabel: `${issuerPrefix} ${i}`,
-      walletName: `${issuerPrefix}_${i}`,
+      wallet_label: `${issuerPrefix} ${i}`,
+      wallet_name: `${issuerPrefix}_${i}`,
     });
   }
   return walletsArray;
@@ -71,11 +71,11 @@ export default function (data) {
   const tenantAdminHeaders = data.tenantAdminHeaders;
   const walletIndex = getWalletIndex(__VU, __ITER, iterations); // __ITER starts from 0, adding 1 to align with the logic
   const wallet = wallets[walletIndex];
-  const credDefTag = wallet.walletName;
+  const credDefTag = wallet.wallet_name;
 
   const createIssuerTenantResponse = createIssuerTenant(
     tenantAdminHeaders,
-    wallet.walletName
+    wallet.wallet_name
   );
   check(createIssuerTenantResponse, {
     "Issuer tenant created successfully": (r) => r.status === 200,
@@ -86,17 +86,17 @@ export default function (data) {
   );
 
   const getTrustRegistryActorResponse = getTrustRegistryActor(
-    wallet.walletName
+    wallet.wallet_name
   );
   check(getTrustRegistryActorResponse, {
     "Trust Registry Actor Response status code is 200": (r) => {
       if (r.status !== 200) {
         console.error(
-          `Unexpected response status while getting trust registry actor for issuer tenant ${wallet.walletName}: ${r.status}`
+          `Unexpected response status while getting trust registry actor for issuer tenant ${wallet.wallet_name}: ${r.status}`
         );
         return false;
       }
-      // console.log(`Got trust registry actor for issuer tenant ${wallet.walletName} successfully.`);
+      // console.log(`Got trust registry actor for issuer tenant ${wallet.wallet_name} successfully.`);
       return true;
     },
   });
@@ -107,8 +107,8 @@ export default function (data) {
   // });
 
   const issuerData = JSON.stringify({
-    wallet_label: wallet.walletLabel,
-    wallet_name: wallet.walletName,
+    wallet_label: wallet.wallet_label,
+    wallet_name: wallet.wallet_name,
     wallet_id: walletId,
     access_token: accessToken,
   });

--- a/scripts/k6/scenarios/delete-issuers.js
+++ b/scripts/k6/scenarios/delete-issuers.js
@@ -34,7 +34,7 @@ export const options = {
   },
   tags: {
     test_run_id: "phased-issuance",
-    test_phase: "delete-holders",
+    test_phase: "delete-issuers",
   },
 };
 
@@ -78,8 +78,8 @@ export default function (data) {
   const wallet = wallets[walletIndex];
 
   const walletId = getWalletIdByWalletName(tenantAdminHeaders, wallet.wallet_name);
-  const deleteHolderResponse = deleteTenant(tenantAdminHeaders, walletId);
-  check(deleteHolderResponse, {
+  const deleteIssuerResponse = deleteTenant(tenantAdminHeaders, walletId);
+  check(deleteIssuerResponse, {
     "Delete Issuer Tenant Response status code is 204": (r) => {
       if (r.status !== 204 && r.status !== 200) {
         console.error(

--- a/scripts/k6/scenarios/revoke-credentials.js
+++ b/scripts/k6/scenarios/revoke-credentials.js
@@ -52,14 +52,14 @@ export const options = {
 };
 
 export function setup() {
-  const tenants = data.trim().split("\n").map(JSON.parse);
-  return { tenants };
+  const issuers = data.trim().split("\n").map(JSON.parse);
+  return { issuers };
 }
 
 export default function (data) {
-  const tenants = data.tenants;
+  const issuers = data.issuers;
   const walletIndex = getWalletIndex(__VU, __ITER, iterations);
-  const wallet = tenants[walletIndex];
+  const issuer = issuers[walletIndex];
 
   // Check environment variable to determine revocation method
   const useAutoPublish =
@@ -71,8 +71,8 @@ export default function (data) {
   if (useAutoPublish) {
     // Option A: Use auto-publish (full flow)
     revokeCredentialResponse = revokeCredentialAutoPublish(
-      wallet.issuer_access_token,
-      wallet.credential_exchange_id
+      issuer.issuer_access_token,
+      issuer.credential_exchange_id
     );
     check(revokeCredentialResponse, {
       "Credential revoked successfully": (r) => {
@@ -81,15 +81,15 @@ export default function (data) {
             `VU ${__VU}: Iteration ${__ITER}: Unexpected response while revoking credential: ${r.response}`
           );
         }
-        log.debug(`Revoked: Wallet Index: ${walletIndex}, Issuer Connection ID: ${wallet.issuer_connection_id}`);
+        log.debug(`Revoked: Wallet Index: ${walletIndex}, Issuer Connection ID: ${issuer.issuer_connection_id}`);
         return true;
       },
     });
 
     // Check if credential is revoked when using auto-publish
     const checkRevokedCredentialResponse = checkRevoked(
-      wallet.issuer_access_token,
-      wallet.credential_exchange_id
+      issuer.issuer_access_token,
+      issuer.credential_exchange_id
     );
     check(checkRevokedCredentialResponse, {
       "Credential state is revoked": (r) => {
@@ -111,8 +111,8 @@ export default function (data) {
     // Option B: Only revoke (no publish, no check)
     // log.debug(`Revoking credential without auto-publish.`);
     revokeCredentialResponse = revokeCredential(
-      wallet.issuer_access_token,
-      wallet.credential_exchange_id
+      issuer.issuer_access_token,
+      issuer.credential_exchange_id
     );
     check(revokeCredentialResponse, {
       "Credential revoked successfully": (r) => {


### PR DESCRIPTION
  ### Changes
  - **Variable naming consistency**: Renamed misleading variables (`wallet` → `connection`/`holder`/`issuer`) throughout scenarios for clarity
  - **Parallel execution fix**: Store original Docker environment values as `CONFIGURED_VUS`/`CONFIGURED_ITERATIONS` to prevent serial execution pollution in
  `run_scenario_parallel()`
  - **Performance improvements**: Removed unnecessary sleep statements in revocation and invitation flows
  - **Bug fixes**: Fixed variable references and improved error handling across scenarios

  ### Key fixes
  - `create-proof.js`: Replace misleading `wallet` variable with `connection`
  - `revoke-credentials.js`: Replace misleading `wallet` variable with `issuer`
  - `create-invitations.js`: Replace misleading `wallet` variable with `connection`, fix connection ID extraction
  - `batch.sh`: Fix parallel execution strategy to use original Docker Compose values