### PR TITLE
:truck: Migrate to official metrics-server chart

### DIFF
--- a/tilt/metrics/Tiltfile
+++ b/tilt/metrics/Tiltfile
@@ -1,5 +1,5 @@
 load("../utils/Tiltfile", "namespace_create_wrap")
-load("ext://helm_resource", "helm_resource")
+load("ext://helm_resource", "helm_resource", "helm_repo")
 
 
 def setup_metrics_server():
@@ -8,23 +8,29 @@ def setup_metrics_server():
         namespace_labels=["istio-injection: disabled"],
     )
 
-    # https://github.com/bitnami/charts/tree/main/bitnami/metrics-server
+    helm_repo(
+        name="metrics-server",
+        url="https://kubernetes-sigs.github.io/metrics-server",
+        resource_name="metrics-server-repo",
+        labels=["10-helm-repos"],
+    )
+
+    # https://github.com/kubernetes-sigs/metrics-server/tree/master/charts/metrics-server
     helm_resource(
         name="metrics-server",
-        chart="oci://registry-1.docker.io/bitnamicharts/metrics-server",
+        chart="metrics-server/metrics-server",
         release_name="metrics-server",
         namespace=namespace,
         flags=[
             "--set",
             "apiService.create=true",
             "--set",
-            "extraArgs[0]=--metric-resolution=15s",
-            "--set",
-            "extraArgs[1]=--kubelet-insecure-tls",
+            "args[0]=--kubelet-insecure-tls",
             "--version",
-            "7.4.11",
+            "3.13.0",
             "--wait",
         ],
         labels=["30-monitoring"],
+        resource_deps=["metrics-server-repo"],
         auto_init=False,
     )


### PR DESCRIPTION
Switch from Bitnami metrics-server chart to the official
Kubernetes SIG chart in Tilt development environment to avoid
disruption from upcoming Bitnami catalog changes.

Bitnami will deprecate their public catalog on August 28th,
2025, moving images to a legacy repository with no updates.
This migration ensures continued support and security updates.

Changes:
* Add explicit helm repository resource for metrics-server
* Update chart reference from Bitnami OCI registry to official
  Kubernetes SIG Helm repository
* Change `extraArgs` configuration to `args` format for
  official chart compatibility
* Remove `--metric-resolution=15s` argument (not needed)
* Keep `--kubelet-insecure-tls` for development environment
* Add resource dependency on helm repository

---

For more info: https://github.com/bitnami/containers/issues/83267