### PR TITLE
:arrow_up: Upgrade Helm, Helmfile, and local infra

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -51,8 +51,8 @@ on:
 permissions: {}
 
 env:
-  HELM_VERSION: v3.18.5
-  HELMFILE_VERSION: v1.1.5
+  HELM_VERSION: v3.18.6
+  HELMFILE_VERSION: v1.1.6
   MISE_VERSION: 2025.8.21
 
   RESET_DEPLOYMENTS: ${{ github.event.inputs.reset-deployments || 'false' }}

--- a/.mise/tasks/kind/install/nginx
+++ b/.mise/tasks/kind/install/nginx
@@ -19,4 +19,4 @@ helm upgrade \
   --wait \
   --timeout 300s \
   ingress-nginx/ingress-nginx \
-  --version 4.13.0
+  --version 4.13.2

--- a/helm/acapy-cloud.yaml.gotmpl
+++ b/helm/acapy-cloud.yaml.gotmpl
@@ -170,7 +170,7 @@ releases:
       app: valkey
     namespace: {{ .Values.namespace }}
     chart: oci://ghcr.io/didx-xyz/bitnami-oss-charts/valkey
-    version: 3.0.31
+    version: 4.0.0
     values:
       - ./acapy-cloud/conf/valkey.yaml
       - primary:
@@ -186,7 +186,7 @@ releases:
       app: postgres
     namespace: {{ .Values.namespace }}
     chart: oci://ghcr.io/didx-xyz/bitnami-oss-charts/postgresql-ha
-    version: 16.3.1
+    version: 16.3.4
     values:
       - ./acapy-cloud/conf/postgres.yaml
       - postgresql:
@@ -261,7 +261,7 @@ releases:
     installed: {{ .Values.minio.enabled }}
     namespace: {{ .Values.namespace }}
     chart: oci://ghcr.io/didx-xyz/bitnami-oss-charts/minio
-    version: 17.0.21
+    version: 17.0.22
     labels:
       app: minio
     values:

--- a/helm/nats/Chart.lock
+++ b/helm/nats/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: oci://ghcr.io/didx-xyz/bitnami-oss-charts
-  version: 2.31.4
+  version: 2.31.5
 - name: nats
   repository: oci://ghcr.io/didx-xyz/bitnami-oss-charts
-  version: 9.0.28
-digest: sha256:2767e1adff0501905e95041032b302d83f17e92b45e4eeb66636fc55af813291
-generated: "2025-08-25T11:52:18.784909+02:00"
+  version: 9.0.29
+digest: sha256:8e82536d75a580e78cf32b9f9f0dece30315f8a08fc1c7325b69617e86dd6435
+generated: "2025-09-03T14:19:21.116024+02:00"

--- a/tilt/acapy-cloud/Tiltfile
+++ b/tilt/acapy-cloud/Tiltfile
@@ -3,15 +3,15 @@ load("ext://color", "color")
 load("ext://helm_resource", "helm_resource", "helm_repo")
 
 # https://github.com/didx-xyz/bitnami-charts/tree/main/bitnami/minio
-minio_version = "17.0.21"
+minio_version = "17.0.22"
 # https://github.com/rowanruseler/helm-charts/tree/main/charts/pgadmin4
 pgadmin_version = "1.49.0"
 # https://github.com/didx-xyz/bitnami-charts/tree/main/bitnami/postgresql-ha
-postgres_version = "16.3.1"
+postgres_version = "16.3.4"
 # https://github.com/redpanda-data/helm-charts/tree/main/charts/connect
 redpanda_connect_version = "3.0.3"
 # https://github.com/didx-xyz/bitnami-charts/tree/main/bitnami/valkey
-valkey_version = "3.0.31"
+valkey_version = "4.0.0"
 
 # Mnemonic for the Cheqd Localnet Validator
 # Will be used for Localnet as well as the Fee Payer for Cheqd DID Driver


### PR DESCRIPTION
Upgrade local infrastructure to their latest versions:

* Helm upgraded from v3.18.5 to v3.18.6
* Helmfile upgraded from v1.1.5 to v1.1.6
* Ingress Nginx upgraded from 4.13.0 to 4.13.2
* Valkey upgraded from 3.0.31 to 4.0.0
* PostgreSQL HA upgraded from 16.3.1 to 16.3.4
* MinIO upgraded from 17.0.21 to 17.0.22
* NATS upgraded from 9.0.28 to 9.0.29
* Bitnami common chart upgraded from 2.31.4 to 2.31.5