### PR TITLE
:art: Remove create-tenant "extra settings" example

### DIFF
--- a/app/models/tenants.py
+++ b/app/models/tenants.py
@@ -43,8 +43,10 @@ ExtraSettings = Literal[
 ]
 ExtraSettings_field = Field(
     None,
-    description="Optional per-tenant settings to configure wallet behaviour for advanced users.",
-    examples=[{"ACAPY_AUTO_ACCEPT_INVITES": False}],
+    description=(
+        "Optional, advanced settings to configure wallet behaviour. If you don't know what these are, "
+        "then you probably don't need them."
+    ),
 )
 
 

--- a/docs/openapi/tenant-admin-openapi.json
+++ b/docs/openapi/tenant-admin-openapi.json
@@ -549,12 +549,7 @@
               }
             ],
             "title": "Extra Settings",
-            "description": "Optional per-tenant settings to configure wallet behaviour for advanced users.",
-            "examples": [
-              {
-                "ACAPY_AUTO_ACCEPT_INVITES": false
-              }
-            ]
+            "description": "Optional, advanced settings to configure wallet behaviour. If you don't know what these are, then you probably don't need them."
           }
         },
         "type": "object",
@@ -829,12 +824,7 @@
               }
             ],
             "title": "Extra Settings",
-            "description": "Optional per-tenant settings to configure wallet behaviour for advanced users.",
-            "examples": [
-              {
-                "ACAPY_AUTO_ACCEPT_INVITES": false
-              }
-            ]
+            "description": "Optional, advanced settings to configure wallet behaviour. If you don't know what these are, then you probably don't need them."
           }
         },
         "type": "object",

--- a/docs/openapi/tenant-admin-openapi.yaml
+++ b/docs/openapi/tenant-admin-openapi.yaml
@@ -345,9 +345,7 @@ components:
               type: object
             - type: 'null'
           title: Extra Settings
-          description: Optional per-tenant settings to configure wallet behaviour for advanced users.
-          examples:
-            - ACAPY_AUTO_ACCEPT_INVITES: false
+          description: Optional, advanced settings to configure wallet behaviour. If you don't know what these are, then you probably don't need them.
       type: object
       required:
         - wallet_label
@@ -517,9 +515,7 @@ components:
               type: object
             - type: 'null'
           title: Extra Settings
-          description: Optional per-tenant settings to configure wallet behaviour for advanced users.
-          examples:
-            - ACAPY_AUTO_ACCEPT_INVITES: false
+          description: Optional, advanced settings to configure wallet behaviour. If you don't know what these are, then you probably don't need them.
       type: object
       title: UpdateTenantRequest
     ValidationError:


### PR DESCRIPTION
This change removes the existing example that was used in the `extra_settings` field for the CreateTenant endpoint.

The example was there in order to illustrate an advanced-user setting (changing `ACAPY_AUTO_ACCEPT_INVITES` to False), but this has the drawback of that example being auto-filled, in the Scalar UI, in the sample create tenant request payload. Meaning, if someone naively creates a tenant with the example request, then the auto-accept flags would be disabled, breaking the recommended flows. Rather than changing the example to set the auto-accept value to True, it's better to just remove it, and avoid all confusion, since True is already the default behaviour.

The extra_settings field description is also updated to indicate that it is only relevant for advanced use cases.