### PR TITLE
:truck: Migrate Bitnami charts to custom registry

### DIFF
--- a/helm/acapy-cloud.yaml.gotmpl
+++ b/helm/acapy-cloud.yaml.gotmpl
@@ -151,7 +151,7 @@ releases:
           podAnnotations:
             ad.datadoghq.com/logs_exclude: "true" # Disable datadog log shipping
 
-  # https://github.com/bitnami/charts/tree/main/bitnami/nats
+  # https://github.com/didx-xyz/bitnami-charts/tree/main/bitnami/nats
   - name: nats
     labels:
       app: nats
@@ -164,12 +164,12 @@ releases:
           podLabels:
             tags.datadoghq.com/env: acapy-cloud-{{ .Environment.Name }}
 
-  # https://github.com/bitnami/charts/tree/main/bitnami/valkey
+  # https://github.com/didx-xyz/bitnami-charts/tree/main/bitnami/valkey
   - name: valkey
     labels:
       app: valkey
     namespace: {{ .Values.namespace }}
-    chart: oci://registry-1.docker.io/bitnamicharts/valkey
+    chart: oci://ghcr.io/didx-xyz/bitnami-oss-charts/valkey
     version: 3.0.28
     values:
       - ./acapy-cloud/conf/valkey.yaml
@@ -180,12 +180,12 @@ releases:
           podLabels:
             tags.datadoghq.com/env: acapy-cloud-{{ .Environment.Name }}
 
-  # https://github.com/bitnami/charts/tree/main/bitnami/postgresql-ha
+  # https://github.com/didx-xyz/bitnami-charts/tree/main/bitnami/postgresql-ha
   - name: postgres
     labels:
       app: postgres
     namespace: {{ .Values.namespace }}
-    chart: oci://registry-1.docker.io/bitnamicharts/postgresql-ha
+    chart: oci://ghcr.io/didx-xyz/bitnami-oss-charts/postgresql-ha
     version: 16.1.2
     values:
       - ./acapy-cloud/conf/postgres.yaml
@@ -256,11 +256,11 @@ releases:
           admission.datadoghq.com/enabled: "false"
           tags.datadoghq.com/env: acapy-cloud-{{ .Environment.Name }}
 
-  # https://github.com/bitnami/charts/tree/main/bitnami/minio
+  # https://github.com/didx-xyz/bitnami-charts/tree/main/bitnami/minio
   - name: minio
     installed: {{ .Values.minio.enabled }}
     namespace: {{ .Values.namespace }}
-    chart: oci://registry-1.docker.io/bitnamicharts/minio
+    chart: oci://ghcr.io/didx-xyz/bitnami-oss-charts/minio
     version: 17.0.19
     labels:
       app: minio

--- a/helm/acapy-cloud.yaml.gotmpl
+++ b/helm/acapy-cloud.yaml.gotmpl
@@ -170,7 +170,7 @@ releases:
       app: valkey
     namespace: {{ .Values.namespace }}
     chart: oci://ghcr.io/didx-xyz/bitnami-oss-charts/valkey
-    version: 3.0.28
+    version: 3.0.31
     values:
       - ./acapy-cloud/conf/valkey.yaml
       - primary:
@@ -186,7 +186,7 @@ releases:
       app: postgres
     namespace: {{ .Values.namespace }}
     chart: oci://ghcr.io/didx-xyz/bitnami-oss-charts/postgresql-ha
-    version: 16.1.2
+    version: 16.3.1
     values:
       - ./acapy-cloud/conf/postgres.yaml
       - postgresql:
@@ -202,7 +202,7 @@ releases:
       app: pgadmin
     namespace: {{ .Values.namespace }}
     chart: runix/pgadmin4
-    version: 1.48.0
+    version: 1.49.0
     installed: {{ .Values.pgAdmin.enabled }}
     values:
       - ./acapy-cloud/conf/pgadmin.yaml
@@ -261,7 +261,7 @@ releases:
     installed: {{ .Values.minio.enabled }}
     namespace: {{ .Values.namespace }}
     chart: oci://ghcr.io/didx-xyz/bitnami-oss-charts/minio
-    version: 17.0.19
+    version: 17.0.21
     labels:
       app: minio
     values:

