### PR TITLE
:arrow_up: Update dependencies and migrate to `#MISE` syntax

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -51,9 +51,9 @@ on:
 permissions: {}
 
 env:
-  HELM_VERSION: v3.18.4
-  HELMFILE_VERSION: v1.1.4
-  MISE_VERSION: 2025.8.7
+  HELM_VERSION: v3.18.5
+  HELMFILE_VERSION: v1.1.5
+  MISE_VERSION: 2025.8.13
 
   RESET_DEPLOYMENTS: ${{ github.event.inputs.reset-deployments || 'false' }}
   RUN_E2E_TESTS: ${{ github.event.inputs.run-e2e-tests || 'true' }}

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       # Checkout the repository to the GitHub Actions runner
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/deploy-test-eks.yml
+++ b/.github/workflows/deploy-test-eks.yml
@@ -134,7 +134,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
 
@@ -219,7 +219,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
 
@@ -399,7 +399,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
 
@@ -581,7 +581,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/deploy-test-eks.yml
+++ b/.github/workflows/deploy-test-eks.yml
@@ -152,7 +152,7 @@ jobs:
       - name: Helmfile Destroy
         if: inputs.reset-deployments
         # https://github.com/helmfile/helmfile-action
-        uses: helmfile/helmfile-action@712000e3d4e28c72778ecc53857746082f555ef3 # v2.0.4
+        uses: helmfile/helmfile-action@6f21d94fa797f5dfbc92b9db62c6832ac6639a88 # v2.0.5
         with:
           helmfile-args: |
             destroy \
@@ -184,7 +184,7 @@ jobs:
 
       - name: Helmfile Apply
         # https://github.com/helmfile/helmfile-action
-        uses: helmfile/helmfile-action@712000e3d4e28c72778ecc53857746082f555ef3 # v2.0.4
+        uses: helmfile/helmfile-action@6f21d94fa797f5dfbc92b9db62c6832ac6639a88 # v2.0.5
         with:
           helmfile-args: |
             apply \
@@ -237,7 +237,7 @@ jobs:
       - name: Helmfile run tests
         id: pytest
         # https://github.com/helmfile/helmfile-action
-        uses: helmfile/helmfile-action@712000e3d4e28c72778ecc53857746082f555ef3 # v2.0.4
+        uses: helmfile/helmfile-action@6f21d94fa797f5dfbc92b9db62c6832ac6639a88 # v2.0.5
         with:
           helmfile-args: |
             apply \
@@ -366,7 +366,7 @@ jobs:
 
       - name: Helmfile Destroy
         # https://github.com/helmfile/helmfile-action
-        uses: helmfile/helmfile-action@712000e3d4e28c72778ecc53857746082f555ef3 # v2.0.4
+        uses: helmfile/helmfile-action@6f21d94fa797f5dfbc92b9db62c6832ac6639a88 # v2.0.5
         if: always()
         with:
           helmfile-args: |
@@ -417,7 +417,7 @@ jobs:
       - name: Helmfile run tests
         id: regression
         # https://github.com/helmfile/helmfile-action
-        uses: helmfile/helmfile-action@712000e3d4e28c72778ecc53857746082f555ef3 # v2.0.4
+        uses: helmfile/helmfile-action@6f21d94fa797f5dfbc92b9db62c6832ac6639a88 # v2.0.5
         with:
           helmfile-args: |
             apply \
@@ -549,7 +549,7 @@ jobs:
 
       - name: Helmfile destroy
         # https://github.com/helmfile/helmfile-action
-        uses: helmfile/helmfile-action@712000e3d4e28c72778ecc53857746082f555ef3 # v2.0.4
+        uses: helmfile/helmfile-action@6f21d94fa797f5dfbc92b9db62c6832ac6639a88 # v2.0.5
         if: always()
         with:
           helmfile-args: |

--- a/.github/workflows/deploy-test-eks.yml
+++ b/.github/workflows/deploy-test-eks.yml
@@ -344,7 +344,7 @@ jobs:
       - name: Create/Update test coverage comment
         if: steps.pytest.outcome == 'success'
         # https://github.com/MishaKav/pytest-coverage-comment
-        uses: MishaKav/pytest-coverage-comment@13d3c18e21895566c746187c9ea74736372e5e91 # v1.1.54
+        uses: MishaKav/pytest-coverage-comment@9638e4b1448019aba40c4aaaa1ade87a9f211aa1 # v1.1.56
         with:
           pytest-coverage-path: ./pytest/test_coverage.txt
           junitxml-path: ./pytest/test_output.xml
@@ -528,7 +528,7 @@ jobs:
       - name: Create/Update test coverage comment
         if: steps.regression.outcome == 'success'
         # https://github.com/MishaKav/pytest-coverage-comment
