### PR TITLE
:wrench: Disable PDB for Valkey with single replica

### DIFF
--- a/helm/acapy-cloud/conf/valkey.yaml
+++ b/helm/acapy-cloud/conf/valkey.yaml
@@ -14,6 +14,8 @@ primary:
     whenDeleted: Delete
   podLabels:
     sidecar.istio.io/inject: "false"
+  pdb:
+    create: false
 replica:
   replicaCount: 0
   resourcesPreset: nano
@@ -26,3 +28,5 @@ replica:
   podLabels:
     sidecar.istio.io/inject: "false"
   podManagementPolicy: Parallel
+  pdb:
+    create: false


### PR DESCRIPTION
With `primary.replicaCount=1` and `replica.replicaCount=0`, the 
default Pod Disruption Budget `maxUnavailable=1` prevents proper 
pod rolling during deployments. Kubernetes cannot safely evict the 
only available pod, blocking updates.

Disable PDB creation for both primary and replica configurations 
to allow smooth rolling updates in single-pod scenarios.