### PR TITLE
:truck: Migrate to Bitnami legacy repository temporarily

### DIFF
--- a/helm/acapy-cloud/conf/dev/connect-cloud.yaml
+++ b/helm/acapy-cloud/conf/dev/connect-cloud.yaml
@@ -48,7 +48,7 @@ initContainers:
     image: busybox
     command: ['sh', '-c', 'until nc -z nats 4222; do echo waiting for nats; sleep 2; done;']
   - name: nats-check
-    image: bitnami/natscli
+    image: docker.io/bitnamilegacy/natscli
     command:
       - sh
       - -c

--- a/helm/acapy-cloud/conf/dev/governance-agent.yaml
+++ b/helm/acapy-cloud/conf/dev/governance-agent.yaml
@@ -109,7 +109,7 @@ initContainers:
     image: busybox
     command: ['sh', '-c', 'until nc -z nats 4222; do echo waiting for nats; sleep 2; done;']
   - name: nats-check
-    image: bitnami/natscli
+    image: docker.io/bitnamilegacy/natscli
     command:
       - sh
       - -c

--- a/helm/acapy-cloud/conf/dev/multitenant-agent.yaml
+++ b/helm/acapy-cloud/conf/dev/multitenant-agent.yaml
@@ -116,7 +116,7 @@ initContainers:
     image: busybox
     command: ['sh', '-c', 'until nc -z nats 4222; do echo waiting for nats; sleep 2; done;']
   - name: nats-check
-    image: bitnami/natscli
+    image: docker.io/bitnamilegacy/natscli
     command:
       - sh
       - -c

--- a/helm/acapy-cloud/conf/dev/waypoint.yaml
+++ b/helm/acapy-cloud/conf/dev/waypoint.yaml
@@ -44,7 +44,7 @@ initContainers:
     image: busybox
     command: ['sh', '-c', 'until nc -z nats 4222; do echo waiting for nats; sleep 2; done;']
   - name: nats-check
-    image: bitnami/natscli
+    image: docker.io/bitnamilegacy/natscli
     command:
       - sh
       - -c

--- a/helm/acapy-cloud/conf/local/connect-cloud.yaml
+++ b/helm/acapy-cloud/conf/local/connect-cloud.yaml
@@ -48,7 +48,7 @@ initContainers:
     image: busybox
     command: ['sh', '-c', 'until nc -z nats 4222; do echo waiting for nats; sleep 2; done;']
   - name: nats-check
-    image: bitnami/natscli
+    image: docker.io/bitnamilegacy/natscli
     command:
       - sh
       - -c

--- a/helm/acapy-cloud/conf/local/governance-agent.yaml
+++ b/helm/acapy-cloud/conf/local/governance-agent.yaml
@@ -97,7 +97,7 @@ startupProbe:
 
 initContainers:
   - name: nats-check
-    image: bitnami/natscli
+    image: docker.io/bitnamilegacy/natscli
     command:
       - sh
       - -c

--- a/helm/acapy-cloud/conf/local/multitenant-agent.yaml
+++ b/helm/acapy-cloud/conf/local/multitenant-agent.yaml
@@ -104,7 +104,7 @@ initContainers:
     image: busybox
     command: ['sh', '-c', 'until nc -z nats 4222; do echo waiting for nats; sleep 2; done;']
   - name: nats-check
-    image: bitnami/natscli
+    image: docker.io/bitnamilegacy/natscli
     command:
       - sh
       - -c

--- a/helm/acapy-cloud/conf/local/waypoint.yaml
+++ b/helm/acapy-cloud/conf/local/waypoint.yaml
@@ -33,7 +33,7 @@ initContainers:
     image: busybox
     command: ['sh', '-c', 'until nc -z nats 4222; do echo waiting for nats; sleep 2; done;']
   - name: nats-check
-    image: bitnami/natscli
+    image: docker.io/bitnamilegacy/natscli
     command:
       - sh
       - -c

--- a/helm/acapy-cloud/conf/minio.yaml
+++ b/helm/acapy-cloud/conf/minio.yaml
@@ -1,4 +1,22 @@
+# https://github.com/bitnami/charts/tree/main/bitnami/minio
+
+global:
+  security:
+    # Required to override image repositories (`bitnami` -> `bitnamilegacy`)
+    # https://github.com/bitnami/charts/issues/35164
+    # https://github.com/bitnami/containers/issues/84600
+    allowInsecureImages: true
+
 fullnameOverride: minio
+
+image:
+  repository: bitnamilegacy/minio
+clientImage:
+  repository: bitnamilegacy/minio-client
+defaultInitContainers:
+  volumePermissions:
+    image:
+      repository: bitnamilegacy/os-shell
 
 auth:
   rootUser: minio # minimum length of 3
@@ -10,6 +28,8 @@ ingress:
   hostname: minio-api.127.0.0.1.nip.io
 
 console:
+  image:
+    repository: bitnamilegacy/minio-object-browser
   podLabels:
     sidecar.istio.io/inject: "false"
   ingress:

--- a/helm/acapy-cloud/conf/postgres.yaml
+++ b/helm/acapy-cloud/conf/postgres.yaml
@@ -1,6 +1,16 @@
 # https://github.com/bitnami/charts/tree/main/bitnami/postgresql-ha
+
+global:
+  security:
+    # Required to override image repositories (`bitnami` -> `bitnamilegacy`)
+    # https://github.com/bitnami/charts/issues/35164
+    # https://github.com/bitnami/containers/issues/84600
+    allowInsecureImages: true
+
 fullnameOverride: cloudapi
 postgresql:
