### PR TITLE
:arrow_up: Update Helm chart dependencies to latest versions

### DIFF
--- a/helm/acapy-cloud.yaml.gotmpl
+++ b/helm/acapy-cloud.yaml.gotmpl
@@ -170,7 +170,7 @@ releases:
       app: valkey
     namespace: {{ .Values.namespace }}
     chart: oci://registry-1.docker.io/bitnamicharts/valkey
-    version: 3.0.20
+    version: 3.0.22
     values:
       - ./acapy-cloud/conf/valkey.yaml
       - primary:
@@ -186,7 +186,7 @@ releases:
       app: postgres
     namespace: {{ .Values.namespace }}
     chart: oci://registry-1.docker.io/bitnamicharts/postgresql-ha
-    version: 16.0.18
+    version: 16.0.22
     values:
       - ./acapy-cloud/conf/postgres.yaml
       - postgresql:
@@ -261,7 +261,7 @@ releases:
     installed: {{ .Values.minio.enabled }}
     namespace: {{ .Values.namespace }}
     chart: oci://registry-1.docker.io/bitnamicharts/minio
-    version: 17.0.11
+    version: 17.0.15
     labels:
       app: minio
     values:

--- a/tilt/acapy-cloud/Tiltfile
+++ b/tilt/acapy-cloud/Tiltfile
@@ -3,15 +3,15 @@ load("ext://color", "color")
 load("ext://helm_resource", "helm_resource", "helm_repo")
 
 # https://github.com/bitnami/charts/tree/main/bitnami/minio
-minio_version = "17.0.11"
+minio_version = "17.0.15"
 # https://github.com/rowanruseler/helm-charts/tree/main/charts/pgadmin4
 pgadmin_version = "1.47.0"
 # https://github.com/bitnami/charts/tree/main/bitnami/postgresql-ha
-postgres_version = "16.0.18"
+postgres_version = "16.0.22"
 # https://github.com/redpanda-data/helm-charts/tree/main/charts/connect
 redpanda_connect_version = "3.0.3"
 # https://github.com/bitnami/charts/tree/main/bitnami/valkey
-valkey_version = "3.0.20"
+valkey_version = "3.0.22"
 
 # Mnemonic for the Cheqd Localnet Validator
 # Will be used for Localnet as well as the Fee Payer for Cheqd DID Driver


### PR DESCRIPTION
Upgrade several Bitnami Helm chart dependencies to their latest
patch versions:

* valkey: 3.0.20 → 3.0.22
* postgresql-ha: 16.0.18 → 16.0.22  
* minio: 17.0.11 → 17.0.15

These updates include bug fixes and security improvements. Version
numbers are synchronized between the main Helm template file
(`helm/acapy-cloud.yaml.gotmpl`) and the Tilt development
configuration (`tilt/acapy-cloud/Tiltfile`).