-        uses: MishaKav/pytest-coverage-comment@13d3c18e21895566c746187c9ea74736372e5e91 # v1.1.54
+        uses: MishaKav/pytest-coverage-comment@9638e4b1448019aba40c4aaaa1ade87a9f211aa1 # v1.1.56
         with:
           pytest-coverage-path: ./pytest-regression/test_coverage.txt
           junitxml-path: ./pytest-regression/test_output.xml

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -63,7 +63,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
           submodules: recursive
@@ -144,7 +144,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
           submodules: recursive

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -29,7 +29,7 @@ jobs:
           EOF
 
       - name: Set up Mise
-        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+        uses: jdx/mise-action@c0b8518a9f5e56c720e9545c993b77ff15dc7b27 # v3.0.2
         with:
           version: ${{ inputs.mise-version }}
           cache: true

--- a/.github/workflows/local-tests.yml
+++ b/.github/workflows/local-tests.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
           submodules: recursive

--- a/.github/workflows/local-tests.yml
+++ b/.github/workflows/local-tests.yml
@@ -45,12 +45,6 @@ jobs:
           install: true
         env:
           MISE_JOBS: 4
-      - name: Load Mise env
-        run: |
-          mise env -s bash \
-              | grep -v 'export PATH=' \
-              | cut -d' ' -f2 \
-              >> "$GITHUB_ENV"
       - name: Install dependencies with Poetry
         run: mise run poetry:install
         env:

--- a/.github/workflows/local-tests.yml
+++ b/.github/workflows/local-tests.yml
@@ -37,7 +37,7 @@ jobs:
           key: python-${{ hashFiles('**/poetry.lock', '.mise.toml') }}
 
       - name: Set up Mise
-        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+        uses: jdx/mise-action@c0b8518a9f5e56c720e9545c993b77ff15dc7b27 # v3.0.2
         with:
           version: ${{ inputs.mise-version }}
           cache: true

--- a/.github/workflows/mdbook-deploy.yml
+++ b/.github/workflows/mdbook-deploy.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/mdbook-deploy.yml
+++ b/.github/workflows/mdbook-deploy.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           path: 'docs/book'
 

--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
       - name: Log in to DIDx DevOps
         id: devops_login
-        uses: actions/create-github-app-token@0f859bf9e69e887678d5bbfbee594437cb440ffe # v2.1.0
+        uses: actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b # v2.1.1
         with:
           app-id: ${{ secrets.devops-app-id }}
           private-key: ${{ secrets.devops-private-key }}

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -41,7 +41,7 @@ jobs:
           egress-policy: audit
 
       - name: "Checkout code"
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -76,6 +76,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@76621b61decf072c1cee8dd1ce2d2a82d33c17ed # v3.29.5
+        uses: github/codeql-action/upload-sarif@df559355d593797519d70b90fc8edd5db049e7a2 # v3.29.5
         with:
           sarif_file: results.sarif

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -76,6 +76,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@df559355d593797519d70b90fc8edd5db049e7a2 # v3.29.5
+        uses: github/codeql-action/upload-sarif@96f518a34f7a870018057716cc4d7a5c014bd61c # v3.29.10
         with:
           sarif_file: results.sarif

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0 # Required for proper blame data in SonarCloud
           persist-credentials: false

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -81,7 +81,7 @@ jobs:
           key: python-${{ hashFiles('**/poetry.lock', '.mise.toml') }}
 
       - name: Set up Mise
-        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+        uses: jdx/mise-action@c0b8518a9f5e56c720e9545c993b77ff15dc7b27 # v3.0.2
         with:
           cache: true
           experimental: true

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -26,7 +26,7 @@ jobs:
           key: python-${{ hashFiles('**/poetry.lock', '.mise.toml') }}
 
       - name: Set up Mise
-        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+        uses: jdx/mise-action@c0b8518a9f5e56c720e9545c993b77ff15dc7b27 # v3.0.2
         with:
           version: ${{ inputs.mise-version }}
           cache: true

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -34,12 +34,6 @@ jobs:
           install: true
         env:
           MISE_JOBS: 4
-      - name: Load Mise env
-        run: |
-          mise env -s bash \
-              | grep -v 'export PATH=' \
-              | cut -d' ' -f2 \
-              >> "$GITHUB_ENV"
 
       - name: Run unit tests
         run: mise run tests:unit

--- a/.github/workflows/update-openapi.yml
+++ b/.github/workflows/update-openapi.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
       - name: Log in to DIDx DevOps
         id: devops_login
-        uses: actions/create-github-app-token@0f859bf9e69e887678d5bbfbee594437cb440ffe # v2.1.0
+        uses: actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b # v2.1.1
         with:
           app-id: ${{ secrets.devops-app-id }}
           private-key: ${{ secrets.devops-private-key }}

--- a/.github/workflows/update-openapi.yml
+++ b/.github/workflows/update-openapi.yml
@@ -51,7 +51,7 @@ jobs:
           private-key: ${{ secrets.devops-private-key }}
 
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: ${{ github.event_name != 'pull_request' }}
           token: ${{ github.event_name == 'pull_request' && github.token || steps.devops_login.outputs.token }}