--- a/helm/acapy-cloud/conf/dev/connect-cloud.yaml
+++ b/helm/acapy-cloud/conf/dev/connect-cloud.yaml
@@ -48,7 +48,7 @@ initContainers:
     image: busybox
     command: ['sh', '-c', 'until nc -z nats 4222; do echo waiting for nats; sleep 2; done;']
   - name: nats-check
-    image: docker.io/bitnamilegacy/natscli
+    image: ghcr.io/didx-xyz/bitnami-oss/natscli
     command:
       - sh
       - -c

--- a/helm/acapy-cloud/conf/dev/governance-agent.yaml
+++ b/helm/acapy-cloud/conf/dev/governance-agent.yaml
@@ -109,7 +109,7 @@ initContainers:
     image: busybox
     command: ['sh', '-c', 'until nc -z nats 4222; do echo waiting for nats; sleep 2; done;']
   - name: nats-check
-    image: docker.io/bitnamilegacy/natscli
+    image: ghcr.io/didx-xyz/bitnami-oss/natscli
     command:
       - sh
       - -c

--- a/helm/acapy-cloud/conf/dev/multitenant-agent.yaml
+++ b/helm/acapy-cloud/conf/dev/multitenant-agent.yaml
@@ -116,7 +116,7 @@ initContainers:
     image: busybox
     command: ['sh', '-c', 'until nc -z nats 4222; do echo waiting for nats; sleep 2; done;']
   - name: nats-check
-    image: docker.io/bitnamilegacy/natscli
+    image: ghcr.io/didx-xyz/bitnami-oss/natscli
     command:
       - sh
       - -c

--- a/helm/acapy-cloud/conf/dev/waypoint.yaml
+++ b/helm/acapy-cloud/conf/dev/waypoint.yaml
@@ -44,7 +44,7 @@ initContainers:
     image: busybox
     command: ['sh', '-c', 'until nc -z nats 4222; do echo waiting for nats; sleep 2; done;']
   - name: nats-check
-    image: docker.io/bitnamilegacy/natscli
+    image: ghcr.io/didx-xyz/bitnami-oss/natscli
     command:
       - sh
       - -c

--- a/helm/acapy-cloud/conf/local/connect-cloud.yaml
+++ b/helm/acapy-cloud/conf/local/connect-cloud.yaml
@@ -48,7 +48,7 @@ initContainers:
     image: busybox
     command: ['sh', '-c', 'until nc -z nats 4222; do echo waiting for nats; sleep 2; done;']
   - name: nats-check
-    image: docker.io/bitnamilegacy/natscli
+    image: ghcr.io/didx-xyz/bitnami-oss/natscli
     command:
       - sh
       - -c

--- a/helm/acapy-cloud/conf/local/governance-agent.yaml
+++ b/helm/acapy-cloud/conf/local/governance-agent.yaml
@@ -97,7 +97,7 @@ startupProbe:
 
 initContainers:
   - name: nats-check
-    image: docker.io/bitnamilegacy/natscli
+    image: ghcr.io/didx-xyz/bitnami-oss/natscli
     command:
       - sh
       - -c

--- a/helm/acapy-cloud/conf/local/multitenant-agent.yaml
+++ b/helm/acapy-cloud/conf/local/multitenant-agent.yaml
@@ -104,7 +104,7 @@ initContainers:
     image: busybox
     command: ['sh', '-c', 'until nc -z nats 4222; do echo waiting for nats; sleep 2; done;']
   - name: nats-check
-    image: docker.io/bitnamilegacy/natscli
+    image: ghcr.io/didx-xyz/bitnami-oss/natscli
     command:
       - sh
       - -c

--- a/helm/acapy-cloud/conf/local/waypoint.yaml
+++ b/helm/acapy-cloud/conf/local/waypoint.yaml
@@ -33,7 +33,7 @@ initContainers:
     image: busybox
     command: ['sh', '-c', 'until nc -z nats 4222; do echo waiting for nats; sleep 2; done;']
   - name: nats-check
-    image: docker.io/bitnamilegacy/natscli
+    image: ghcr.io/didx-xyz/bitnami-oss/natscli
     command:
       - sh
       - -c

