### PR TITLE
🧑‍💻 Tilt no cheqd

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -46,7 +46,7 @@ run = "poetry lock --regenerate"
 [tasks."tilt:up"]
 description = "Start Tilt"
 depends = ["kind:create"]
-run = "tilt up"
+run = "tilt up -- $@"
 
 [tasks."tilt:up:podman"]
 description = "Start Tilt with Podman"

--- a/Tiltfile
+++ b/Tiltfile
@@ -17,6 +17,7 @@ config.define_bool(
     False,
     "Detect Host IP and set Ingress Domain Name to expose services outside of 'localhost' context",
 )
+config.define_bool("no-cheqd")
 cfg = config.parse()
 
 
@@ -83,7 +84,8 @@ cmd_button(
 # Setup acapy-cloud
 build_enabled = not cfg.get("no-build")
 expose = cfg.get("expose")
-setup_cloudapi(build_enabled, expose)
+cheqd_self_hosted = not cfg.get("no-cheqd")
+setup_cloudapi(build_enabled, expose, cheqd_self_hosted)
 
 if config.tilt_subcommand not in ("down"):
     # _FORCE_ Kube Context to `kind-acapy-cloud`

--- a/tilt/README.md
+++ b/tilt/README.md
@@ -1,0 +1,7 @@
+# Linting
+
+Linting
+
+```bash
+mise run fmt
+```

--- a/tilt/acapy-cloud/Tiltfile
+++ b/tilt/acapy-cloud/Tiltfile
@@ -758,13 +758,17 @@ def setup_cloudapi(build_enabled, expose, cheqd_self_hosted=True):
             "depends": ["did-resolver"],
             "flags": [
                 "--set",
-                "secretData.FEE_PAYER_TESTNET_MNEMONIC=" + (
-                    "" if not cheqd_self_hosted else cheqd_validator_mnemonic
-                ),
-            ] + ([
-                "--set",
-                "env.TESTNET_RPC_URL=https://rpc.cheqd.network",
-            ] if not cheqd_self_hosted else []),
+                "secretData.FEE_PAYER_TESTNET_MNEMONIC="
+                + ("" if not cheqd_self_hosted else cheqd_validator_mnemonic),
+            ]
+            + (
+                [
+                    "--set",
+                    "env.TESTNET_RPC_URL=https://rpc.cheqd.network",
+                ]
+                if not cheqd_self_hosted
+                else []
+            ),
         },
         "did-registrar": {
             # https://github.com/decentralized-identity/universal-registrar
@@ -776,10 +780,15 @@ def setup_cloudapi(build_enabled, expose, cheqd_self_hosted=True):
             "flags": [
                 "--set",
                 "ingressDomain=" + ingress_domain,
-            ] + ([
-                "--set",
-                "env.TESTNET_ENDPOINT=grpc.cheqd.network:443\\,true\\,5s",
-            ] if not cheqd_self_hosted else []),
+            ]
+            + (
+                [
+                    "--set",
+                    "env.TESTNET_ENDPOINT=grpc.cheqd.network:443\\,true\\,5s",
+                ]
+                if not cheqd_self_hosted
+                else []
+            ),
             "links": [
                 link(
                     "http://resolver.cheqd." + ingress_domain + "/1.0/identifiers/",

--- a/tilt/acapy-cloud/Tiltfile
+++ b/tilt/acapy-cloud/Tiltfile
@@ -758,7 +758,9 @@ def setup_cloudapi(build_enabled, expose, cheqd_self_hosted=True):
             "depends": ["did-resolver"],
             "flags": [
                 "--set",
-                "secretData.FEE_PAYER_TESTNET_MNEMONIC=" + cheqd_validator_mnemonic,
+                "secretData.FEE_PAYER_TESTNET_MNEMONIC=" + (
+                    "" if not cheqd_self_hosted else cheqd_validator_mnemonic
+                ),
             ] + ([
                 "--set",
                 "env.TESTNET_RPC_URL=https://rpc.cheqd.network",

--- a/tilt/acapy-cloud/Tiltfile
+++ b/tilt/acapy-cloud/Tiltfile
@@ -19,6 +19,7 @@ cheqd_validator_mnemonic = (
     "betray purity grief spatial rude select loud reason wolf harvest session awesome"
 )
 
+
 registry = "localhost:5001"
 
 # Detect CPU Architecture
@@ -447,7 +448,7 @@ def add_live_update(live_update_config, enabled):
     return []
 
 
-def setup_cheqd_localnet(namespace, ingress_domain):
+def setup_cheqd_localnet(namespace, ingress_domain, cheqd_self_hosted=True):
     print(color.green("Installing Cheqd Localnet..."))
 
     project_root = os.getcwd()
@@ -459,6 +460,7 @@ def setup_cheqd_localnet(namespace, ingress_domain):
         ingress_domain,
         build_enabled=False,
         release_config={
+            "enabled": cheqd_self_hosted,
             "flags": [
                 "--set",
                 "secrets.validatorMnemonic=" + cheqd_validator_mnemonic,
@@ -491,7 +493,7 @@ def setup_cheqd_localnet(namespace, ingress_domain):
     )
 
 
-def setup_cloudapi(build_enabled, expose):
+def setup_cloudapi(build_enabled, expose, cheqd_self_hosted=True):
     print(color.green("Installing CloudAPI..."))
 
     # Adopt and manage CloudAPI namespace
@@ -504,7 +506,7 @@ def setup_cloudapi(build_enabled, expose):
     ingress_domain = generate_ingress_domain(expose)
     print(color.green("Ingress Domain: " + ingress_domain))
 
-    setup_cheqd_localnet(namespace, ingress_domain)
+    setup_cheqd_localnet(namespace, ingress_domain, cheqd_self_hosted)
     setup_minio(namespace, ingress_domain)
     setup_nats(namespace)
     setup_pgadmin(namespace, ingress_domain)
@@ -757,7 +759,10 @@ def setup_cloudapi(build_enabled, expose):
             "flags": [
                 "--set",
                 "secretData.FEE_PAYER_TESTNET_MNEMONIC=" + cheqd_validator_mnemonic,
-            ],
+            ] + ([
+                "--set",
+                "env.TESTNET_RPC_URL=https://rpc.cheqd.network",
+            ] if not cheqd_self_hosted else []),
         },
         "did-registrar": {
             # https://github.com/decentralized-identity/universal-registrar
@@ -765,11 +770,14 @@ def setup_cloudapi(build_enabled, expose):
         },
         "did-resolver": {
             # https://github.com/cheqd/did-resolver
-            "depends": ["cheqd"],
+            "depends": ["cheqd"] if cheqd_self_hosted else [],
             "flags": [
                 "--set",
                 "ingressDomain=" + ingress_domain,
-            ],
+            ] + ([
+                "--set",
+                "env.TESTNET_ENDPOINT=grpc.cheqd.network:443\\,true\\,5s",
+            ] if not cheqd_self_hosted else []),
             "links": [
                 link(
                     "http://resolver.cheqd." + ingress_domain + "/1.0/identifiers/",


### PR DESCRIPTION
 Adds the ability to choose between self-hosted cheqd node deployment or using the Cheqd Testnet
 - New flag: --no-cheqd to disable self-hosted cheqd deployment
  - Dynamic configuration:
    - did-resolver uses grpc.cheqd.network:443,true,5s when centralized
    - driver-did-cheqd uses https://rpc.cheqd.network and empty mnemonic when centralized
    - Removes cheqd service dependency when not self-hosted
  - Improved mise integration: Enable passing Tiltfile arguments through mise tasks
  
  # Self-hosted cheqd (default behavior)
  mise run tilt:up

  # Use Cheqd Testnet (faucet wallet)
  mise run tilt:up -- --no-cheqd

  # Fast startup: pre-built images + Cheqd Testnet
  mise run tilt:up -- --no-build --no-cheqd