### PR TITLE
:recycle: Simplify snapshot download and pin genesis URL

### DIFF
--- a/helm/cheqd/templates/statefulset.yaml
+++ b/helm/cheqd/templates/statefulset.yaml
@@ -96,7 +96,7 @@ spec:
               if [ ! -f /cheqd/config/genesis.json ]; then
                 echo "Genesis file not found, downloading..."
                 wget -qO /cheqd/config/genesis.json \
-                  https://raw.githubusercontent.com/cheqd/cheqd-node/refs/heads/main/networks/{{ .Values.network }}/genesis.json
+                  https://raw.githubusercontent.com/cheqd/cheqd-node/refs/tags/v{{ .Values.image.tag | default .Chart.AppVersion }}/networks/{{ .Values.network }}/genesis.json
               else
                 echo "Genesis file already exists, skipping download."
               fi
@@ -132,33 +132,21 @@ spec:
               apk add --no-cache --update lz4 aria2
 
               SNAPSHOT_FILE="/cheqd/{{ tpl .Values.snapshot.filename . }}"
-              ARIA2_FILE="${SNAPSHOT_FILE}.aria2"
+              echo "Downloading snapshot..."
+              echo "Snapshot file: ${SNAPSHOT_FILE}"
+              echo "Snapshot network: {{ .Values.network }}"
 
-              # Download snapshot if needed
-              if [ -f "${ARIA2_FILE}" ]; then
-                echo "Partial download detected, continuing..."
-              elif [ -f "${SNAPSHOT_FILE}" ]; then
-                echo "Snapshot file already exists, skipping download..."
-              else
-                echo "Starting snapshot download..."
-              fi
-
-              if [ ! -f "${SNAPSHOT_FILE}" ] || [ -f "${ARIA2_FILE}" ]; then
-                echo "Downloading snapshot..."
-                echo "Snapshot date: {{ .Values.snapshot.date }}"
-                echo "Snapshot network: {{ .Values.network }}"
-
-                aria2c --split=8 \
-                  --max-connection-per-server=8 \
-                  --continue=true \
-                  {{- if .Values.snapshot.checksum }}
-                  --check-integrity=true \
-                  --checksum=sha-256={{ .Values.snapshot.checksum }} \
-                  {{- end }}
-                  --dir=/cheqd \
-                  --out={{ tpl .Values.snapshot.filename . }} \
-                  {{ tpl .Values.snapshot.url . }}
-              fi
+              # Download snapshot
+              aria2c --split=8 \
+                --max-connection-per-server=8 \
+                --continue=true \
+                {{- if .Values.snapshot.checksum }}
+                --check-integrity=true \
+                --checksum=sha-256={{ .Values.snapshot.checksum }} \
+                {{- end }}
+                --dir=/cheqd \
+                --out={{ tpl .Values.snapshot.filename . }} \
+                {{ tpl .Values.snapshot.url . }}
 
               # Extract snapshot
               echo "Extracting snapshot..."


### PR DESCRIPTION
* Remove redundant conditional checks for existing snapshot files
  and partial downloads in the snapshot download logic
* Update genesis.json URL to use versioned branch
  (`v{{ .Values.image.tag }}`) instead of `main` branch
* Streamline aria2c download process by removing file existence
  checks that were causing unnecessary complexity

The snapshot download now consistently downloads fresh snapshots
without checking for existing files, making the process more
predictable and easier to debug. The genesis URL fix ensures
compatibility with specific node versions rather than always
pulling from the main branch.