--- a/helm/acapy-cloud/conf/minio.yaml
+++ b/helm/acapy-cloud/conf/minio.yaml
@@ -1,22 +1,23 @@
-# https://github.com/bitnami/charts/tree/main/bitnami/minio
+# https://github.com/didx-xyz/bitnami-charts/tree/main/bitnami/minio
 
 global:
   security:
-    # Required to override image repositories (`bitnami` -> `bitnamilegacy`)
+    # Required to override image repositories (`docker.io/bitnami` -> `ghcr.io/didx-xyz/bitnami-oss`)
     # https://github.com/bitnami/charts/issues/35164
     # https://github.com/bitnami/containers/issues/84600
     allowInsecureImages: true
+  imageRegistry: ghcr.io
 
 fullnameOverride: minio
 
 image:
-  repository: bitnamilegacy/minio
+  repository: didx-xyz/bitnami-oss/minio
 clientImage:
-  repository: bitnamilegacy/minio-client
+  repository: didx-xyz/bitnami-oss/minio-client
 defaultInitContainers:
   volumePermissions:
     image:
-      repository: bitnamilegacy/os-shell
+      repository: didx-xyz/bitnami-oss/os-shell
 
 auth:
   rootUser: minio # minimum length of 3
@@ -29,7 +30,7 @@ ingress:
 
 console:
   image:
-    repository: bitnamilegacy/minio-object-browser
+    repository: didx-xyz/bitnami-oss/minio-object-browser
   podLabels:
     sidecar.istio.io/inject: "false"
   ingress:

--- a/helm/acapy-cloud/conf/postgres.yaml
+++ b/helm/acapy-cloud/conf/postgres.yaml
@@ -1,16 +1,17 @@
-# https://github.com/bitnami/charts/tree/main/bitnami/postgresql-ha
+# https://github.com/didx-xyz/bitnami-charts/tree/main/bitnami/postgresql-ha
 
 global:
   security:
-    # Required to override image repositories (`bitnami` -> `bitnamilegacy`)
+    # Required to override image repositories (`docker.io/bitnami` -> `ghcr.io/didx-xyz/bitnami-oss`)
     # https://github.com/bitnami/charts/issues/35164
     # https://github.com/bitnami/containers/issues/84600
     allowInsecureImages: true
+  imageRegistry: ghcr.io
 
 fullnameOverride: cloudapi
 postgresql:
   image:
-    repository: bitnamilegacy/postgresql-repmgr
+    repository: didx-xyz/bitnami-oss/postgresql-repmgr
   podAnnotations:
     sidecar.istio.io/proxyCPU: 10m
   podLabels:
@@ -36,7 +37,7 @@ postgresql:
         CREATE USER multitenant WITH PASSWORD 'multitenant' CREATEDB;
         CREATE USER mediator WITH PASSWORD 'mediator' CREATEDB;
       EOSQL
-  # https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15
+  # https://github.com/didx-xyz/bitnami-charts/blob/main/bitnami/common/templates/_resources.tpl#L15
   resourcesPreset: none
   maxConnections: 4500 # pgpool.numInitChildren * pgpool.maxPool
 persistentVolumeClaimRetentionPolicy:
@@ -44,7 +45,7 @@ persistentVolumeClaimRetentionPolicy:
   whenDeleted: Delete
 pgpool:
   image:
-    repository: bitnamilegacy/pgpool
+    repository: didx-xyz/bitnami-oss/pgpool
   podAnnotations:
     sidecar.istio.io/proxyCPU: 10m
   podLabels:
@@ -59,7 +60,7 @@ pgpool:
   reservedConnections: 5
   maxPool: 15             # Maximum cached connections per child process
   childMaxConnections: 30 # Maximum client connections per child process
-  # https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15
+  # https://github.com/didx-xyz/bitnami-charts/blob/main/bitnami/common/templates/_resources.tpl#L15
   resourcesPreset: none
   tls:
     enabled: false
@@ -69,7 +70,7 @@ pgpool:
   srCheckPassword: repmgr
 metrics:
   image:
-    repository: bitnamilegacy/postgres-exporter
+    repository: didx-xyz/bitnami-oss/postgres-exporter
 volumePermissions:
   image:
