### PR TITLE
:adhesive_bandage: Preserve uncommitted submodule changes in Tilt

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -33,7 +33,7 @@ allow_k8s_contexts([kind_cluster_name])
 if config.tilt_subcommand in ("up", "ci"):
     print(color.green("Ensuring submodules are initialized and updated"))
     run_command(
-        "git submodule update --init --recursive",
+        "git submodule update --init --recursive --merge",
         dir=os.path.dirname(__file__),
     )
     print(color.green("Setting up Istio"))


### PR DESCRIPTION
Add `--merge` flag to `git submodule update` command to prevent 
resetting uncommitted changes in submodules during Tilt startup.

The previous command would discard any uncommitted changes in 
submodule directories when initializing/updating. Adding `--merge` 
preserves local modifications while still ensuring submodules are 
properly initialized for development workflows.