### PR TITLE
:adhesive_bandage: Only initialize uninitialized submodules in Tilt

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -31,9 +31,9 @@ kind_cluster_name = "kind-acapy-cloud"
 allow_k8s_contexts([kind_cluster_name])
 
 if config.tilt_subcommand in ("up", "ci"):
-    print(color.green("Ensuring submodules are initialized and updated"))
+    print(color.green("Ensuring submodules are initialized"))
     run_command(
-        "git submodule update --init --recursive --merge",
+        "git submodule status | awk '/^-/ {print $2}' | xargs -r git submodule update --init",
         dir=os.path.dirname(__file__),
     )
     print(color.green("Setting up Istio"))


### PR DESCRIPTION
Change submodule handling to only initialize submodules that are 
not already initialized, avoiding any potential disruption to 
existing submodule state.

* Update message to reflect initialization-only behavior
* Use `git submodule status | awk '/^-/ {print $2}'` to extract 
  paths of uninitialized submodules (those with `-` prefix)
* Use `xargs -r git submodule update --init` to initialize only 
  the specific submodules that need it
* The `-r` flag prevents `xargs` from running when no 
  uninitialized submodules exist

Git submodule status prefixes:
* ` ` (space) - initialized submodule at correct commit
* `-` - uninitialized submodule 
* `+` - initialized submodule with different commit than expected

This approach is more precise and efficient, only initializing 
the specific submodules that require it while preserving existing 
submodule state for development workflows.