### PR TITLE
:arrow_up: Update helm infra

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -52,8 +52,8 @@ permissions: {}
 
 env:
   HELM_VERSION: v3.18.4
-  HELMFILE_VERSION: v1.1.2
-  MISE_VERSION: 2025.7.3
+  HELMFILE_VERSION: v1.1.3
+  MISE_VERSION: 2025.8.4
 
   RESET_DEPLOYMENTS: ${{ github.event.inputs.reset-deployments || 'false' }}
   RUN_E2E_TESTS: ${{ github.event.inputs.run-e2e-tests || 'true' }}

--- a/.github/workflows/deploy-test-eks.yml
+++ b/.github/workflows/deploy-test-eks.yml
@@ -116,7 +116,7 @@ concurrency:
 
 env:
   HELM_VERSION_DEFAULT: v3.18.4
-  HELMFILE_VERSION_DEFAULT: v1.1.2
+  HELMFILE_VERSION_DEFAULT: v1.1.3
 
 jobs:
   deploy:

--- a/helm/acapy-cloud.yaml.gotmpl
+++ b/helm/acapy-cloud.yaml.gotmpl
@@ -186,7 +186,7 @@ releases:
       app: postgres
     namespace: {{ .Values.namespace }}
     chart: oci://registry-1.docker.io/bitnamicharts/postgresql-ha
-    version: 16.0.22
+    version: 16.1.0
     values:
       - ./acapy-cloud/conf/postgres.yaml
       - postgresql:
@@ -261,7 +261,7 @@ releases:
     installed: {{ .Values.minio.enabled }}
     namespace: {{ .Values.namespace }}
     chart: oci://registry-1.docker.io/bitnamicharts/minio
-    version: 17.0.15
+    version: 17.0.16
     labels:
       app: minio
     values:

--- a/helm/nats/Chart.lock
+++ b/helm/nats/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 2.31.3
 - name: nats
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 9.0.23
-digest: sha256:2c6bbd3a950af91c243f4cb72a3d26e953a163f6eabc1c177d1e0f9893e59024
-generated: "2025-07-10T16:25:07.625929+02:00"
+  version: 9.0.24
+digest: sha256:30d7da8f3e0150aa25296881096d5dcde457f3bdc3c72bf67de9ab780e8f28eb
+generated: "2025-08-04T14:26:48.741166+02:00"

--- a/tilt/acapy-cloud/Tiltfile
+++ b/tilt/acapy-cloud/Tiltfile
@@ -3,11 +3,11 @@ load("ext://color", "color")
 load("ext://helm_resource", "helm_resource", "helm_repo")
 
 # https://github.com/bitnami/charts/tree/main/bitnami/minio
-minio_version = "17.0.15"
+minio_version = "17.0.16"
 # https://github.com/rowanruseler/helm-charts/tree/main/charts/pgadmin4
 pgadmin_version = "1.47.0"
 # https://github.com/bitnami/charts/tree/main/bitnami/postgresql-ha
-postgres_version = "16.0.22"
+postgres_version = "16.1.0"
 # https://github.com/redpanda-data/helm-charts/tree/main/charts/connect
 redpanda_connect_version = "3.0.3"
 # https://github.com/bitnami/charts/tree/main/bitnami/valkey


### PR DESCRIPTION
Upgrade multiple dependencies to their latest versions:

* Helmfile: v1.1.2 → v1.1.3
* Mise: 2025.7.3 → 2025.8.4
* PostgreSQL HA chart: 16.0.22 → 16.1.0
* MinIO chart: 17.0.15 → 17.0.16
* NATS chart: 9.0.23 → 9.0.24

Updates apply across CI/CD workflows, Helm configurations, and
Tilt development environment to maintain consistency and benefit
from latest bug fixes and improvements.