-    repository: bitnamilegacy/os-shell
+    repository: didx-xyz/bitnami-oss/os-shell

--- a/helm/acapy-cloud/conf/valkey.yaml
+++ b/helm/acapy-cloud/conf/valkey.yaml
@@ -1,16 +1,17 @@
-# https://github.com/bitnami/charts/tree/main/bitnami/valkey
+# https://github.com/didx-xyz/bitnami-charts/tree/main/bitnami/valkey
 
 global:
   security:
-    # Required to override image repositories (`bitnami` -> `bitnamilegacy`)
+    # Required to override image repositories (`docker.io/bitnami` -> `ghcr.io/didx-xyz/bitnami-oss`)
     # https://github.com/bitnami/charts/issues/35164
     # https://github.com/bitnami/containers/issues/84600
     allowInsecureImages: true
+  imageRegistry: ghcr.io
 
 fullnameOverride: valkey
 architecture: replication
 image:
-  repository: bitnamilegacy/valkey
+  repository: didx-xyz/bitnami-oss/valkey
 auth:
   enabled: false
 primary:
@@ -42,13 +43,13 @@ replica:
     create: false
 sentinel:
   image:
-    repository: bitnamilegacy/valkey-sentinel
+    repository: didx-xyz/bitnami-oss/valkey-sentinel
 metrics:
   image:
-    repository: bitnamilegacy/valkey-exporter
+    repository: didx-xyz/bitnami-oss/valkey-exporter
 volumePermissions:
   image:
-    repository: bitnamilegacy/os-shell
+    repository: didx-xyz/bitnami-oss/os-shell
 kubectl:
   image:
-    repository: bitnamilegacy/kubectl
+    repository: didx-xyz/bitnami-oss/kubectl

--- a/helm/cheqd/Chart.yaml
+++ b/helm/cheqd/Chart.yaml
@@ -8,4 +8,4 @@ appVersion: 4.1.1
 # dependencies:
 #   - name: common
 #     version: 2.x.x
-#     repository: oci://registry-1.docker.io/bitnamicharts
+#     repository: oci://ghcr.io/didx-xyz/bitnami-oss-charts

--- a/helm/cheqd/templates/statefulset.yaml
+++ b/helm/cheqd/templates/statefulset.yaml
@@ -166,7 +166,7 @@ spec:
         {{- end }}
         {{- if .Values.lbService.enabled }}
         - name: discover-lb-hostname
-          image: docker.io/bitnamilegacy/kubectl:latest
+          image: ghcr.io/didx-xyz/bitnami-oss/kubectl:latest
           imagePullPolicy: IfNotPresent
           command:
             - sh

--- a/helm/nats/Chart.lock
+++ b/helm/nats/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.31.3
+  repository: oci://ghcr.io/didx-xyz/bitnami-oss-charts
+  version: 2.31.4
 - name: nats
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 9.0.25
-digest: sha256:788e172bc0b9ac605a4d5c53b761f891de261f27d1811e8eea2eead7fda1354c
-generated: "2025-08-11T11:06:25.197106+02:00"
+  repository: oci://ghcr.io/didx-xyz/bitnami-oss-charts
+  version: 9.0.28
+digest: sha256:2767e1adff0501905e95041032b302d83f17e92b45e4eeb66636fc55af813291
+generated: "2025-08-25T11:52:18.784909+02:00"

--- a/helm/nats/Chart.yaml
+++ b/helm/nats/Chart.yaml
@@ -6,12 +6,12 @@ version: "9"
 appVersion: 2.x.x
 
 dependencies:
-  # https://github.com/bitnami/charts/tree/main/bitnami/common
+  # https://github.com/didx-xyz/bitnami-charts/tree/main/bitnami/common
   - name: common
-    repository: oci://registry-1.docker.io/bitnamicharts
+    repository: oci://ghcr.io/didx-xyz/bitnami-oss-charts
     version: 2.x.x
 
-  # https://github.com/bitnami/charts/tree/main/bitnami/nats
+  # https://github.com/didx-xyz/bitnami-charts/tree/main/bitnami/nats
   - name: nats