--- a/.mise.toml
+++ b/.mise.toml
@@ -3,7 +3,7 @@
 "aqua:nats-io/natscli" = "0.2"
 helm = "3"
 helmfile = "1"
-istioctl = "1.26"
+istioctl = "1.27"
 jq = "latest"
 kind = "0.29"
 kubectl = "1.33"

--- a/.mise/tasks/kind/create
+++ b/.mise/tasks/kind/create
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# mise description="Create Kubernetes Kind Cluster with Registry Caches"
-# mise outputs=[".mise/kubeconfig.yaml"]
-# mise depends=["kind:install:docker-registry", "kind:install:docker-cache"]
+#MISE description="Create Kubernetes Kind Cluster with Registry Caches"
+#MISE outputs=[".mise/kubeconfig.yaml"]
+#MISE depends=["kind:install:docker-registry", "kind:install:docker-cache"]
 
 set -o errexit
 

--- a/.mise/tasks/kind/destroy
+++ b/.mise/tasks/kind/destroy
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -e
-# mise description="Destroy Kubernetes Kind Cluster"
+#MISE description="Destroy Kubernetes Kind Cluster"
 #USAGE flag "--destroy-registry-containers" help="Destroy Kind registry & cache containers"
 
 kind delete cluster --name ${KIND_CLUSTER_NAME}

--- a/.mise/tasks/kind/install/docker-cache
+++ b/.mise/tasks/kind/install/docker-cache
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# mise description="Start up the Docker Pullthrough Cache"
+#MISE description="Start up the Docker Pullthrough Cache"
 
 # Disable Docker cache in CI
 if [ -n "${GITHUB_ACTIONS}" ]; then

--- a/.mise/tasks/kind/install/docker-registry
+++ b/.mise/tasks/kind/install/docker-registry
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# mise description="Start up the local Kind Docker Registry"
+#MISE description="Start up the local Kind Docker Registry"
 
 ## Setup local docker registry and caches
 # https://kind.sigs.k8s.io/docs/user/local-registry/

--- a/.mise/tasks/kind/install/istio
+++ b/.mise/tasks/kind/install/istio
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# mise description="Install Istio in Kubernetes"
-# mise depends=["kind:create"]
+#MISE description="Install Istio in Kubernetes"
+#MISE depends=["kind:create"]
 
 # Ensure we are on the right kube context
 kubectl config use-context ${KIND_K8S_CONTEXT}

--- a/.mise/tasks/kind/install/nginx
+++ b/.mise/tasks/kind/install/nginx
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# mise description="Install Ingress Nginx in Kubernetes"
-# mise depends=["kind:create"]
+#MISE description="Install Ingress Nginx in Kubernetes"
+#MISE depends=["kind:create"]
 
 # Ensure we are on the right kube context
 kubectl config use-context ${KIND_K8S_CONTEXT}

--- a/scripts/k6/Dockerfile
+++ b/scripts/k6/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/golang:1.24-alpine@sha256:c8c5f95d64aa79b6547f3b626eb84b16a7ce18a139e3e9ca19a8c078b85ba80d AS builder
+FROM docker.io/golang:1.25-alpine@sha256:77dd832edf2752dafd030693bef196abb24dcba3a2bc3d7a6227a7a1dae73169 AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
This PR updates various dependencies across the project and migrates mise task comments to the new `#MISE` format in preparation for the deprecation of `# mise` syntax.

## Changes

### 🔧 Tool Dependencies
- **Helm**: v3.18.4 → v3.18.5
- **Helmfile**: v1.1.4 → v1.1.5  
- **Mise**: 2025.8.7 → 2025.8.13
- **istioctl**: 1.26 → 1.27
- **Golang**: 1.24-alpine → 1.25-alpine

### 🔄 GitHub Actions
- **github/codeql-action**: 3.29.8 → 3.29.10
- **helmfile/helmfile-action**: 2.0.4 → 2.0.5
- **actions/upload-pages-artifact**: 3.0.1 → 4.0.0 (major version)
- **actions/checkout** 4.2.2 -> 5.0.0 (major version)
- **jdx/mise-action** 2.4.4 -> 3.0.2 (major version)
- **MishaKav/pytest-coverage-comment**: 1.1.54 → 1.1.56
- **actions/create-github-app-token**: 2.1.0 → 2.1.1

### 📝 Breaking Change Preparation
- Migrated all `# mise` task comments to `#MISE` format across kind-related tasks
- The `# mise` syntax is deprecated and will be removed in Mise `2026.3.0`

## Files Modified
- `.github/workflows/cicd.yml` - tool version updates
- `.mise.toml` - istioctl version bump
- `.mise/tasks/kind/*` - comment format migration
- `.github/workflows/` - various action version updates
- `scripts/k6/Dockerfile` - golang base image update