### PR TITLE
:arrow_up: Update dependencies and tools

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -52,8 +52,8 @@ permissions: {}
 
 env:
   HELM_VERSION: v3.18.4
-  HELMFILE_VERSION: v1.1.3
-  MISE_VERSION: 2025.8.4
+  HELMFILE_VERSION: v1.1.4
+  MISE_VERSION: 2025.8.7
 
   RESET_DEPLOYMENTS: ${{ github.event.inputs.reset-deployments || 'false' }}
   RUN_E2E_TESTS: ${{ github.event.inputs.run-e2e-tests || 'true' }}

--- a/.github/workflows/deploy-test-eks.yml
+++ b/.github/workflows/deploy-test-eks.yml
@@ -116,7 +116,7 @@ concurrency:
 
 env:
   HELM_VERSION_DEFAULT: v3.18.4
-  HELMFILE_VERSION_DEFAULT: v1.1.3
+  HELMFILE_VERSION_DEFAULT: v1.1.4
 
 jobs:
   deploy:
@@ -139,7 +139,7 @@ jobs:
           persist-credentials: false
 
       - name: Connect to EKS
-        uses: didx-xyz/workflows/connect-eks@db85590d7cdd99f3eb257b0526d905263eca8499 # master
+        uses: didx-xyz/workflows/connect-eks@f45db9156cccb0d7bd1ebf2c940fe5d55f4eb690 # master
         with:
           aws-region: af-south-1
           aws-role-arn: arn:aws:iam::402177810328:role/cicd
@@ -224,7 +224,7 @@ jobs:
           persist-credentials: false
 
       - name: Connect to EKS
-        uses: didx-xyz/workflows/connect-eks@db85590d7cdd99f3eb257b0526d905263eca8499 # master
+        uses: didx-xyz/workflows/connect-eks@f45db9156cccb0d7bd1ebf2c940fe5d55f4eb690 # master
         with:
           aws-region: af-south-1
           aws-role-arn: arn:aws:iam::402177810328:role/cicd
@@ -404,7 +404,7 @@ jobs:
           persist-credentials: false
 
       - name: Connect to EKS
-        uses: didx-xyz/workflows/connect-eks@db85590d7cdd99f3eb257b0526d905263eca8499 # master
+        uses: didx-xyz/workflows/connect-eks@f45db9156cccb0d7bd1ebf2c940fe5d55f4eb690 # master
         with:
           aws-region: af-south-1
           aws-role-arn: arn:aws:iam::402177810328:role/cicd
@@ -586,7 +586,7 @@ jobs:
           persist-credentials: false
 
       - name: Connect to EKS
-        uses: didx-xyz/workflows/connect-eks@db85590d7cdd99f3eb257b0526d905263eca8499 # master
+        uses: didx-xyz/workflows/connect-eks@f45db9156cccb0d7bd1ebf2c940fe5d55f4eb690 # master
         with:
           aws-region: af-south-1
           aws-role-arn: arn:aws:iam::402177810328:role/cicd

--- a/helm/acapy-cloud.yaml.gotmpl
+++ b/helm/acapy-cloud.yaml.gotmpl
@@ -170,7 +170,7 @@ releases:
       app: valkey
     namespace: {{ .Values.namespace }}
     chart: oci://registry-1.docker.io/bitnamicharts/valkey
-    version: 3.0.22
+    version: 3.0.28
     values:
       - ./acapy-cloud/conf/valkey.yaml
       - primary:
@@ -186,7 +186,7 @@ releases:
       app: postgres
     namespace: {{ .Values.namespace }}
     chart: oci://registry-1.docker.io/bitnamicharts/postgresql-ha
-    version: 16.1.0
+    version: 16.1.2
     values:
       - ./acapy-cloud/conf/postgres.yaml
       - postgresql:
@@ -202,7 +202,7 @@ releases:
       app: pgadmin
     namespace: {{ .Values.namespace }}
     chart: runix/pgadmin4
-    version: 1.47.0
+    version: 1.48.0
     installed: {{ .Values.pgAdmin.enabled }}
     values:
       - ./acapy-cloud/conf/pgadmin.yaml
@@ -261,7 +261,7 @@ releases:
     installed: {{ .Values.minio.enabled }}
     namespace: {{ .Values.namespace }}
     chart: oci://registry-1.docker.io/bitnamicharts/minio
-    version: 17.0.16
+    version: 17.0.19
     labels:
       app: minio
     values:

--- a/helm/nats/Chart.lock
+++ b/helm/nats/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 2.31.3
 - name: nats
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 9.0.24
-digest: sha256:30d7da8f3e0150aa25296881096d5dcde457f3bdc3c72bf67de9ab780e8f28eb
-generated: "2025-08-04T14:26:48.741166+02:00"
+  version: 9.0.25
+digest: sha256:788e172bc0b9ac605a4d5c53b761f891de261f27d1811e8eea2eead7fda1354c
+generated: "2025-08-11T11:06:25.197106+02:00"

--- a/tilt/acapy-cloud/Tiltfile
+++ b/tilt/acapy-cloud/Tiltfile
@@ -3,15 +3,15 @@ load("ext://color", "color")
 load("ext://helm_resource", "helm_resource", "helm_repo")
 
 # https://github.com/bitnami/charts/tree/main/bitnami/minio
-minio_version = "17.0.16"
+minio_version = "17.0.19"
 # https://github.com/rowanruseler/helm-charts/tree/main/charts/pgadmin4
-pgadmin_version = "1.47.0"
+pgadmin_version = "1.48.0"
 # https://github.com/bitnami/charts/tree/main/bitnami/postgresql-ha
-postgres_version = "16.1.0"
+postgres_version = "16.1.2"
 # https://github.com/redpanda-data/helm-charts/tree/main/charts/connect
 redpanda_connect_version = "3.0.3"
 # https://github.com/bitnami/charts/tree/main/bitnami/valkey
-valkey_version = "3.0.22"
+valkey_version = "3.0.28"
 
 # Mnemonic for the Cheqd Localnet Validator
 # Will be used for Localnet as well as the Fee Payer for Cheqd DID Driver

--- a/tilt/metrics/Tiltfile
+++ b/tilt/metrics/Tiltfile
@@ -22,7 +22,7 @@ def setup_metrics_server():
             "--set",
             "extraArgs[1]=--kubelet-insecure-tls",
             "--version",
-            "7.4.10",
+            "7.4.11",
             "--wait",
         ],
         labels=["30-monitoring"],


### PR DESCRIPTION
This commit updates multiple dependencies and tools to their latest
versions to ensure security patches and improved functionality:

* Update Helmfile from v1.1.3 to v1.1.4 in CI workflows
* Update Mise from 2025.8.4 to 2025.8.7 in CI workflows
* Update `didx-xyz/workflows/connect-eks` action to latest commit
* Upgrade Helm chart versions:
  * Valkey: 3.0.22 → 3.0.28
  * PostgreSQL HA: 16.1.0 → 16.1.2
  * pgAdmin4: 1.47.0 → 1.48.0
  * MinIO: 17.0.16 → 17.0.19
  * NATS: 9.0.24 → 9.0.25
  * Metrics Server: 7.4.10 -> 7.4.11
* Update corresponding version references in Tiltfile
* Regenerate Chart.lock with updated dependencies

These updates include bug fixes, security improvements, and feature
enhancements from upstream projects.