-    repository: oci://registry-1.docker.io/bitnamicharts
+    repository: oci://ghcr.io/didx-xyz/bitnami-oss-charts
     version: 9.x.x

--- a/helm/nats/templates/job.yaml
+++ b/helm/nats/templates/job.yaml
@@ -32,7 +32,7 @@ spec:
             - while ! nc -z {{ template "common.names.fullname" . }} {{ default 4222 .Values.nats.service.ports.client }}; do sleep 1; done
       containers:
         - name: natscli
-          image: docker.io/bitnamilegacy/natscli:{{ default "latest" .Values.postInstall.cli.version }}
+          image: ghcr.io/didx-xyz/bitnami-oss/natscli:{{ default "latest" .Values.postInstall.cli.version }}
           command:
             - sh
             - -c

--- a/helm/nats/values.yaml
+++ b/helm/nats/values.yaml
@@ -4,10 +4,11 @@ fullnameOverride: nats
 
 global:
   security:
-    # Required to override image repositories (`bitnami` -> `bitnamilegacy`)
+    # Required to override image repositories (`docker.io/bitnami` -> `ghcr.io/didx-xyz/bitnami-oss`)
     # https://github.com/bitnami/charts/issues/35164
     # https://github.com/bitnami/containers/issues/84600
     allowInsecureImages: true
+  imageRegistry: ghcr.io
 
 postInstall:
   enabled: true
@@ -56,7 +57,7 @@ postInstall:
 
   restartPolicy: Never
 
-# https://github.com/bitnami/charts/tree/main/bitnami/nats
+# https://github.com/didx-xyz/bitnami-charts/tree/main/bitnami/nats
 nats:
   ## @param fullnameOverride String to fully override common.names.fullname template
   ##
@@ -64,7 +65,7 @@ nats:
   ## @param image.repository [default: bitnami/nats] NATS image repository
   ##
   image:
-    repository: bitnamilegacy/nats
+    repository: didx-xyz/bitnami-oss/nats
 
   ## @param replicaCount Number of NATS nodes
   ##
@@ -139,7 +140,7 @@ nats:
   ## NATS resource requests and limits
   ## ref: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
   ## @param resourcesPreset Set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if resources is set (resources is recommended for production).
-  ## More information: https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15
+  ## More information: https://github.com/didx-xyz/bitnami-charts/blob/main/bitnami/common/templates/_resources.tpl#L15
   ##
   resourcesPreset: none
   ## @param resources Set container requests and limits for different resources like CPU or memory (essential for production workloads)
@@ -207,4 +208,4 @@ nats:
   metrics:
     ## @param metrics.image.repository [default: bitnami/nats-exporter] Prometheus metrics exporter image repository
     image:
-      repository: bitnamilegacy/nats-exporter
+      repository: didx-xyz/bitnami-oss/nats-exporter

--- a/tilt/acapy-cloud/Tiltfile
+++ b/tilt/acapy-cloud/Tiltfile
@@ -3,15 +3,15 @@ load("ext://color", "color")
 load("ext://helm_resource", "helm_resource", "helm_repo")
 
 # https://github.com/didx-xyz/bitnami-charts/tree/main/bitnami/minio
-minio_version = "17.0.19"
+minio_version = "17.0.21"
 # https://github.com/rowanruseler/helm-charts/tree/main/charts/pgadmin4
-pgadmin_version = "1.48.0"
+pgadmin_version = "1.49.0"
 # https://github.com/didx-xyz/bitnami-charts/tree/main/bitnami/postgresql-ha
-postgres_version = "16.1.2"
+postgres_version = "16.3.1"
 # https://github.com/redpanda-data/helm-charts/tree/main/charts/connect
 redpanda_connect_version = "3.0.3"
 # https://github.com/didx-xyz/bitnami-charts/tree/main/bitnami/valkey
-valkey_version = "3.0.28"
+valkey_version = "3.0.31"
 
 # Mnemonic for the Cheqd Localnet Validator
 # Will be used for Localnet as well as the Fee Payer for Cheqd DID Driver

--- a/tilt/acapy-cloud/Tiltfile
+++ b/tilt/acapy-cloud/Tiltfile
@@ -2,15 +2,15 @@ load("../utils/Tiltfile", "namespace_create_wrap", "generate_ingress_domain")
 load("ext://color", "color")
 load("ext://helm_resource", "helm_resource", "helm_repo")
 
