### PR TITLE
✅ Configure auto-publish revocations from env only

### DIFF
--- a/scripts/k6/scripts/batch.sh
+++ b/scripts/k6/scripts/batch.sh
@@ -100,6 +100,7 @@ scenario_create_credentials() {
 }
 
 scenario_create_proof_verified() {
+  export IS_REVOKED=false
   run_scenario_parallel ./scenarios/create-proof.js
 }
 
@@ -173,7 +174,6 @@ run_batch() {
   scenario_create_invitations
   scenario_create_credentials
   scenario_create_proof_verified
-  export USE_AUTO_PUBLISH=false
   scenario_revoke_credentials
   scenario_publish_revoke
   scenario_create_proof_unverified


### PR DESCRIPTION
It is already configurable in compose, but was hard-coded and overridden in `batch.sh`.