### PR TITLE
:arrow_up: Bump Cheqd Localnet Node from 4.1.0 to 4.1.1

### DIFF
--- a/helm/cheqd/conf/localnet/values.yaml
+++ b/helm/cheqd/conf/localnet/values.yaml
@@ -1,6 +1,6 @@
 # https://github.com/cheqd/cheqd-node
 image:
-  tag: 4.1.0
+  tag: 4.1.1
 
 podLabels:
   sidecar.istio.io/inject: "false"


### PR DESCRIPTION
* Bring localnet version in parity with testnet

---

@wdbasson, this only affects localnet.
This is the version of the node that Cheqd is using in Testnet.
This brings local version in parity with what is running in the actual Testnet.