-# https://github.com/bitnami/charts/tree/main/bitnami/minio
+# https://github.com/didx-xyz/bitnami-charts/tree/main/bitnami/minio
 minio_version = "17.0.19"
 # https://github.com/rowanruseler/helm-charts/tree/main/charts/pgadmin4
 pgadmin_version = "1.48.0"
-# https://github.com/bitnami/charts/tree/main/bitnami/postgresql-ha
+# https://github.com/didx-xyz/bitnami-charts/tree/main/bitnami/postgresql-ha
 postgres_version = "16.1.2"
 # https://github.com/redpanda-data/helm-charts/tree/main/charts/connect
 redpanda_connect_version = "3.0.3"
-# https://github.com/bitnami/charts/tree/main/bitnami/valkey
+# https://github.com/didx-xyz/bitnami-charts/tree/main/bitnami/valkey
 valkey_version = "3.0.28"
 
 # Mnemonic for the Cheqd Localnet Validator
@@ -32,10 +32,10 @@ def setup_postgres(namespace):
     values_file = "./helm/acapy-cloud/conf/postgres.yaml"
 
     ## Setup HA Postgres
-    # https://github.com/bitnami/charts/tree/main/bitnami/postgresql-ha
+    # https://github.com/didx-xyz/bitnami-charts/tree/main/bitnami/postgresql-ha
     helm_resource(
         name="postgres",
-        chart="oci://registry-1.docker.io/bitnamicharts/postgresql-ha",
+        chart="oci://ghcr.io/didx-xyz/bitnami-oss-charts/postgresql-ha",
         release_name="postgres",
         namespace=namespace,
         flags=[
@@ -63,10 +63,10 @@ def setup_valkey(namespace):
     values_file = "./helm/acapy-cloud/conf/valkey.yaml"
 
     ## Setup Valkey
-    # https://github.com/bitnami/charts/tree/main/bitnami/valkey
+    # https://github.com/didx-xyz/bitnami-charts/tree/main/bitnami/valkey
     helm_resource(
         name="valkey",
-        chart="oci://registry-1.docker.io/bitnamicharts/valkey",
+        chart="oci://ghcr.io/didx-xyz/bitnami-oss-charts/valkey",
         release_name="valkey",
         namespace=namespace,
         flags=[
@@ -138,7 +138,7 @@ def setup_nats(namespace):
     values_file = chart_dir + "/values.yaml"
 
     ## Setup NATS
-    # https://github.com/bitnami/charts/tree/main/bitnami/nats
+    # https://github.com/didx-xyz/bitnami-charts/tree/main/bitnami/nats
     flags = []
     if config.tilt_subcommand == "ci":
         flags = [
@@ -307,10 +307,10 @@ def setup_minio(namespace, ingress_domain):
 
     print(color.green("Installing MinIO..."))
 
-    # https://github.com/bitnami/charts/tree/main/bitnami/minio
+    # https://github.com/didx-xyz/bitnami-charts/tree/main/bitnami/minio
     helm_resource(
         name=resource_name,
-        chart="oci://registry-1.docker.io/bitnamicharts/minio",
+        chart="oci://ghcr.io/didx-xyz/bitnami-oss-charts/minio",
         release_name=resource_name,
         namespace=namespace,
         flags=[


### PR DESCRIPTION
Replace official Bitnami chart and image repositories with custom
`ghcr.io/didx-xyz/bitnami-oss` registry to address deprecation and
availability issues with upstream repositories.

Changes include:
* Update Helm chart sources from `registry-1.docker.io/bitnamicharts`
  to `ghcr.io/didx-xyz/bitnami-oss-charts`
* Migrate container images from `docker.io/bitnamilegacy` to
  `ghcr.io/didx-xyz/bitnami-oss`
* Add `imageRegistry: ghcr.io` to global chart configurations
* Update repository references for PostgreSQL, Valkey, MinIO, NATS,
  and related utility images

This migration ensures continued availability and support for Bitnami-
based services while maintaining compatibility with existing
configurations.

References: bitnami/charts#35164, bitnami/containers#83267