### PR TITLE
:green_heart: Temporarily disable Codacy SARIF upload

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -56,8 +56,11 @@ jobs:
           # This will handover control about PR rejection to the GitHub side
           max-allowed-issues: 2147483647
 
-      # Upload the SARIF file generated in the previous step
-      - name: Upload SARIF results file
-        uses: github/codeql-action/upload-sarif@51f77329afa6477de8c49fc9c7046c15b9a4e79d # v3.29.5
-        with:
-          sarif_file: results.sarif
+      ## Disabled, pending fix for:
+      ## - https://github.blog/changelog/2025-07-21-code-scanning-will-stop-combining-multiple-sarif-runs-uploaded-in-the-same-sarif-file
+      ## - https://github.com/codacy/codacy-analysis-cli-action/issues/142
+      # # Upload the SARIF file generated in the previous step
+      # - name: Upload SARIF results file
+      #   uses: github/codeql-action/upload-sarif@51f77329afa6477de8c49fc9c7046c15b9a4e79d # v3.29.5
+      #   with:
+      #     sarif_file: results.sarif


### PR DESCRIPTION
Disable SARIF upload due to pending fixes in related dependencies and
to avoid issues with code scanning.
The upload will be re-enabled once the upstream issues are resolved.

---

https://github.blog/changelog/2025-07-21-code-scanning-will-stop-combining-multiple-sarif-runs-uploaded-in-the-same-sarif-file

https://github.com/codacy/codacy-analysis-cli-action/issues/142