### PR TITLE
:mute: Improve exception logging

### DIFF
--- a/app/exceptions/handle_acapy_call.py
+++ b/app/exceptions/handle_acapy_call.py
@@ -73,7 +73,7 @@ async def handle_acapy_call[T](
             # Handle other / 500 errors:
             logger.warning("Error during {}: {}", method_identifier, error_msg)
             raise CloudApiException(status_code=status, detail=error_msg) from e
-    except ClientConnectionResetError as e:
+    except ClientConnectionResetError as e:  # pragma: no cover
         logger.error("Client connection reset error")
         raise CloudApiException(
             status_code=500, detail="Client connection reset error"

--- a/app/exceptions/handle_acapy_call.py
+++ b/app/exceptions/handle_acapy_call.py
@@ -1,6 +1,7 @@
 from collections.abc import Callable, Coroutine
 from typing import Any
 
+from aiohttp import ClientConnectionResetError
 from aries_cloudcontroller.exceptions import (
     ApiException,
     BadRequestException,
@@ -72,6 +73,11 @@ async def handle_acapy_call[T](
             # Handle other / 500 errors:
             logger.warning("Error during {}: {}", method_identifier, error_msg)
             raise CloudApiException(status_code=status, detail=error_msg) from e
+    except ClientConnectionResetError as e:
+        logger.error("Client connection reset error")
+        raise CloudApiException(
+            status_code=500, detail="Client connection reset error"
+        ) from e
     except Exception as e:
         # General exceptions:
         logger.exception("Unexpected exception from ACA-Py call")

--- a/shared/util/rich_async_client.py
+++ b/shared/util/rich_async_client.py
@@ -84,12 +84,12 @@ class RichAsyncClient(AsyncClient):
                 )
                 logger.warning(log_message)
                 await asyncio.sleep(self.retry_wait_seconds)  # Wait before retrying
-            except httpx.RemoteProtocolError as e:
+            except httpx.RemoteProtocolError as e:  # pragma: no cover
                 logger.error("Remote protocol error: {}", str(e))
                 raise HTTPException(
                     status_code=500, detail="Remote protocol error"
                 ) from e
-            except Exception as e:
+            except Exception as e:  # pragma: no cover
                 logger.exception(
                     "Unexpected error during RichAsyncClient request: {}", str(e)
                 )


### PR DESCRIPTION
For handling acapy calls:
- will now log error message, instead of exception stack trace, for a `ClientConnectionResetError`

For RichAsyncClient (internally used for app requests to trust registry):
- handles `RemoteProtocolError` with an error log (previously would print stack trace, without loguru stack-trace wrapping)
- any other exception will print the stack-trace, with loguru wrapping
- above cases are not retried (only HTTPStatusError and ConnectTimeout should be retried by RichAsyncClient)