+  image:
+    repository: bitnamilegacy/postgresql-repmgr
   podAnnotations:
     sidecar.istio.io/proxyCPU: 10m
   podLabels:
@@ -33,6 +43,8 @@ persistentVolumeClaimRetentionPolicy:
   enabled: true
   whenDeleted: Delete
 pgpool:
+  image:
+    repository: bitnamilegacy/pgpool
   podAnnotations:
     sidecar.istio.io/proxyCPU: 10m
   podLabels:
@@ -55,3 +67,9 @@ pgpool:
   # PostgreSQL 15 -> 16 compatibility
   srCheckUsername: repmgr
   srCheckPassword: repmgr
+metrics:
+  image:
+    repository: bitnamilegacy/postgres-exporter
+volumePermissions:
+  image:
+    repository: bitnamilegacy/os-shell

--- a/helm/acapy-cloud/conf/valkey.yaml
+++ b/helm/acapy-cloud/conf/valkey.yaml
@@ -1,6 +1,16 @@
 # https://github.com/bitnami/charts/tree/main/bitnami/valkey
+
+global:
+  security:
+    # Required to override image repositories (`bitnami` -> `bitnamilegacy`)
+    # https://github.com/bitnami/charts/issues/35164
+    # https://github.com/bitnami/containers/issues/84600
+    allowInsecureImages: true
+
 fullnameOverride: valkey
 architecture: replication
+image:
+  repository: bitnamilegacy/valkey
 auth:
   enabled: false
 primary:
@@ -30,3 +40,15 @@ replica:
   podManagementPolicy: Parallel
   pdb:
     create: false
+sentinel:
+  image:
+    repository: bitnamilegacy/valkey-sentinel
+metrics:
+  image:
+    repository: bitnamilegacy/valkey-exporter
+volumePermissions:
+  image:
+    repository: bitnamilegacy/os-shell
+kubectl:
+  image:
+    repository: bitnamilegacy/kubectl

--- a/helm/cheqd/templates/statefulset.yaml
+++ b/helm/cheqd/templates/statefulset.yaml
@@ -166,7 +166,7 @@ spec:
         {{- end }}
         {{- if .Values.lbService.enabled }}
         - name: discover-lb-hostname
-          image: docker.io/bitnami/kubectl:latest
+          image: docker.io/bitnamilegacy/kubectl:latest
           imagePullPolicy: IfNotPresent
           command:
             - sh

--- a/helm/nats/templates/job.yaml
+++ b/helm/nats/templates/job.yaml
@@ -32,7 +32,7 @@ spec:
             - while ! nc -z {{ template "common.names.fullname" . }} {{ default 4222 .Values.nats.service.ports.client }}; do sleep 1; done
       containers:
         - name: natscli
-          image: bitnami/natscli:{{ default "latest" .Values.postInstall.cli.version }}
+          image: docker.io/bitnamilegacy/natscli:{{ default "latest" .Values.postInstall.cli.version }}
           command:
             - sh
             - -c

--- a/helm/nats/values.yaml
+++ b/helm/nats/values.yaml
@@ -2,6 +2,13 @@
 ##
 fullnameOverride: nats
 
+global:
+  security:
+    # Required to override image repositories (`bitnami` -> `bitnamilegacy`)
+    # https://github.com/bitnami/charts/issues/35164
+    # https://github.com/bitnami/containers/issues/84600
+    allowInsecureImages: true
+
 postInstall:
   enabled: true
 
@@ -54,6 +61,10 @@ nats:
   ## @param fullnameOverride String to fully override common.names.fullname template
   ##
   fullnameOverride: nats
+  ## @param image.repository [default: bitnami/nats] NATS image repository
+  ##
+  image:
+    repository: bitnamilegacy/nats
 
   ## @param replicaCount Number of NATS nodes
   ##
@@ -189,3 +200,11 @@ nats:
     ## @param persistentVolumeClaimRetentionPolicy.whenDeleted Volume retention behavior that applies when the StatefulSet is deleted
     ##
     whenDeleted: Delete
+
+  ## Metrics / Prometheus NATS Exporter
+  ## ref: https://github.com/nats-io/prometheus-nats-exporter
+  ##
+  metrics:
+    ## @param metrics.image.repository [default: bitnami/nats-exporter] Prometheus metrics exporter image repository
+    image:
+      repository: bitnamilegacy/nats-exporter


### PR DESCRIPTION
Switch Bitnami container images from `bitnami/` to
`docker.io/bitnamilegacy/` to maintain functionality during
the Bitnami catalog transition period.

This is a temporary workaround until proper migration to
official upstream charts is completed. The legacy repository
contains archived images with no further updates and should
only be used for migration purposes.

Changes:
* Update image repositories across all Helm configurations:
  - NATS CLI, MinIO, PostgreSQL, Valkey, kubectl images
* Add `global.security.allowInsecureImages: true` to override
  repository validation in Bitnami charts
* Update both local and dev environment configurations
* Maintain existing functionality while planning permanent
  migration to upstream charts

Images migrated: natscli, minio, minio-client, minio-object-browser,
postgresql-repmgr, pgpool, postgres-exporter, valkey,
valkey-sentinel, valkey-exporter, kubectl, nats, nats-exporter,
os-shell

References: https://github.com/bitnami/containers/issues/83267